### PR TITLE
fix: use correct checksums filename in npm install script

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -87,7 +87,7 @@ async function main() {
 
   // Download checksums and archive in parallel
   const [checksumsText, archiveData] = await Promise.all([
-    download(`${baseUrl}/checksums.txt`).then((buf) => buf.toString("utf8")),
+    download(`${baseUrl}/gomarklint_${version}_checksums.txt`).then((buf) => buf.toString("utf8")),
     download(`${baseUrl}/${archiveName}`),
   ]);
 


### PR DESCRIPTION
## Summary
- GoReleaser generates `gomarklint_{version}_checksums.txt`, not `checksums.txt`
- Fix the download URL in `npm/install.js` to use the correct filename

## Test plan
- [ ] `npm install -g @shinagawa-web/gomarklint` succeeds after next release