### PR TITLE
feat: add npm package distribution

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,3 +32,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+  npm-publish:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set package version from tag
+        working-directory: npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '${VERSION}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ e2e/gomarklint-e2e-test
 *.out
 *.html
 
+# npm wrapper
+npm/gomarklint
+npm/gomarklint.exe
+npm/node_modules/
+
 # Claude Code
 .claude/worktrees/
 .claude/settings.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - format: tar.gz

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,6 +29,12 @@ Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALA
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
+**npm を使う場合:**
+
+```sh
+npm install -g @shinagawa-web/gomarklint
+```
+
 **`go install` を使う場合:**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALA
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
+**Via npm:**
+
+```sh
+npm install -g @shinagawa-web/gomarklint
+```
+
 **Via `go install`:**
 
 ```sh

--- a/npm/cli.js
+++ b/npm/cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const ext = process.platform === "win32" ? ".exe" : "";
+const bin = path.join(__dirname, "gomarklint" + ext);
+
+try {
+  execFileSync(bin, process.argv.slice(2), { stdio: "inherit" });
+} catch (e) {
+  process.exitCode = e.status || 1;
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,132 @@
+"use strict";
+
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const { execSync } = require("child_process");
+
+const REPO = "shinagawa-web/gomarklint";
+
+const PLATFORM_MAP = {
+  darwin: "Darwin",
+  linux: "Linux",
+  win32: "Windows",
+};
+
+const ARCH_MAP = {
+  x64: "x86_64",
+  arm64: "arm64",
+};
+
+function getPlatformInfo() {
+  const platform = PLATFORM_MAP[process.platform];
+  const arch = ARCH_MAP[process.arch];
+
+  if (!platform || !arch) {
+    throw new Error(
+      `Unsupported platform: ${process.platform}-${process.arch}\n` +
+        `Supported: darwin-x64, darwin-arm64, linux-x64, linux-arm64, win32-x64, win32-arm64`
+    );
+  }
+
+  const ext = process.platform === "win32" ? "zip" : "tar.gz";
+  const archiveName = `gomarklint_${platform}_${arch}.${ext}`;
+
+  return { platform, arch, ext, archiveName };
+}
+
+function download(url) {
+  return new Promise((resolve, reject) => {
+    const request = (url) => {
+      https
+        .get(url, { headers: { "User-Agent": "gomarklint-npm" } }, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            request(res.headers.location);
+            return;
+          }
+          if (res.statusCode !== 200) {
+            reject(new Error(`Download failed: HTTP ${res.statusCode} for ${url}`));
+            return;
+          }
+          const chunks = [];
+          res.on("data", (chunk) => chunks.push(chunk));
+          res.on("end", () => resolve(Buffer.concat(chunks)));
+          res.on("error", reject);
+        })
+        .on("error", reject);
+    };
+    request(url);
+  });
+}
+
+function verifyChecksum(data, expected) {
+  const actual = crypto.createHash("sha256").update(data).digest("hex");
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch!\n  Expected: ${expected}\n  Actual:   ${actual}`
+    );
+  }
+}
+
+async function main() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+  );
+  const version = pkg.version;
+
+  if (version === "0.0.0") {
+    console.log("Skipping binary download for development version.");
+    return;
+  }
+
+  const { archiveName } = getPlatformInfo();
+  const baseUrl = `https://github.com/${REPO}/releases/download/v${version}`;
+
+  console.log(`Downloading gomarklint v${version} (${archiveName})...`);
+
+  // Download checksums and archive in parallel
+  const [checksumsText, archiveData] = await Promise.all([
+    download(`${baseUrl}/checksums.txt`).then((buf) => buf.toString("utf8")),
+    download(`${baseUrl}/${archiveName}`),
+  ]);
+
+  // Verify checksum
+  const checksumLine = checksumsText
+    .split("\n")
+    .find((line) => line.includes(archiveName));
+
+  if (!checksumLine) {
+    throw new Error(`Checksum not found for ${archiveName}`);
+  }
+
+  const expectedHash = checksumLine.split(/\s+/)[0];
+  verifyChecksum(archiveData, expectedHash);
+  console.log("Checksum verified.");
+
+  // Write archive to temp file and extract
+  const archivePath = path.join(__dirname, archiveName);
+  fs.writeFileSync(archivePath, archiveData);
+
+  try {
+    execSync(`tar -xf "${archiveName}"`, { cwd: __dirname, stdio: "pipe" });
+  } catch (e) {
+    throw new Error(`Failed to extract archive: ${e.message}`);
+  }
+
+  // Clean up archive
+  fs.unlinkSync(archivePath);
+
+  // Set executable permission on non-Windows
+  if (process.platform !== "win32") {
+    const binPath = path.join(__dirname, "gomarklint");
+    fs.chmodSync(binPath, 0o755);
+  }
+
+  console.log("gomarklint installed successfully.");
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shinagawa-web/gomarklint",
+  "version": "0.0.0",
+  "description": "A fast, extensible Markdown linter written in Go",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shinagawa-web/gomarklint.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/shinagawa-web/gomarklint",
+  "keywords": [
+    "markdown",
+    "linter",
+    "lint",
+    "gomarklint"
+  ],
+  "bin": {
+    "gomarklint": "cli.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "cli.js",
+    "install.js"
+  ],
+  "engines": {
+    "node": ">=16"
+  }
+}


### PR DESCRIPTION
## Summary
- Add npm wrapper package `@shinagawa-web/gomarklint` that downloads the Go binary from GitHub Releases on `postinstall`
- SHA-256 checksum verification via `checksums.txt` for supply chain security
- Add `npm-publish` job to release workflow with `--provenance` for npm provenance attestation
- Add explicit `arm64` builds to GoReleaser config (Apple Silicon / Linux ARM)

## Test plan
- [ ] Verify `npm-publish` job runs after `release` job on next tag push
- [ ] Verify `npm install -g @shinagawa-web/gomarklint` downloads correct binary
- [ ] Verify `gomarklint --version` works after npm install
- [ ] Verify checksum verification catches tampered archives

Closes #110