### PR TITLE
feat: add no-empty-links rule (MD042)

### DIFF
--- a/e2e/config-no-empty-links.json
+++ b/e2e/config-no-empty-links.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "no-empty-links": true
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -212,6 +212,27 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "bare URL found, use angle brackets or a Markdown link: http://other.example.com")
 		assertOutputContains(t, output, "2 issues found")
 	})
+
+	t.Run("NoEmptyLinksValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/no_empty_links_valid.md", "--config", "config-no-empty-links.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "link has empty destination")
+	})
+
+	t.Run("NoEmptyLinksViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/no_empty_links_violation.md", "--config", "config-no-empty-links.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/no_empty_links_violation.md:")
+		assertOutputContains(t, output, "fixtures/no_empty_links_violation.md:3:")
+		assertOutputContains(t, output, "link has empty destination: [click here]()")
+		assertOutputContains(t, output, "fixtures/no_empty_links_violation.md:5:")
+		assertOutputContains(t, output, "link has empty destination: [another](#)")
+		assertOutputContains(t, output, "fixtures/no_empty_links_violation.md:7:")
+		assertOutputContains(t, output, "link has empty destination: ![broken image](<>)")
+		assertOutputContains(t, output, "3 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -333,7 +354,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "heading must be preceded by a blank line")
 		assertOutputContains(t, output, "Errors in fixtures/no_bare_urls_violation.md:")
 		assertOutputContains(t, output, "bare URL found")
-		assertOutputContains(t, output, "Checked 29 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/no_empty_links_violation.md:")
+		assertOutputContains(t, output, "link has empty destination")
+		assertOutputContains(t, output, "Checked 31 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")
@@ -341,6 +364,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/longer_closing_fence.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_headings_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_bare_urls_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/no_empty_links_valid.md
+++ b/e2e/fixtures/no_empty_links_valid.md
@@ -1,0 +1,7 @@
+## Valid Link Formats
+
+Use a normal link: [Example](#example)
+
+Use a fragment link: [Section](#section)
+
+Use a relative path: [Page](./page.md)

--- a/e2e/fixtures/no_empty_links_violation.md
+++ b/e2e/fixtures/no_empty_links_violation.md
@@ -1,0 +1,7 @@
+## Empty Links
+
+[click here]()
+
+[another](#)
+
+![broken image](<>)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ const DefaultConfigJSON = `{
     "single-h1": true,
     "blanks-around-headings": true,
     "no-bare-urls": true,
+    "no-empty-links": true,
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
@@ -248,6 +249,11 @@ func Default() Config {
 				Options:  map[string]interface{}{},
 			},
 			"no-bare-urls": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{},
+			},
+			"no-empty-links": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -206,6 +206,9 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	if l.config.IsEnabled("no-bare-urls") {
 		allErrors = append(allErrors, l.withSeverity(rule.CheckNoBareURLs(path, lines, offset), "no-bare-urls")...)
 	}
+	if l.config.IsEnabled("no-empty-links") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
+	}
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -459,6 +459,25 @@ func TestRun_NoBareURLs(t *testing.T) {
 	}
 }
 
+func TestRun_NoEmptyLinks(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-empty-links"] = on()
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "empty-link.md")
+	if err := os.WriteFile(testFile, []byte("[click here]()\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors == 0 {
+		t.Error("expected error for empty link destination")
+	}
+}
+
 func TestRun_WarningSeverity(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-setext-headings"] = &config.RuleConfig{

--- a/internal/rule/no_empty_links.go
+++ b/internal/rule/no_empty_links.go
@@ -37,7 +37,7 @@ func findEmptyLinks(line string) []string {
 		if emptyLinkDest(dest) {
 			// Walk back to find the opening '[' (or '![').
 			bracketStart := pos + idx
-			for bracketStart > 0 && line[bracketStart-1] != '[' && line[bracketStart-1] != '\n' {
+			for bracketStart > 0 && line[bracketStart-1] != '[' {
 				bracketStart--
 			}
 			if bracketStart > 0 && line[bracketStart-1] == '[' {

--- a/internal/rule/no_empty_links.go
+++ b/internal/rule/no_empty_links.go
@@ -1,0 +1,102 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// emptyLinkDest reports whether dest is an "empty" link destination.
+// Empty means literally empty, a lone fragment "#", or angle-bracket-wrapped
+// empty "<>".
+func emptyLinkDest(dest string) bool {
+	return dest == "" || dest == "#" || dest == "<>"
+}
+
+// findEmptyLinks scans a single line (already stripped of inline code) for
+// Markdown links or images whose destination is empty.
+// It returns the raw matched text for each violation (e.g. "[text]()").
+func findEmptyLinks(line string) []string {
+	var results []string
+	pos := 0
+	for pos < len(line) {
+		// Look for '](' which signals link/image destination.
+		idx := strings.Index(line[pos:], "](")
+		if idx == -1 {
+			break
+		}
+		openParen := pos + idx + 2 // position right after '('
+
+		// Find the matching closing ')'.
+		closeParen := strings.Index(line[openParen:], ")")
+		if closeParen == -1 {
+			break
+		}
+		closeParen += openParen
+
+		dest := strings.TrimSpace(line[openParen:closeParen])
+		if emptyLinkDest(dest) {
+			// Walk back to find the opening '[' (or '![').
+			bracketStart := pos + idx
+			for bracketStart > 0 && line[bracketStart-1] != '[' && line[bracketStart-1] != '\n' {
+				bracketStart--
+			}
+			if bracketStart > 0 && line[bracketStart-1] == '[' {
+				bracketStart--
+				// Check for image prefix '!'.
+				if bracketStart > 0 && line[bracketStart-1] == '!' {
+					bracketStart--
+				}
+			}
+			results = append(results, line[bracketStart:closeParen+1])
+		}
+		pos = closeParen + 1
+	}
+	return results
+}
+
+// CheckNoEmptyLinks flags Markdown links and images whose destination URL is
+// empty, contains only "#", or is "<>".
+// Links inside fenced code blocks and inline code spans are ignored.
+func CheckNoEmptyLinks(filename string, lines []string, offset int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		marker := openingFenceMarker(trimmed)
+		if marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		if !strings.Contains(line, "](") {
+			continue
+		}
+
+		scanned := line
+		if strings.ContainsRune(line, '`') {
+			scanned = stripInlineCode(line)
+		}
+
+		for _, match := range findEmptyLinks(scanned) {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + i + 1,
+				Message: fmt.Sprintf("no-empty-links: link has empty destination: %s", match),
+			})
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/no_empty_links_test.go
+++ b/internal/rule/no_empty_links_test.go
@@ -133,8 +133,8 @@ func TestCheckNoEmptyLinks(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
-			name:     "valid: destination with only spaces is empty",
-			content:  "[text](   )\n",
+			name:    "valid: destination with only spaces is empty",
+			content: "[text](   )\n",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [text](   )"},
 			},

--- a/internal/rule/no_empty_links_test.go
+++ b/internal/rule/no_empty_links_test.go
@@ -1,0 +1,165 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNoEmptyLinks(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		wantErrs []LintError
+	}{
+		{
+			name:     "valid: normal link",
+			content:  "[Example](https://example.com)\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fragment link",
+			content:  "[Section](#section)\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: relative path",
+			content:  "[Page](./page.md)\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: image with URL",
+			content:  "![Alt](https://example.com/img.png)\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: empty link destination",
+			content: "[click here]()\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [click here]()"},
+			},
+		},
+		{
+			name:    "invalid: fragment-only destination",
+			content: "[click here](#)\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [click here](#)"},
+			},
+		},
+		{
+			name:    "invalid: angle bracket empty destination",
+			content: "[click here](<>)\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [click here](<>)"},
+			},
+		},
+		{
+			name:    "invalid: empty image destination",
+			content: "![alt text]()\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: ![alt text]()"},
+			},
+		},
+		{
+			name:    "invalid: image with fragment-only destination",
+			content: "![alt](#)\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: ![alt](#)"},
+			},
+		},
+		{
+			name:     "valid: link inside fenced code block",
+			content:  "```\n[text]()\n```\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link inside tilde fence",
+			content:  "~~~\n[text]()\n~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link inside inline code",
+			content:  "Use `[text]()` as example.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link inside double-backtick inline code",
+			content:  "Use ``[text]()`` as example.\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: multiple empty links on one line",
+			content: "[a]() and [b](#)\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [a]()"},
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [b](#)"},
+			},
+		},
+		{
+			name:    "invalid: empty link on second line",
+			content: "# Heading\n\n[broken]()\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "no-empty-links: link has empty destination: [broken]()"},
+			},
+		},
+		{
+			name:    "offset shifts line numbers",
+			content: "[text]()\n",
+			offset:  5,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 6, Message: "no-empty-links: link has empty destination: [text]()"},
+			},
+		},
+		{
+			name:     "valid: no links at all",
+			content:  "Just some plain text.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: empty link after inline code on same line",
+			content: "Run `cmd` then [see]()\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [see]()"},
+			},
+		},
+		{
+			name:     "valid: unclosed paren is not a link",
+			content:  "[text](no closing paren\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: destination with only spaces is empty",
+			content:  "[text](   )\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [text](   )"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckNoEmptyLinks("test.md", lines, tt.offset)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i].File != tt.wantErrs[i].File {
+					t.Errorf("[%d] file: got %q, want %q", i, got[i].File, tt.wantErrs[i].File)
+				}
+				if got[i].Line != tt.wantErrs[i].Line {
+					t.Errorf("[%d] line: got %d, want %d", i, got[i].Line, tt.wantErrs[i].Line)
+				}
+				if got[i].Message != tt.wantErrs[i].Message {
+					t.Errorf("[%d] message: got %q, want %q", i, got[i].Message, tt.wantErrs[i].Message)
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/no_empty_links_test.go
+++ b/internal/rule/no_empty_links_test.go
@@ -133,7 +133,7 @@ func TestCheckNoEmptyLinks(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
-			name:    "valid: destination with only spaces is empty",
+			name:    "invalid: destination with only spaces is empty",
 			content: "[text](   )\n",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "no-empty-links: link has empty destination: [text](   )"},


### PR DESCRIPTION
## Summary

- Add `no-empty-links` rule (MD042) that detects Markdown links and images with empty destinations: `[]()`, `[](#)`, `[](<>)`
- Skip content inside fenced code blocks and inline code spans
- Register rule in config (enabled by default) and integrate into linter pipeline
- Add unit tests (21 cases, 100% coverage) and e2e tests with fixtures

Closes #106
Closes part of #76

## Test plan

- [x] Unit tests pass (`go test ./internal/rule/ -run TestCheckNoEmptyLinks`)
- [x] All existing tests pass (`go test ./...`)
- [x] E2E tests pass (`make test-e2e`)
- [x] 100% code coverage on all functions in `no_empty_links.go`