### PR TITLE
Add heading-level check flag and config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ gomarklint ./docs --enable-link-check
 
 Options:
 
+- `--config` — Path to the config file. Defaults to `.gomarklint.json`.
+  - Example: `--config ./configs/gomarklint.json`
 - `--min-heading` — Set the minimum heading level to expect. Defaults to `2` (i.e. `##`), which aligns with common blogging/static site practices.
+- `--enable-heading-level-check` — Enable heading-level validation (default: `true`).
+Ensures top-level sections start at or below `--min-heading` and don’t skip levels.
+- `--enable-duplicate-heading-check` — Enable duplicate heading detection within a file (default: `true`).
+Helps avoid ambiguous anchors and ToC collisions.
 - `--enable-link-check` — Check for broken external links (http/https) such as [text](https://...), ![alt](https://...), or bare URLs. Only runs when explicitly enabled.
   - Example: `[text](https://...)`, `![img](https://...)`, or bare URLs
 > 🕒 Note: With `--enable-link-check` enabled, performance depends on network conditions.
@@ -146,8 +152,8 @@ Options:
 
 - `--skip-link-patterns` — (optional) One or more regular expressions to exclude specific URLs from link checking. Useful for skipping `localhost`, internal domains, etc.
   - Example: `--skip-link-patterns localhost --skip-link-patterns ^https://internal\.example\.com`
-- `--output` — Set output format. Accepts `"text"` (default) or `"json"`.  Use `"json"` to generate structured output for CI tools, scripts, etc.
-  - Example: `--output=json`
+- `--output` — Output format: `"text"` (default) or `"json"`.
+Use `"json"` for CI ingestion and tooling.
 
 ## ⚙️ Configuration File
 
@@ -169,7 +175,8 @@ By default, if the file exists in the current directory, it will be loaded autom
   ],
   "ignore": ["doc.md"],
   "output": "text",
