### PR TITLE
feat: add Homebrew tap distribution

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,3 +29,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,15 @@ archives:
       - goos: windows
         format: zip
 
+brews:
+  - repository:
+      owner: shinagawa-web
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/shinagawa-web/gomarklint"
+    description: "A fast, extensible Markdown linter written in Go"
+    license: "MIT"
+
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
## Summary

- Add `brews` section to `.goreleaser.yaml` to auto-generate and push a Homebrew formula to `shinagawa-web/homebrew-tap` on each release
- Pass `HOMEBREW_TAP_GITHUB_TOKEN` secret to GoReleaser in the release workflow

After merging and tagging a release, users can install via:
```
brew install shinagawa-web/tap/gomarklint
```

## Test plan

- [ ] Verify GoReleaser config is valid: `goreleaser check`
- [ ] Tag a release and confirm the formula is pushed to `shinagawa-web/homebrew-tap`
- [ ] Test `brew install shinagawa-web/tap/gomarklint` works

Closes #109