### PR TITLE
fix: update golangci workflow to trigger on push to main branch

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -1,10 +1,11 @@
 name: golang-ci
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    paths:
-      - "**.go"
-      - .github/workflows/golangci.yml
-      - .golangci.yml
+    branches:
+      - main
 
 jobs:
   golangci-lint:


### PR DESCRIPTION
Removed path filters from CI to prevent PRs from getting stuck in "Waiting for status to be reported". Since this is a "Required" check, it needs to run on every PR to allow merging.