### PR TITLE
fix: point npm homepage to docs site

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@ go install github.com/shinagawa-web/gomarklint@latest
 
 完全なドキュメントは **[https://shinagawa-web.github.io/gomarklint/](https://shinagawa-web.github.io/gomarklint/)** で参照できます。
 
-- [クイックスタート](https://shinagawa-web.github.io/gomarklint/docs/)
+- [クイックスタート](https://shinagawa-web.github.io/gomarklint/docs/quick-start/)
 - [ルール一覧](https://shinagawa-web.github.io/gomarklint/docs/rules/)
 - [CLI リファレンス](https://shinagawa-web.github.io/gomarklint/docs/cli/)
 - [設定](https://shinagawa-web.github.io/gomarklint/docs/configuration/)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ go install github.com/shinagawa-web/gomarklint@latest
 
 Full documentation is available at **[shinagawa-web.github.io/gomarklint](https://shinagawa-web.github.io/gomarklint/)**
 
-- [Quick Start](https://shinagawa-web.github.io/gomarklint/docs/)
+- [Quick Start](https://shinagawa-web.github.io/gomarklint/docs/quick-start/)
 - [Rules](https://shinagawa-web.github.io/gomarklint/docs/rules/)
 - [CLI Reference](https://shinagawa-web.github.io/gomarklint/docs/cli/)
 - [Configuration](https://shinagawa-web.github.io/gomarklint/docs/configuration/)

--- a/docs/content/docs/github-actions.md
+++ b/docs/content/docs/github-actions.md
@@ -10,26 +10,53 @@ You can use gomarklint in your CI workflows using the official [GitHub Action](h
 > **Note:** It is recommended that you create a `.gomarklint.json` configuration file in your repository root before using `gomarklint` in GitHub Actions. If no configuration file is present, gomarklint will run with its default settings.
 > You can generate a starter config with: `gomarklint init`
 
-## Example: `.github/workflows/lint.yml`
+## Quick Start
 
 ```yml
+# .github/workflows/docs-lint.yml
 name: Lint Markdown
 
 on:
-  push:
-    paths:
-      - '**/*.md'
   pull_request:
     paths:
       - '**/*.md'
 
 jobs:
-  markdown-lint:
+  docs-lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Run gomarklint Action
-        uses: shinagawa-web/gomarklint-action@v1
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: shinagawa-web/gomarklint-action@v1
 ```
+
+## PR Comment
+
+Post lint results as a comment on pull requests. The comment is automatically updated on subsequent runs, avoiding duplicates.
+
+```yml
+- uses: shinagawa-web/gomarklint-action@v1
+  with:
+    comment-on-pr: 'true'
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+> **Note:** The job needs `pull-requests: write` permission.
+
+```yml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `args` | No | `''` | Arguments to pass to gomarklint |
+| `comment-on-pr` | No | `'false'` | Post lint results as a PR comment |
+| `github-token` | No | `${{ github.token }}` | GitHub token for posting PR comments |

--- a/npm/README.md
+++ b/npm/README.md
@@ -43,7 +43,7 @@ gomarklint --format json
 
 Full documentation is available at **[shinagawa-web.github.io/gomarklint](https://shinagawa-web.github.io/gomarklint/)**
 
-- [Quick Start](https://shinagawa-web.github.io/gomarklint/docs/)
+- [Quick Start](https://shinagawa-web.github.io/gomarklint/docs/quick-start/)
 - [Rules](https://shinagawa-web.github.io/gomarklint/docs/rules/)
 - [CLI Reference](https://shinagawa-web.github.io/gomarklint/docs/cli/)
 - [Configuration](https://shinagawa-web.github.io/gomarklint/docs/configuration/)

--- a/npm/package.json
+++ b/npm/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/shinagawa-web/gomarklint.git",
     "directory": "npm"
   },
-  "homepage": "https://github.com/shinagawa-web/gomarklint",
+  "homepage": "https://shinagawa-web.github.io/gomarklint/",
   "keywords": [
     "markdown",
     "linter",


### PR DESCRIPTION
## Summary
- Change `homepage` in `npm/package.json` from GitHub repo to docs site (https://shinagawa-web.github.io/gomarklint/)

## Test plan
- [ ] Next npm publish shows docs site as Homepage on https://www.npmjs.com/package/@shinagawa-web/gomarklint