### PR TITLE
fix: add minimum required permissions to workflows

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -56,6 +56,8 @@ jobs:
   check-labels:
     runs-on: ubuntu-latest
     needs: auto-label
+    permissions:
+      pull-requests: read
     steps:
       - name: Check for labels
         uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/go-install-check.yml
+++ b/.github/workflows/go-install-check.yml
@@ -9,6 +9,9 @@ on:
       - go.mod
       - go.sum
 
+permissions:
+  contents: read
+
 jobs:
   check-go-install:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   golangci-lint:
     name: golangci-lint


### PR DESCRIPTION
## Summary

Resolves 3 open code scanning alerts for missing workflow permissions.

Each workflow now declares only the permissions it actually needs, following the principle of least privilege.

| Workflow | Permissions added |
|---|---|
| `go-install-check.yml` | `contents: read` |
| `golangci.yml` | `contents: read`, `checks: write` |
| `auto-label.yml` (`check-labels` job) | `pull-requests: read` |

Note: `auto-label` job already had `pull-requests: write` declared — only the `check-labels` job was missing its permissions block.

Closes code scanning alerts #1, #2, #3.

## Test plan

- [x] Verify workflows run correctly after permissions are added
- [x] Confirm no over-privileged scopes are granted