### PR TITLE
feat: add shell installer (install.sh)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,12 @@
 
 > エンジニアリングチームのための高速・実用的な Markdown リンター。Go 製、CI 向け設計。
 
+**かんたんインストール**（macOS / Linux）:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+```
+
 **バイナリをダウンロード**（Go 環境不要）:
 
 [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest) からお使いのプラットフォーム向けバイナリをダウンロードできます。

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 [English](README.md) | 日本語
 
-> エンジニアリングチームのための高速・実用的な Markdown リンター。Go 製、CI 向け設計。
+> 高速・実用的な Markdown リンター。Go 製、CI 向け設計。
 
 **かんたんインストール**（macOS / Linux）:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@
 **かんたんインストール**（macOS / Linux）:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh
 ```
 
 **バイナリをダウンロード**（Go 環境不要）:

--- a/README.ja.md
+++ b/README.ja.md
@@ -35,6 +35,12 @@ Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALA
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
+**Homebrew を使う場合:**
+
+```sh
+brew install shinagawa-web/tap/gomarklint
+```
+
 **npm を使う場合:**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ English | [日本語](README.ja.md)
 **Quick install** (macOS / Linux):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh
 ```
 
 **Download binary** (no Go required):

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALA
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
 ```
 
+**Via Homebrew:**
+
+```sh
+brew install shinagawa-web/tap/gomarklint
+```
+
 **Via npm:**
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ English | [日本語](README.ja.md)
 
 > A fast, opinionated Markdown linter for engineering teams. Built in Go, designed for CI.
 
+**Quick install** (macOS / Linux):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+```
+
 **Download binary** (no Go required):
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 English | [日本語](README.ja.md)
 
-> A fast, opinionated Markdown linter for engineering teams. Built in Go, designed for CI.
+> A fast, opinionated Markdown linter. Built in Go, designed for CI.
 
 **Quick install** (macOS / Linux):
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -15,7 +15,7 @@ title: "gomarklint"
 
 ```sh
 # macOS / Linux — one-line install
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh
 
 # or via Homebrew
 brew install shinagawa-web/tap/gomarklint

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -14,12 +14,17 @@ title: "gomarklint"
 > A fast Markdown linter built in Go — for local dev and CI alike.
 
 ```sh
-# macOS — download binary (no Go required)
-tar -xzf gomarklint_Darwin_x86_64.tar.gz
-sudo mv gomarklint /usr/local/bin/
+# macOS / Linux — one-line install
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+
+# or via Homebrew
+brew install shinagawa-web/tap/gomarklint
+
+# or via npm
+npm install -g @shinagawa-web/gomarklint
 ```
 
-Download from [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest) · [Quick Start →]({{< relref "/docs/quick-start" >}})
+[Quick Start →]({{< relref "/docs/quick-start" >}})
 
 - Catch broken links and headings before your docs ship.
 - Enforce predictable structure (no more "why is this H4 under H2?").

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -10,7 +10,7 @@ weight: 1
 **Quick install** (macOS / Linux):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh
 ```
 
 **Via Homebrew:**

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -7,6 +7,30 @@ weight: 1
 
 ## Install
 
+**Quick install** (macOS / Linux):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash
+```
+
+**Via Homebrew:**
+
+```sh
+brew install shinagawa-web/tap/gomarklint
+```
+
+**Via npm:**
+
+```sh
+npm install -g @shinagawa-web/gomarklint
+```
+
+**Via `go install`:**
+
+```sh
+go install github.com/shinagawa-web/gomarklint@latest
+```
+
 **Download binary** (no Go required):
 
 Download the latest binary for your platform from [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest).
