### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test and Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/shinagawa-web/gomarklint/security/code-scanning/4](https://github.com/shinagawa-web/gomarklint/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions` block that grants the least privileges needed for this workflow, either at the workflow root (applies to all jobs) or per job. Since this workflow only needs to read repository contents, the minimal safe starting point is `contents: read`. Other actions here (Go setup, build, tests, Codecov upload using its own token) don’t require additional GitHub API scopes.

The single best fix is to add a top‑level `permissions` block after the `name` line (or after `on:`) in `.github/workflows/test.yml`:

- Keep existing functionality unchanged by only constraining the `GITHUB_TOKEN` to read repository contents.
- No step in the shown workflow depends on write permissions, so this won’t break anything.

Concretely:
- Edit `.github/workflows/test.yml`.
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  near the top of the file, so it applies to all jobs (including `test`). No extra imports or definitions are needed since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
