### PR TITLE
docs: add prebuilt binary and Windows install instructions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,10 +20,13 @@ tar -xzf gomarklint_Darwin_x86_64.tar.gz
 sudo mv gomarklint /usr/local/bin/
 # sudo が使えない場合はユーザーローカルへ
 mkdir -p ~/.local/bin && mv gomarklint ~/.local/bin/
+```
 
+```powershell
 # Windows (PowerShell)
-Expand-Archive gomarklint_Windows_x86_64.zip
-mv gomarklint.exe C:\Windows\System32\
+Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALAPPDATA\Programs\gomarklint"
+# PATH に追加（初回のみ）
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
 **`go install` を使う場合:**

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ tar -xzf gomarklint_Darwin_x86_64.tar.gz
 sudo mv gomarklint /usr/local/bin/
 # or install to user-local directory (no sudo required)
 mkdir -p ~/.local/bin && mv gomarklint ~/.local/bin/
+```
 
+```powershell
 # Windows (PowerShell)
-Expand-Archive gomarklint_Windows_x86_64.zip
-mv gomarklint.exe C:\Windows\System32\
+Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALAPPDATA\Programs\gomarklint"
+# Add to PATH (run once)
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
 **Via `go install`:**

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -17,10 +17,13 @@ tar -xzf gomarklint_Darwin_x86_64.tar.gz
 sudo mv gomarklint /usr/local/bin/
 # or install to user-local directory (no sudo required)
 mkdir -p ~/.local/bin && mv gomarklint ~/.local/bin/
+```
 
+```powershell
 # Windows (PowerShell)
-Expand-Archive gomarklint_Windows_x86_64.zip
-mv gomarklint.exe C:\Windows\System32\
+Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALAPPDATA\Programs\gomarklint"
+# Add to PATH (run once)
+[Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
 **Via `go install`:**


### PR DESCRIPTION
## Summary

- Add prebuilt binary download instructions (macOS/Linux and Windows) to README, README.ja.md, and Quick Start docs
- Users without a Go environment can now install gomarklint by downloading from GitHub Releases