@@ -26,12 +50,6 @@ mkdir -p ~/.local/bin && mv gomarklint ~/.local/bin/
 Expand-Archive -Path gomarklint_Windows_x86_64.zip -DestinationPath "$env:LOCALAPPDATA\Programs\gomarklint"
 # Add to PATH (run once)
 [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$env:LOCALAPPDATA\Programs\gomarklint", "User")
-```
-
-**Via `go install`:**
-
-```sh
-go install github.com/shinagawa-web/gomarklint@latest
 ```
 
 **Build from source:**

--- a/install.sh
+++ b/install.sh
@@ -26,11 +26,30 @@ case "$ARCH" in
     ;;
 esac
 
-# Get latest version from GitHub API
-VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+# Resolve version: environment variable, GitHub API, or redirect fallback
+fetch_version_from_api() {
+  curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+    | grep '"tag_name"' \
+    | sed -E 's/.*"v?([^"]+)".*/\1/' \
+    | head -n 1
+}
+
+fetch_version_from_redirect() {
+  curl -fsSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" 2>/dev/null \
+    | sed -E 's#.*/tag/v?([^/]+)$#\1#'
+}
+
+if [ -n "${GOMARKLINT_VERSION:-}" ]; then
+  VERSION="$(printf '%s' "$GOMARKLINT_VERSION" | sed -E 's/^v//')"
+else
+  VERSION="$(fetch_version_from_api)"
+  if [ -z "$VERSION" ]; then
+    VERSION="$(fetch_version_from_redirect)"
+  fi
+fi
 
 if [ -z "$VERSION" ]; then
-  echo "Error: Failed to fetch latest version" >&2
+  echo "Error: Failed to determine version. Set GOMARKLINT_VERSION to install a specific release." >&2
   exit 1
 fi
 
@@ -39,21 +58,51 @@ if [ "$(id -u)" -eq 0 ]; then
   INSTALL_DIR="/usr/local/bin"
 else
   INSTALL_DIR="${HOME}/.local/bin"
-  mkdir -p "$INSTALL_DIR"
 fi
 
-# Download and extract
+mkdir -p "$INSTALL_DIR"
+
+# Download archive and checksums
 ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+CHECKSUMS="${BINARY}_${VERSION}_checksums.txt"
+BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
 
 echo "Installing ${BINARY} v${VERSION} (${OS}/${ARCH})..."
-echo "  From: ${URL}"
+echo "  From: ${BASE_URL}/${ARCHIVE}"
 echo "  To:   ${INSTALL_DIR}/${BINARY}"
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-curl -fsSL "$URL" -o "${TMPDIR}/${ARCHIVE}"
+curl -fsSL "${BASE_URL}/${ARCHIVE}" -o "${TMPDIR}/${ARCHIVE}"
+curl -fsSL "${BASE_URL}/${CHECKSUMS}" -o "${TMPDIR}/${CHECKSUMS}"
+
+# Verify SHA-256 checksum
+EXPECTED="$(grep "${ARCHIVE}" "${TMPDIR}/${CHECKSUMS}" | awk '{print $1}')"
+if [ -z "$EXPECTED" ]; then
+  echo "Error: Checksum not found for ${ARCHIVE}" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 "${TMPDIR}/${ARCHIVE}" | awk '{print $1}')"
+else
+  echo "Warning: No sha256sum or shasum found, skipping checksum verification." >&2
+  ACTUAL="$EXPECTED"
+fi
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "Error: Checksum mismatch!" >&2
+  echo "  Expected: ${EXPECTED}" >&2
+  echo "  Actual:   ${ACTUAL}" >&2
+  exit 1
+fi
+
+echo "Checksum verified."
+
+# Extract and install
 tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
 install -m 755 "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+REPO="shinagawa-web/gomarklint"
+BINARY="gomarklint"
+
+# Detect OS
+OS="$(uname -s)"
+case "$OS" in
+  Darwin) OS="Darwin" ;;
+  Linux)  OS="Linux" ;;
+  *)
+    echo "Error: Unsupported OS: $OS" >&2
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)
+    echo "Error: Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+# Get latest version from GitHub API
+VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Failed to fetch latest version" >&2
+  exit 1
+fi
+
+# Determine install directory
+if [ "$(id -u)" -eq 0 ]; then
+  INSTALL_DIR="/usr/local/bin"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+# Download and extract
+ARCHIVE="${BINARY}_${OS}_${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+
+echo "Installing ${BINARY} v${VERSION} (${OS}/${ARCH})..."
+echo "  From: ${URL}"
+echo "  To:   ${INSTALL_DIR}/${BINARY}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL "$URL" -o "${TMPDIR}/${ARCHIVE}"
+tar -xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+install -m 755 "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+
+echo "Successfully installed ${BINARY} v${VERSION} to ${INSTALL_DIR}/${BINARY}"
+
+# Check if install dir is in PATH
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo ""
+    echo "Note: ${INSTALL_DIR} is not in your PATH."
+    echo "Add it by running:"
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    ;;
+esac

--- a/npm/README.md
+++ b/npm/README.md
@@ -51,7 +51,7 @@ Full documentation is available at **[shinagawa-web.github.io/gomarklint](https:
 
 ## Other installation methods
 
-- **Shell:** `curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash`
+- **Shell:** `curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | sh`
 - **Homebrew:** `brew install shinagawa-web/tap/gomarklint`
 - **Go:** `go install github.com/shinagawa-web/gomarklint@latest`
 - **Binary:** Download from [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest)

--- a/npm/README.md
+++ b/npm/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@shinagawa-web/gomarklint)](https://www.npmjs.com/package/@shinagawa-web/gomarklint)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/shinagawa-web/gomarklint/blob/main/LICENSE)
 
-> A fast, opinionated Markdown linter for engineering teams. Built in Go, designed for CI.
+> A fast, opinionated Markdown linter. Built in Go, designed for CI.
 
 - Catch broken links and headings before your docs ship.
 - Enforce predictable structure (no more "why is this H4 under H2?").
@@ -51,6 +51,7 @@ Full documentation is available at **[shinagawa-web.github.io/gomarklint](https:
 
 ## Other installation methods
 
+- **Shell:** `curl -fsSL https://raw.githubusercontent.com/shinagawa-web/gomarklint/main/install.sh | bash`
 - **Homebrew:** `brew install shinagawa-web/tap/gomarklint`
 - **Go:** `go install github.com/shinagawa-web/gomarklint@latest`
 - **Binary:** Download from [GitHub Releases](https://github.com/shinagawa-web/gomarklint/releases/latest)


### PR DESCRIPTION
## Summary
- Add `install.sh` that detects OS/arch and downloads the latest binary from GitHub Releases
- Installs to `~/.local/bin` (user) or `/usr/local/bin` (root)
- Warns if install directory is not in PATH
- Add `curl | bash` install method to README.md and README.ja.md

## Test plan
- [x] Tested locally on macOS arm64 — binary downloaded and runs correctly

Closes #112