### PR TITLE
fix(ci): replace goreleaser changelog labels with regexp for v2 compat

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,33 +43,23 @@ changelog:
   use: github
   groups:
     - title: "Breaking Changes 🛠"
-      labels:
-        - breaking-change
+      regexp: '^.*!:|^BREAKING CHANGE'
       order: 0
     - title: "Exciting New Features 🎉"
-      labels:
-        - enhancement
+      regexp: '^feat'
       order: 1
     - title: "Bug Fixes 🐛"
-      labels:
-        - bug
+      regexp: '^fix'
       order: 2
     - title: "Code Refactoring ♻️"
-      labels:
-        - refactor
+      regexp: '^refactor'
       order: 3
     - title: "Documentation 📝"
-      labels:
-        - documentation
+      regexp: '^docs'
       order: 4
     - title: "Maintenance 🔧"
-      labels:
-        - chore
+      regexp: '^chore'
       order: 5
-    - title: "Dependency Updates 📦"
-      labels:
-        - dependencies
-      order: 6
     - title: "Other Changes"
       order: 999
   filters:


### PR DESCRIPTION
## Summary

- Replace `labels` with `regexp` in `.goreleaser.yaml` changelog groups
- Remove "Dependency Updates" group (dependabot PRs match `chore` regexp)

## Why

GoReleaser v2 removed the `labels` field from `ChangelogGroup`. The `v2.0.1` release failed with:

```
field labels not found in type config.ChangelogGroup
```

After merging, re-tag `v2.0.1` (or `v2.0.2`) to trigger the release workflow.