### PR TITLE
fix: always exit non-zero when there are linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ gomarklint ./...
 gomarklint docs README.md internal/handbook
 ```
 
-Exit code is non-zero on violations (configurable soon), so it plugs into CI trivially.
+Exit code is non-zero if any violations are found, zero otherwise.
 
 ### 3) JSON output (for CI / tooling)
 
@@ -141,7 +141,7 @@ Notes:
 
 - Flags override config values when explicitly provided.
 - Paths are expanded (globs/dirs) and filtered by ignore (from config).
-- Exit behavior: if any issues exist and GITHUB_ACTIONS=true, the command returns a non-nil error (non-zero exit); otherwise it prints results and exits zero. This makes it friendly locally while strict on CI.
+- Exit behavior: the command returns a non-nil error (non-zero exit), zero otherwise.
 
 ## Configuration
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -161,12 +161,8 @@ var rootCmd = &cobra.Command{
 			printHumanOutput(orderedPaths, results, len(files), totalLines, totalErrors, totalLinksChecked, cfg.EnableLinkCheck, elapsed)
 		}
 
-		onCI := os.Getenv("GITHUB_ACTIONS") == "true"
 		if totalErrors > 0 {
-			if onCI {
-				return errors.New("")
-			}
-			return nil
+			return errors.New("")
 		}
 		return nil
 	},


### PR DESCRIPTION
Previously, this was only enabled when `GITHUB_ACTIONS` was set to the string "true" in the environment. That violates the principle of least surprise if nothing else; the fact that every other linter I know of will exit zero is a standalone reason to not do that.

The exit hatch of setting `GITHUB_ACTIONS` if we want to use gomarklint in, e.g., pre-push or pre-commit hooks was counter-intuitive. And also GitHub Actions is not the only CI. It will come as a surprise to anyone who is using it on some other CI as much as it'll come as a surprise to those other use cases.

Instead, let's exit non-zero by default when there are linting errors. If someone out there needs a non-zero exit code under all circumstances, then they can use `|| true` in their shell.

Fixes #48.