### PR TITLE
chore: add external link E2E tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -71,7 +71,7 @@ func TestE2E(t *testing.T) {
 		t.Run("DuplicateHeadings", func(t *testing.T) {
 			output := runTest(t, "fixtures/duplicate_headings.md", "--config", ".gomarklint.json")
 			assertOutputContains(t, output, "Errors in fixtures/duplicate_headings.md:")
-			assertOutputContains(t, output, "fixtures/duplicate_headings.md:9:")
+			assertOutputContains(t, output, "fixtures/duplicate_headings.md:14:")
 			assertOutputContains(t, output, "duplicate heading")
 			assertOutputContains(t, output, "\"section one\"")
 			assertOutputContains(t, output, "Checked 1 file(s)")
@@ -193,7 +193,7 @@ func TestE2E(t *testing.T) {
 			assertOutputContains(t, output, "fixtures/invalid_heading_level.md:1:")
 			assertOutputContains(t, output, "First heading should be level 2 (found level 1)")
 			assertOutputContains(t, output, "Errors in fixtures/duplicate_headings.md:")
-			assertOutputContains(t, output, "fixtures/duplicate_headings.md:9:")
+			assertOutputContains(t, output, "fixtures/duplicate_headings.md:14:")
 			assertOutputContains(t, output, "duplicate heading: \"section one\"")
 			assertOutputContains(t, output, "Errors in fixtures/multiple_blank_lines.md:")
 			assertOutputContains(t, output, "fixtures/multiple_blank_lines.md:5:")
@@ -217,7 +217,7 @@ func TestE2E(t *testing.T) {
 			assertOutputContains(t, output, "fixtures/empty.md:1:")
 			assertOutputContains(t, output, "Missing final blank line")
 			assertOutputContains(t, output, "Errors in fixtures/multiple_violations.md:")
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:1:")
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:6:")
 			// Count may vary, but should have checked all files
 			assertOutputContains(t, output, "Checked 17 file(s)")
 			assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
@@ -234,7 +234,7 @@ func TestE2E(t *testing.T) {
 			assertOutputContains(t, output, "fixtures/invalid_heading_level.md:1:")
 			assertOutputContains(t, output, "First heading should be level 2")
 			assertOutputContains(t, output, "Errors in fixtures/duplicate_headings.md:")
-			assertOutputContains(t, output, "fixtures/duplicate_headings.md:9:")
+			assertOutputContains(t, output, "fixtures/duplicate_headings.md:14:")
 			assertOutputContains(t, output, "duplicate heading")
 			assertOutputContains(t, output, "Errors in fixtures/multiple_blank_lines.md:")
 			assertOutputContains(t, output, "fixtures/multiple_blank_lines.md:5:")
@@ -288,24 +288,24 @@ func TestE2E(t *testing.T) {
 			assertOutputContains(t, output, "Errors in fixtures/multiple_violations.md:")
 
 			// Heading level error (first heading is level 1, should be level 2)
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:1:")
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:6:")
 			assertOutputContains(t, output, "First heading should be level 2")
 
 			// Multiple blank lines error
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:5:")
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:10:")
 			assertOutputContains(t, output, "Multiple consecutive blank lines")
 
-			// Duplicate heading error (line 12)
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:12:")
+			// Duplicate heading error (line 17)
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:17:")
 			assertOutputContains(t, output, "duplicate heading")
 			assertOutputContains(t, output, "section one")
 
 			// Empty alt text error
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:16:")
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:21:")
 			assertOutputContains(t, output, "image with empty alt text")
 
 			// Unclosed code block error
-			assertOutputContains(t, output, "fixtures/multiple_violations.md:20:")
+			assertOutputContains(t, output, "fixtures/multiple_violations.md:25:")
 			assertOutputContains(t, output, "Unclosed code block")
 
 			// File should have been checked

--- a/e2e/fixtures/duplicate_headings.md
+++ b/e2e/fixtures/duplicate_headings.md
@@ -1,3 +1,8 @@
+---
+title: Duplicate Headings Test
+description: Test file with duplicate heading names
+---
+
 ## Section One
 
 Content here.

--- a/e2e/fixtures/mixed_link_types.md
+++ b/e2e/fixtures/mixed_link_types.md
@@ -1,3 +1,8 @@
+---
+title: Mixed Link Types Test
+description: Test file with various types of links
+---
+
 ## Mixed Link Types
 
 This file contains various types of links:

--- a/e2e/fixtures/multiple_external_links.md
+++ b/e2e/fixtures/multiple_external_links.md
@@ -1,3 +1,8 @@
+---
+title: Multiple External Links Test
+description: Test file with multiple valid and invalid external links
+---
+
 ## Multiple External Links
 
 Valid links:

--- a/e2e/fixtures/multiple_violations.md
+++ b/e2e/fixtures/multiple_violations.md
@@ -1,3 +1,8 @@
+---
+title: Multiple Violations Test
+description: Test file with multiple types of errors
+---
+
 # First Heading
 
 Some content here.


### PR DESCRIPTION
Add comprehensive E2E test cases for external link validation based on unit tests. Add frontmatter to fixture files and update line numbers in tests accordingly.