-  "enableDuplicateHeadingCheck": true
+  "enableDuplicateHeadingCheck": true,
+  "enableHeadingLevelCheck": true
 }
 
 ```
@@ -316,10 +323,38 @@ When specifying files or directories, `gomarklint` will:
 - Report all files, regardless of `.gitignore`
 - Silently skip missing files (`os.IsNotExist`)
 
+## 🛠 Local Development
+
+To set up a local development environment for `gomarklint`:
+
+```bash
+# Run all tests
+go test ./...
+
+# Show CLI help from local source
+go run . --help
+
+# Generate a default .gomarklint.json (from your local build)
+go run . init
+
+# Lint the included sample files in ./testdata
+go run . testdata
+```
+
+Notes:
+- `go run .` uses the local source directly, so you don’t need to `go install` during development.
+- When adding new CLI flags or config fields, confirm they appear in `--help` and the generated `.gomarklint.json`.
+- Tests should remain fast and self-contained — contributions that break this will be rejected.
+
+
 ## 🤝 Contributing
 
 Issues, suggestions, and PRs are welcome!
-This project is just getting started and will evolve step by step.
+Before submitting a pull request, please follow the guidelines below to ensure a smooth review process.
+
+Requirements:
+
+- Go version: Go `1.22+` (latest stable recommended)
 
 ## 📜 License
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ var enableLinkCheck bool
 var skipLinkPatterns []string
 var configFilePath string
 var outputFormat string
+var enableHeadingLevelCheck bool
+var enableDuplicateHeadingCheck bool
 
 var rootCmd = &cobra.Command{
 	Use:   "gomarklint [files or directories]",
@@ -47,6 +49,12 @@ var rootCmd = &cobra.Command{
 		if cmd.Flags().Changed("enable-link-check") {
 			cfg.EnableLinkCheck = enableLinkCheck
 		}
+		if cmd.Flags().Changed("enable-heading-level-check") {
+			cfg.EnableHeadingLevelCheck = enableHeadingLevelCheck
+		}
+		if cmd.Flags().Changed("enable-duplicate-heading-check") {
+			cfg.EnableDuplicateHeadingCheck = enableDuplicateHeadingCheck
+		}
 		if cmd.Flags().Changed("skip-link-patterns") {
 			cfg.SkipLinkPatterns = skipLinkPatterns
 		}
@@ -63,6 +71,8 @@ var rootCmd = &cobra.Command{
 		minHeadingLevel = cfg.MinHeadingLevel
 		enableLinkCheck = cfg.EnableLinkCheck
 		skipLinkPatterns = cfg.SkipLinkPatterns
+		enableHeadingLevelCheck = cfg.EnableHeadingLevelCheck
+		enableDuplicateHeadingCheck = cfg.EnableDuplicateHeadingCheck
 
 		if len(args) == 0 {
 			if len(cfg.Include) > 0 {
@@ -127,10 +137,12 @@ var rootCmd = &cobra.Command{
 
 func collectErrors(path string, content string, cfg config.Config, patterns []*regexp.Regexp) ([]rule.LintError, int) {
 	var allErrors []rule.LintError
-	allErrors = append(allErrors, rule.CheckHeadingLevels(path, content, cfg.MinHeadingLevel)...)
 	allErrors = append(allErrors, rule.CheckFinalBlankLine(path, content)...)
 	allErrors = append(allErrors, rule.CheckUnclosedCodeBlocks(path, content)...)
 	allErrors = append(allErrors, rule.CheckEmptyAltText(path, content)...)
+	if cfg.EnableHeadingLevelCheck {
+		allErrors = append(allErrors, rule.CheckHeadingLevels(path, content, cfg.MinHeadingLevel)...)
+	}
 	if cfg.EnableDuplicateHeadingCheck {
 		allErrors = append(allErrors, rule.CheckDuplicateHeadings(path, content)...)
 	}
@@ -213,6 +225,8 @@ func init() {
 
 	rootCmd.Flags().IntVar(&minHeadingLevel, "min-heading", 2, "minimum heading level to start from (default: 2)")
 	rootCmd.Flags().BoolVar(&enableLinkCheck, "enable-link-check", false, "enable external link checking")
+	rootCmd.Flags().BoolVar(&enableHeadingLevelCheck, "enable-heading-level-check", true, "enable heading level check")
+	rootCmd.Flags().BoolVar(&enableDuplicateHeadingCheck, "enable-duplicate-heading-check", true, "enable duplicate heading check")
 	rootCmd.Flags().StringArrayVar(&skipLinkPatterns, "skip-link-patterns", nil, "patterns of URLs to skip link checking")
 	rootCmd.Flags().StringVar(&outputFormat, "output", "text", "output format: text or json")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	Ignore                      []string `json:"ignore"`
 	OutputFormat                string   `json:"output"`
 	EnableDuplicateHeadingCheck bool     `json:"enableDuplicateHeadingCheck"`
+	EnableHeadingLevelCheck     bool     `json:"enableHeadingLevelCheck"`
 }
 
 func Default() Config {
@@ -20,5 +21,6 @@ func Default() Config {
 		Ignore:                      []string{},
 		OutputFormat:                "text",
 		EnableDuplicateHeadingCheck: true,
+		EnableHeadingLevelCheck:     true,
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,6 +81,7 @@ func TestDefaultConfig(t *testing.T) {
 		Ignore:                      []string{},
 		OutputFormat:                "text",
 		EnableDuplicateHeadingCheck: true,
+		EnableHeadingLevelCheck:     true,
 	}
 
 	got := Default()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/shinagawa-web/gomarklint/cmd"
@@ -8,6 +9,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "[gomarklint error]:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## ✨ Summary

Add support for `EnableHeadingLevelCheck` flag and config field.

## 🛠 Changes

- Added new config field: `EnableHeadingLevelCheck` in `config.Config`
  - Default: `true`
- Added CLI flag `--enable-heading-level-check`
  - Registered via `rootCmd.Flags().BoolVar(...)`
  - Defaults to `true`
- Updated CLI `--help` output (auto-reflected)
- Verified through:
  - `go test ./...`
  - `go run . --help`
  - `go run . init` (confirmed field appears in generated config)
  - `go run . testdata`

## 📖 Docs

- Will update README.md to document:
  - `--enable-heading-level-check option`
  - Local development commands (`go test ./...`, `go run . init`, etc.)
  - Contributing guidelines