### PR TITLE
fix: closing fence should accept longer runs than opening fence

### DIFF
--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -32,19 +32,25 @@ func CheckUnclosedCodeBlocks(filename string, lines []string, offset int) []Lint
 func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
 	inBlock := false
 	var start int
+	var fenceMarker string
 	var closedRanges [][2]int
 	var unclosedStarts []int
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "```") {
-			if inBlock {
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
 				closedRanges = append(closedRanges, [2]int{start + 1, i + 1})
 				inBlock = false
-			} else {
-				start = i
-				inBlock = true
+				fenceMarker = ""
 			}
+			continue
+		}
+		marker := openingFenceMarker(trimmed)
+		if marker != "" {
+			start = i
+			fenceMarker = marker
+			inBlock = true
 		}
 	}
 

--- a/internal/rule/code_block_test.go
+++ b/internal/rule/code_block_test.go
@@ -40,6 +40,35 @@ func TestCheckUnclosedCodeBlocks(t *testing.T) {
 			content:  "# Just a heading\nSome text",
 			wantErrs: nil,
 		},
+		{
+			name:     "longer closing fence closes block",
+			content:  "```\ncode\n`````\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "tilde fence properly tracked",
+			content:  "~~~\ncode\n~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "tilde fence unclosed by backtick",
+			content: "~~~\ncode\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "Unclosed code block"},
+			},
+		},
+		{
+			name:     "longer tilde closing fence",
+			content:  "~~~\ncode\n~~~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "shorter closing fence does not close",
+			content: "````\ncode\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "Unclosed code block"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/fence.go
+++ b/internal/rule/fence.go
@@ -1,0 +1,27 @@
+package rule
+
+import "strings"
+
+// IsClosingFence reports whether trimmed is a valid closing fence for the given
+// opening fence marker. Per the CommonMark spec, a closing fence must:
+//  1. Use the same fence character as the opener (backtick or tilde)
+//  2. Have a run length >= the opener's length
+//  3. Contain only optional whitespace after the fence run
+func IsClosingFence(trimmed, openMarker string) bool {
+	if len(trimmed) == 0 || len(openMarker) == 0 {
+		return false
+	}
+	ch := openMarker[0]
+	if trimmed[0] != ch {
+		return false
+	}
+	// Count the run of fence characters
+	n := 0
+	for n < len(trimmed) && trimmed[n] == ch {
+		n++
+	}
+	if n < len(openMarker) {
+		return false
+	}
+	return strings.TrimSpace(trimmed[n:]) == ""
+}

--- a/internal/rule/fence_test.go
+++ b/internal/rule/fence_test.go
@@ -1,0 +1,37 @@
+package rule
+
+import "testing"
+
+func TestIsClosingFence(t *testing.T) {
+	tests := []struct {
+		name       string
+		trimmed    string
+		openMarker string
+		want       bool
+	}{
+		{"exact backtick match", "```", "```", true},
+		{"exact tilde match", "~~~", "~~~", true},
+		{"longer closing backtick", "````", "```", true},
+		{"longer closing tilde", "~~~~", "~~~", true},
+		{"much longer closing", "``````", "```", true},
+		{"shorter closing rejected", "```", "````", false},
+		{"trailing whitespace allowed", "```  ", "```", true},
+		{"trailing text rejected", "``` foo", "```", false},
+		{"mismatched fence char", "~~~", "```", false},
+		{"mismatched fence char reverse", "```", "~~~", false},
+		{"empty trimmed", "", "```", false},
+		{"empty marker", "```", "", false},
+		{"both empty", "", "", false},
+		{"4-backtick exact", "````", "````", true},
+		{"4-backtick longer close", "`````", "````", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsClosingFence(tt.trimmed, tt.openMarker)
+			if got != tt.want {
+				t.Errorf("IsClosingFence(%q, %q) = %v, want %v", tt.trimmed, tt.openMarker, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rule/fenced_code_language.go
+++ b/internal/rule/fenced_code_language.go
@@ -21,7 +21,7 @@ func CheckFencedCodeLanguage(filename string, lines []string, offset int) []Lint
 		trimmed := strings.TrimSpace(line)
 
 		if inBlock {
-			if strings.HasPrefix(trimmed, fenceMarker) && strings.TrimSpace(trimmed[len(fenceMarker):]) == "" {
+			if IsClosingFence(trimmed, fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}

--- a/internal/rule/fenced_code_language_test.go
+++ b/internal/rule/fenced_code_language_test.go
@@ -108,6 +108,23 @@ func TestCheckFencedCodeLanguage(t *testing.T) {
 				{File: "test.md", Line: 1, Message: "Fenced code block must have a language identifier"},
 			},
 		},
+		{
+			name:     "longer closing fence closes block",
+			content:  "```go\ncode\n`````\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "longer closing fence allows next block to be detected",
+			content: "```go\ncode\n`````\n\n```\nno lang\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "Fenced code block must have a language identifier"},
+			},
+		},
+		{
+			name:     "longer closing tilde fence",
+			content:  "~~~py\ncode\n~~~~~\n",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/single_h1.go
+++ b/internal/rule/single_h1.go
@@ -14,7 +14,7 @@ func CheckSingleH1(filename string, lines []string, offset int) []LintError {
 		trimmed := strings.TrimSpace(line)
 
 		if inBlock {
-			if strings.HasPrefix(trimmed, fenceMarker) && strings.TrimSpace(trimmed[len(fenceMarker):]) == "" {
+			if IsClosingFence(trimmed, fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}

--- a/internal/rule/single_h1_test.go
+++ b/internal/rule/single_h1_test.go
@@ -77,6 +77,18 @@ func TestCheckSingleH1(t *testing.T) {
 				{File: "test.md", Line: 3, Message: "Multiple H1 headings found; only one H1 is allowed per file"},
 			},
 		},
+		{
+			name:     "H1 inside block closed by longer fence is ignored",
+			content:  "# Title\n\n```markdown\n# Not a heading\n`````\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "H1 after block closed by longer fence is detected",
+			content: "# Title\n\n```markdown\n# Ignored\n`````\n\n# Second\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 7, Message: "Multiple H1 headings found; only one H1 is allowed per file"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Extract shared `IsClosingFence(trimmed, openMarker)` helper in `fence.go` for CommonMark-compliant closing fence detection
- Fix `code_block.go` to properly track opening fence markers (backtick vs tilde) instead of hardcoding `` ``` ``
- Replace inline `HasPrefix` + remainder checks in `fenced_code_language.go` and `single_h1.go` with the shared helper
- Add unit tests covering longer closing fences, mismatched fence characters, and shorter closing fences

Closes #95

## Test plan

- [x] `make test-all` passes (unit + E2E)
- [ ] Verify with a Markdown file containing `` ```` `` closing a `` ``` `` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)