### PR TITLE
chore: add Claude Code settings files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ e2e/gomarklint-e2e-test
 *.out
 *.html
 
-# Claude Code worktrees
+# Claude Code
 .claude/worktrees/
+.claude/settings.json
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` and `.claude/settings.local.json` to `.gitignore`
- These are local Claude Code configuration files that should not be tracked