### PR TITLE
fix: Ignore code blocks for multiple consecutive blank lines check

### DIFF
--- a/internal/rule/no_multiple_blank_lines_test.go
+++ b/internal/rule/no_multiple_blank_lines_test.go
@@ -57,6 +57,18 @@ func TestCheckNoMultipleBlankLines(t *testing.T) {
 				{File: "test.md", Line: 3, Message: "Multiple consecutive blank lines"},
 			},
 		},
+		{
+			name:     "code blocks",
+			content:  "I am text before a code block\n\n```\nI am in a code block\n\n\nMultiple consecutive blank lines should be ignored\n```",
+			wantErrs: nil,
+		},
+		{
+			name:    "blank lines after code blocks",
+			content: "I am text before a code block\n\n```\nI am in a code block\n\n\nMultiple consecutive blank lines should be ignored\n```\n\n\nBut the newlines before this one should be considered errors.",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 10, Message: "Multiple consecutive blank lines"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Previously, multiple consecutive blank lines inside code blocks were reported as errors. That was causing `README.md` to report errors. (There are others, all of which are consecutive newline problems; I'll fix those in a follow-up PR and add a CI check if I can work that out.)

Code blocks should not be considered for this rule. For example, most widely-used Python code styles have two newlines after the imports in a file, and two newlines after top-level classes and functions. Other languages might have their own community norms. gomarklint should assume that code blocks, being verbatim, are formatted that way for a reason.