### PR TITLE
investigate: benchmark regression on EPYC for no-trailing-spaces

### DIFF
--- a/.github/workflows/bench-investigate.yml
+++ b/.github/workflows/bench-investigate.yml
@@ -22,66 +22,74 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      # Test 1: 12 rules vs 13 rules (with count=6 for statistical significance)
-      - name: "Test 1: 12 vs 13 rules (count=6)"
+      # Test A: How does the number of enabled rules (if-block count) affect perf?
+      - name: "Test A: if-block count scaling (12, 13, 15, 20, 25 rules)"
         run: |
-          echo "=== 12 rules vs 13 rules (1000 sections) ==="
-          go test -bench='BenchmarkWith1[23]Rules$' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test1.txt
+          go test -bench='BenchmarkBlocks' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee testA.txt
 
-      # Test 2: 12 vs 13 rules ExtraLarge
-      - name: "Test 2: 12 vs 13 rules XL (count=6)"
+      # Test B: Does splitting collectErrors into two smaller functions help?
+      - name: "Test B: single vs split function"
         run: |
-          echo "=== 12 vs 13 rules (5000 sections) ==="
-          go test -bench='BenchmarkWith1[23]Rules_XL' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test2.txt
+          go test -bench='Benchmark(Single|Split)Function' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee testB.txt
 
-      # Test 3: Noop rule (does adding ANY 13th rule cause regression?)
-      - name: "Test 3: 12 rules vs 12+noop vs 13 vs 13+noop (count=6)"
+      # Test C: Cross-binary comparison (simulates what the original benchmark.yml does)
+      # Build two separate test binaries and compare
+      - name: "Test C: cross-binary comparison"
         run: |
-          echo "=== Noop test ==="
-          go test -bench='BenchmarkWith1[23](Rules$|PlusNoop$)' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test3.txt
+          echo "=== Build binary with 26 if-blocks (current source) ==="
+          go test -c -o bench_26blocks ./cmd/
 
-      # Test 4: Per-rule isolation (which rules are expensive on EPYC?)
-      - name: "Test 4: Per-rule costs"
-        run: |
-          echo "=== Individual rule costs ==="
-          go test -bench='BenchmarkIsolated_' -benchmem -count=3 ./cmd/ -run='^$' 2>&1 | tee test4.txt
+          echo "=== Run 13 rules on 26-block binary ==="
+          ./bench_26blocks -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_26blocks.txt
 
-      # Test 5: CPU profile of full linting with 13 rules
-      - name: "Test 5: CPU profile"
-        run: |
-          go test -bench='BenchmarkWith13Rules$' -cpuprofile=cpu.prof -count=1 ./cmd/ -run='^$'
-          go tool pprof -text -cum cpu.prof 2>&1 | head -60 | tee test5.txt
+          echo "=== Now strip noop blocks from source and rebuild ==="
+          # Remove noop if-blocks from linter.go to get a 13-block binary
+          sed -i '/Noop blocks for benchmark/,/noop13/d' internal/linter/linter.go
+          go test -c -o bench_13blocks ./cmd/
+
+          echo "=== Run 13 rules on 13-block binary ==="
+          ./bench_13blocks -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_13blocks.txt
+
+          echo "=== Now also strip no-trailing-spaces to get 12-block binary ==="
+          sed -i '/no-trailing-spaces/d' internal/linter/linter.go
+          go test -c -o bench_12blocks ./cmd/
+
+          echo "=== Run 12 rules on 12-block binary ==="
+          ./bench_12blocks -test.bench='BenchmarkBlocks12' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_12blocks.txt
 
       - name: Collect results
         id: results
         run: |
           {
-            echo "## Benchmark Investigation (EPYC amd64)"
+            echo "## Benchmark Investigation Round 2 (EPYC amd64)"
             echo ""
-            echo "### Test 1: 12 vs 13 rules (1000 sections, count=6)"
+            echo "### Test A: if-block count scaling"
+            echo "All run in the same binary (26 if-blocks in source). Only the enabled rule count changes."
             echo '```'
-            cat test1.txt
-            echo '```'
-            echo ""
-            echo "### Test 2: 12 vs 13 rules (5000 sections, count=6)"
-            echo '```'
-            cat test2.txt
+            cat testA.txt
             echo '```'
             echo ""
-            echo "### Test 3: Noop rule test"
-            echo "Does adding ANY 13th call site cause regression?"
+            echo "### Test B: single function vs split (7+6 blocks)"
             echo '```'
-            cat test3.txt
-            echo '```'
-            echo ""
-            echo "### Test 4: Per-rule costs on EPYC"
-            echo '```'
-            cat test4.txt
+            cat testB.txt
             echo '```'
             echo ""
-            echo "### Test 5: CPU profile (top functions)"
+            echo "### Test C: cross-binary comparison (the real test)"
+            echo "Same rules enabled, but compiled from source with different numbers of if-blocks."
+            echo ""
+            echo "#### 12-block binary (12 rules, no no-trailing-spaces in source)"
             echo '```'
-            cat test5.txt
+            cat testC_12blocks.txt
+            echo '```'
+            echo ""
+            echo "#### 13-block binary (13 rules, no-trailing-spaces in source)"
+            echo '```'
+            cat testC_13blocks.txt
+            echo '```'
+            echo ""
+            echo "#### 26-block binary (13 real + 13 noop in source)"
+            echo '```'
+            cat testC_26blocks.txt
             echo '```'
           } > results.md
           cat results.md

--- a/.github/workflows/bench-investigate.yml
+++ b/.github/workflows/bench-investigate.yml
@@ -22,7 +22,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      # Test A: How does the number of enabled rules (if-block count) affect perf?
+      # Test A: How does the number of enabled rules affect perf in the same binary?
       - name: "Test A: if-block count scaling (12, 13, 15, 20, 25 rules)"
         run: |
           go test -bench='BenchmarkBlocks' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee testA.txt
@@ -32,30 +32,51 @@ jobs:
         run: |
           go test -bench='Benchmark(Single|Split)Function' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee testB.txt
 
-      # Test C: Cross-binary comparison (simulates what the original benchmark.yml does)
-      # Build two separate test binaries and compare
+      # Test C: Cross-binary comparison
+      # Build separate binaries from different source states
       - name: "Test C: cross-binary comparison"
         run: |
-          echo "=== Build binary with 26 if-blocks (current source) ==="
-          go test -c -o bench_26blocks ./cmd/
+          echo "=== Binary A: full source (26 if-blocks) ==="
+          go test -c -o bench_full ./cmd/
+          ./bench_full -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_full.txt
 
-          echo "=== Run 13 rules on 26-block binary ==="
-          ./bench_26blocks -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_26blocks.txt
+          echo "=== Binary B: remove noop blocks (13 if-blocks) ==="
+          cp internal/linter/linter.go internal/linter/linter.go.bak
+          python3 -c "
+          import re
+          with open('internal/linter/linter.go') as f:
+              src = f.read()
+          # Remove the noop section (from comment to last noop13 block)
+          src = re.sub(r'\n\t// Noop blocks for benchmark.*?\n\t\}', '', src, flags=re.DOTALL)
+          with open('internal/linter/linter.go', 'w') as f:
+              f.write(src)
+          "
+          go test -c -o bench_13 ./cmd/
+          ./bench_13 -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_13.txt
 
-          echo "=== Now strip noop blocks from source and rebuild ==="
-          # Remove noop if-blocks from linter.go to get a 13-block binary
-          sed -i '/Noop blocks for benchmark/,/noop13/d' internal/linter/linter.go
-          go test -c -o bench_13blocks ./cmd/
+          echo "=== Binary C: also remove no-trailing-spaces (12 if-blocks) ==="
+          python3 -c "
+          with open('internal/linter/linter.go') as f:
+              lines = f.readlines()
+          out = []
+          skip = False
+          for line in lines:
+              if 'no-trailing-spaces' in line:
+                  skip = True
+                  continue
+              if skip and line.strip() == '}':
+                  skip = False
+                  continue
+              skip = False
+              out.append(line)
+          with open('internal/linter/linter.go', 'w') as f:
+              f.writelines(out)
+          "
+          go test -c -o bench_12 ./cmd/
+          ./bench_12 -test.bench='BenchmarkBlocks12' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_12.txt
 
-          echo "=== Run 13 rules on 13-block binary ==="
-          ./bench_13blocks -test.bench='BenchmarkSingleFunction' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_13blocks.txt
-
-          echo "=== Now also strip no-trailing-spaces to get 12-block binary ==="
-          sed -i '/no-trailing-spaces/d' internal/linter/linter.go
-          go test -c -o bench_12blocks ./cmd/
-
-          echo "=== Run 12 rules on 12-block binary ==="
-          ./bench_12blocks -test.bench='BenchmarkBlocks12' -test.benchmem -test.count=6 -test.run='^$' 2>&1 | tee testC_12blocks.txt
+          # Restore
+          cp internal/linter/linter.go.bak internal/linter/linter.go
 
       - name: Collect results
         id: results
@@ -63,8 +84,8 @@ jobs:
           {
             echo "## Benchmark Investigation Round 2 (EPYC amd64)"
             echo ""
-            echo "### Test A: if-block count scaling"
-            echo "All run in the same binary (26 if-blocks in source). Only the enabled rule count changes."
+            echo "### Test A: if-block count scaling (same binary)"
+            echo "All run in the same binary (26 if-blocks in source). Only the enabled rule count changes via config."
             echo '```'
             cat testA.txt
             echo '```'
@@ -74,22 +95,23 @@ jobs:
             cat testB.txt
             echo '```'
             echo ""
-            echo "### Test C: cross-binary comparison (the real test)"
-            echo "Same rules enabled, but compiled from source with different numbers of if-blocks."
+            echo "### Test C: cross-binary comparison"
+            echo "Same rules running, but compiled from source with different if-block counts."
+            echo "This simulates what the original benchmark.yml does (PR binary vs main binary)."
             echo ""
-            echo "#### 12-block binary (12 rules, no no-trailing-spaces in source)"
+            echo "#### Binary with 12 if-blocks (no no-trailing-spaces in source)"
             echo '```'
-            cat testC_12blocks.txt
-            echo '```'
-            echo ""
-            echo "#### 13-block binary (13 rules, no-trailing-spaces in source)"
-            echo '```'
-            cat testC_13blocks.txt
+            cat testC_12.txt
             echo '```'
             echo ""
-            echo "#### 26-block binary (13 real + 13 noop in source)"
+            echo "#### Binary with 13 if-blocks (with no-trailing-spaces in source)"
             echo '```'
-            cat testC_26blocks.txt
+            cat testC_13.txt
+            echo '```'
+            echo ""
+            echo "#### Binary with 26 if-blocks (13 real + 13 noop in source)"
+            echo '```'
+            cat testC_full.txt
             echo '```'
           } > results.md
           cat results.md

--- a/.github/workflows/bench-investigate.yml
+++ b/.github/workflows/bench-investigate.yml
@@ -1,0 +1,117 @@
+name: Benchmark Investigation
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  investigate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Test 1: 12 rules vs 13 rules (with count=6 for statistical significance)
+      - name: "Test 1: 12 vs 13 rules (count=6)"
+        run: |
+          echo "=== 12 rules vs 13 rules (1000 sections) ==="
+          go test -bench='BenchmarkWith1[23]Rules$' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test1.txt
+
+      # Test 2: 12 vs 13 rules ExtraLarge
+      - name: "Test 2: 12 vs 13 rules XL (count=6)"
+        run: |
+          echo "=== 12 vs 13 rules (5000 sections) ==="
+          go test -bench='BenchmarkWith1[23]Rules_XL' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test2.txt
+
+      # Test 3: Noop rule (does adding ANY 13th rule cause regression?)
+      - name: "Test 3: 12 rules vs 12+noop vs 13 vs 13+noop (count=6)"
+        run: |
+          echo "=== Noop test ==="
+          go test -bench='BenchmarkWith1[23](Rules$|PlusNoop$)' -benchmem -count=6 ./cmd/ -run='^$' 2>&1 | tee test3.txt
+
+      # Test 4: Per-rule isolation (which rules are expensive on EPYC?)
+      - name: "Test 4: Per-rule costs"
+        run: |
+          echo "=== Individual rule costs ==="
+          go test -bench='BenchmarkIsolated_' -benchmem -count=3 ./cmd/ -run='^$' 2>&1 | tee test4.txt
+
+      # Test 5: CPU profile of full linting with 13 rules
+      - name: "Test 5: CPU profile"
+        run: |
+          go test -bench='BenchmarkWith13Rules$' -cpuprofile=cpu.prof -count=1 ./cmd/ -run='^$'
+          go tool pprof -text -cum cpu.prof 2>&1 | head -60 | tee test5.txt
+
+      - name: Collect results
+        id: results
+        run: |
+          {
+            echo "## Benchmark Investigation (EPYC amd64)"
+            echo ""
+            echo "### Test 1: 12 vs 13 rules (1000 sections, count=6)"
+            echo '```'
+            cat test1.txt
+            echo '```'
+            echo ""
+            echo "### Test 2: 12 vs 13 rules (5000 sections, count=6)"
+            echo '```'
+            cat test2.txt
+            echo '```'
+            echo ""
+            echo "### Test 3: Noop rule test"
+            echo "Does adding ANY 13th call site cause regression?"
+            echo '```'
+            cat test3.txt
+            echo '```'
+            echo ""
+            echo "### Test 4: Per-rule costs on EPYC"
+            echo '```'
+            cat test4.txt
+            echo '```'
+            echo ""
+            echo "### Test 5: CPU profile (top functions)"
+            echo '```'
+            cat test5.txt
+            echo '```'
+          } > results.md
+          cat results.md
+
+      - name: Comment PR
+        uses: actions/github-script@v9
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const body = '<!-- bench-investigate -->\n' + fs.readFileSync('results.md', 'utf8');
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const existing = comments.find(c => c.body.includes('<!-- bench-investigate -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }

--- a/cmd/bench_investigate_test.go
+++ b/cmd/bench_investigate_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
+)
+
+// BenchmarkWith12Rules runs full linting WITHOUT no-trailing-spaces (simulates main).
+func BenchmarkWith12Rules(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["no-trailing-spaces"].Enabled = false
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// BenchmarkWith13Rules runs full linting WITH no-trailing-spaces.
+func BenchmarkWith13Rules(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// BenchmarkWith12Rules_XL runs full linting WITHOUT no-trailing-spaces (5000 sections).
+func BenchmarkWith12Rules_XL(b *testing.B) {
+	content := generateComplexMarkdown(5000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["no-trailing-spaces"].Enabled = false
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// BenchmarkWith13Rules_XL runs full linting WITH no-trailing-spaces (5000 sections).
+func BenchmarkWith13Rules_XL(b *testing.B) {
+	content := generateComplexMarkdown(5000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// --- Per-rule isolation benchmarks ---
+
+func benchSingleRule(b *testing.B, ruleName string, sections int) {
+	content := generateComplexMarkdown(sections)
+	cfg := config.Default()
+	for name := range cfg.Rules {
+		cfg.Rules[name].Enabled = false
+	}
+	cfg.Rules[ruleName].Enabled = true
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+func BenchmarkIsolated_FinalBlankLine(b *testing.B)       { benchSingleRule(b, "final-blank-line", 1000) }
+func BenchmarkIsolated_UnclosedCodeBlock(b *testing.B)    { benchSingleRule(b, "unclosed-code-block", 1000) }
+func BenchmarkIsolated_EmptyAltText(b *testing.B)         { benchSingleRule(b, "empty-alt-text", 1000) }
+func BenchmarkIsolated_HeadingLevel(b *testing.B)         { benchSingleRule(b, "heading-level", 1000) }
+func BenchmarkIsolated_FencedCodeLanguage(b *testing.B)   { benchSingleRule(b, "fenced-code-language", 1000) }
+func BenchmarkIsolated_DuplicateHeading(b *testing.B)     { benchSingleRule(b, "duplicate-heading", 1000) }
+func BenchmarkIsolated_NoMultipleBlankLines(b *testing.B) { benchSingleRule(b, "no-multiple-blank-lines", 1000) }
+func BenchmarkIsolated_NoSetextHeadings(b *testing.B)     { benchSingleRule(b, "no-setext-headings", 1000) }
+func BenchmarkIsolated_SingleH1(b *testing.B)             { benchSingleRule(b, "single-h1", 1000) }
+func BenchmarkIsolated_BlanksAroundHeadings(b *testing.B) { benchSingleRule(b, "blanks-around-headings", 1000) }
+func BenchmarkIsolated_NoBareURLs(b *testing.B)           { benchSingleRule(b, "no-bare-urls", 1000) }
+func BenchmarkIsolated_NoEmptyLinks(b *testing.B)         { benchSingleRule(b, "no-empty-links", 1000) }
+func BenchmarkIsolated_NoTrailingSpaces(b *testing.B)     { benchSingleRule(b, "no-trailing-spaces", 1000) }
+
+// --- Dummy rule tests: does adding ANY no-op rule cause regression? ---
+
+// BenchmarkWith12PlusNoop runs 12 real rules + noop (no-trailing-spaces disabled).
+// Tests if a 13th call site in collectErrors causes regression on its own.
+func BenchmarkWith12PlusNoop(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["no-trailing-spaces"].Enabled = false
+	cfg.Rules["noop"] = &config.RuleConfig{Enabled: true, Severity: config.SeverityError, Options: map[string]interface{}{}}
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// BenchmarkWith13PlusNoop runs 13 real rules + noop (14 total).
+// Tests if the regression scales with rule count.
+func BenchmarkWith13PlusNoop(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["noop"] = &config.RuleConfig{Enabled: true, Severity: config.SeverityError, Options: map[string]interface{}{}}
+	lint := linter.New(cfg)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}

--- a/cmd/bench_investigate_test.go
+++ b/cmd/bench_investigate_test.go
@@ -7,110 +7,93 @@ import (
 	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
 )
 
-// BenchmarkWith12Rules runs full linting WITHOUT no-trailing-spaces (simulates main).
-func BenchmarkWith12Rules(b *testing.B) {
+func makeConfig(noopCount int, enableTrailing bool) config.Config {
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	if !enableTrailing {
+		cfg.Rules["no-trailing-spaces"].Enabled = false
+	}
+	noopNames := []string{"noop1", "noop2", "noop3", "noop4", "noop5", "noop6", "noop7", "noop8", "noop9", "noop10", "noop11", "noop12", "noop13"}
+	for i := 0; i < noopCount && i < len(noopNames); i++ {
+		cfg.Rules[noopNames[i]] = &config.RuleConfig{Enabled: true, Severity: config.SeverityError, Options: map[string]interface{}{}}
+	}
+	return cfg
+}
+
+// --- Test A: How does if-block count affect performance? ---
+// All use the SAME compiled binary. Vary enabled noop rules.
+// Total if-blocks in source: 13 real + 13 noop = 26
+// Enabled rules: 12 base + no-trailing-spaces + N noops
+
+// 12 rules (no-trailing-spaces OFF, 0 noops)
+func BenchmarkBlocks12(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	lint := linter.New(makeConfig(0, false))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// 13 rules (no-trailing-spaces ON, 0 noops)
+func BenchmarkBlocks13(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	lint := linter.New(makeConfig(0, true))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// 15 rules (13 + 2 noops)
+func BenchmarkBlocks15(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	lint := linter.New(makeConfig(2, true))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// 20 rules (13 + 7 noops)
+func BenchmarkBlocks20(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	lint := linter.New(makeConfig(7, true))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// 25 rules (13 + 12 noops)
+func BenchmarkBlocks25(b *testing.B) {
+	content := generateComplexMarkdown(1000)
+	lint := linter.New(makeConfig(12, true))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+// --- Test B: Does splitting collectErrors into smaller functions help? ---
+
+// BenchmarkSplitFunction uses collectErrorsSplit (two groups of ~6-7 rules)
+func BenchmarkSplitFunction(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["no-trailing-spaces"].Enabled = false
 	lint := linter.New(cfg)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
+		_, _, _ = lint.LintContentSplit("benchmark.md", content)
 	}
 }
 
-// BenchmarkWith13Rules runs full linting WITH no-trailing-spaces.
-func BenchmarkWith13Rules(b *testing.B) {
+// BenchmarkSingleFunction is the same rules but via the original single collectErrors
+func BenchmarkSingleFunction(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
-	lint := linter.New(cfg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-// BenchmarkWith12Rules_XL runs full linting WITHOUT no-trailing-spaces (5000 sections).
-func BenchmarkWith12Rules_XL(b *testing.B) {
-	content := generateComplexMarkdown(5000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["no-trailing-spaces"].Enabled = false
-	lint := linter.New(cfg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-// BenchmarkWith13Rules_XL runs full linting WITH no-trailing-spaces (5000 sections).
-func BenchmarkWith13Rules_XL(b *testing.B) {
-	content := generateComplexMarkdown(5000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	lint := linter.New(cfg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-// --- Per-rule isolation benchmarks ---
-
-func benchSingleRule(b *testing.B, ruleName string, sections int) {
-	content := generateComplexMarkdown(sections)
-	cfg := config.Default()
-	for name := range cfg.Rules {
-		cfg.Rules[name].Enabled = false
-	}
-	cfg.Rules[ruleName].Enabled = true
-	lint := linter.New(cfg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-func BenchmarkIsolated_FinalBlankLine(b *testing.B)       { benchSingleRule(b, "final-blank-line", 1000) }
-func BenchmarkIsolated_UnclosedCodeBlock(b *testing.B)    { benchSingleRule(b, "unclosed-code-block", 1000) }
-func BenchmarkIsolated_EmptyAltText(b *testing.B)         { benchSingleRule(b, "empty-alt-text", 1000) }
-func BenchmarkIsolated_HeadingLevel(b *testing.B)         { benchSingleRule(b, "heading-level", 1000) }
-func BenchmarkIsolated_FencedCodeLanguage(b *testing.B)   { benchSingleRule(b, "fenced-code-language", 1000) }
-func BenchmarkIsolated_DuplicateHeading(b *testing.B)     { benchSingleRule(b, "duplicate-heading", 1000) }
-func BenchmarkIsolated_NoMultipleBlankLines(b *testing.B) { benchSingleRule(b, "no-multiple-blank-lines", 1000) }
-func BenchmarkIsolated_NoSetextHeadings(b *testing.B)     { benchSingleRule(b, "no-setext-headings", 1000) }
-func BenchmarkIsolated_SingleH1(b *testing.B)             { benchSingleRule(b, "single-h1", 1000) }
-func BenchmarkIsolated_BlanksAroundHeadings(b *testing.B) { benchSingleRule(b, "blanks-around-headings", 1000) }
-func BenchmarkIsolated_NoBareURLs(b *testing.B)           { benchSingleRule(b, "no-bare-urls", 1000) }
-func BenchmarkIsolated_NoEmptyLinks(b *testing.B)         { benchSingleRule(b, "no-empty-links", 1000) }
-func BenchmarkIsolated_NoTrailingSpaces(b *testing.B)     { benchSingleRule(b, "no-trailing-spaces", 1000) }
-
-// --- Dummy rule tests: does adding ANY no-op rule cause regression? ---
-
-// BenchmarkWith12PlusNoop runs 12 real rules + noop (no-trailing-spaces disabled).
-// Tests if a 13th call site in collectErrors causes regression on its own.
-func BenchmarkWith12PlusNoop(b *testing.B) {
-	content := generateComplexMarkdown(1000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["no-trailing-spaces"].Enabled = false
-	cfg.Rules["noop"] = &config.RuleConfig{Enabled: true, Severity: config.SeverityError, Options: map[string]interface{}{}}
-	lint := linter.New(cfg)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-// BenchmarkWith13PlusNoop runs 13 real rules + noop (14 total).
-// Tests if the regression scales with rule count.
-func BenchmarkWith13PlusNoop(b *testing.B) {
-	content := generateComplexMarkdown(1000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["noop"] = &config.RuleConfig{Enabled: true, Severity: config.SeverityError, Options: map[string]interface{}{}}
 	lint := linter.New(cfg)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const DefaultConfigJSON = `{
     "blanks-around-headings": true,
     "no-bare-urls": true,
     "no-empty-links": true,
+    "no-trailing-spaces": true,
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
@@ -254,6 +255,11 @@ func Default() Config {
 				Options:  map[string]interface{}{},
 			},
 			"no-empty-links": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{},
+			},
+			"no-trailing-spaces": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -209,6 +209,12 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	if l.config.IsEnabled("no-empty-links") {
 		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
 	}
+	if l.config.IsEnabled("no-trailing-spaces") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoTrailingSpaces(path, body, lines, offset), "no-trailing-spaces")...)
+	}
+	if l.config.IsEnabled("noop") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop(path, lines, offset), "noop")...)
+	}
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -212,8 +212,45 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	if l.config.IsEnabled("no-trailing-spaces") {
 		allErrors = append(allErrors, l.withSeverity(rule.CheckNoTrailingSpaces(path, body, lines, offset), "no-trailing-spaces")...)
 	}
-	if l.config.IsEnabled("noop") {
-		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop(path, lines, offset), "noop")...)
+	// Noop blocks for benchmark investigation: simulate more if-blocks
+	if l.config.IsEnabled("noop1") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop1(path, lines, offset), "noop1")...)
+	}
+	if l.config.IsEnabled("noop2") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop2(path, lines, offset), "noop2")...)
+	}
+	if l.config.IsEnabled("noop3") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop3(path, lines, offset), "noop3")...)
+	}
+	if l.config.IsEnabled("noop4") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop4(path, lines, offset), "noop4")...)
+	}
+	if l.config.IsEnabled("noop5") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop5(path, lines, offset), "noop5")...)
+	}
+	if l.config.IsEnabled("noop6") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop6(path, lines, offset), "noop6")...)
+	}
+	if l.config.IsEnabled("noop7") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop7(path, lines, offset), "noop7")...)
+	}
+	if l.config.IsEnabled("noop8") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop8(path, lines, offset), "noop8")...)
+	}
+	if l.config.IsEnabled("noop9") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop9(path, lines, offset), "noop9")...)
+	}
+	if l.config.IsEnabled("noop10") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop10(path, lines, offset), "noop10")...)
+	}
+	if l.config.IsEnabled("noop11") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop11(path, lines, offset), "noop11")...)
+	}
+	if l.config.IsEnabled("noop12") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop12(path, lines, offset), "noop12")...)
+	}
+	if l.config.IsEnabled("noop13") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoop13(path, lines, offset), "noop13")...)
 	}
 
 	linksChecked := 0

--- a/internal/linter/linter_split.go
+++ b/internal/linter/linter_split.go
@@ -1,0 +1,85 @@
+package linter
+
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v2/internal/file"
+	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+)
+
+// collectErrorsSplit is an alternative to collectErrors that splits rule
+// execution into two separate functions. Used for benchmark investigation
+// to test whether splitting a large function into smaller ones avoids
+// compiler optimization regressions on amd64.
+func (l *Linter) collectErrorsSplit(path string, content string) ([]rule.LintError, int, int) {
+	body, offset := file.StripFrontmatter(content)
+	lines := strings.Split(body, "\n")
+
+	var allErrors []rule.LintError
+	allErrors = l.collectGroupA(allErrors, path, body, lines, offset)
+	allErrors = l.collectGroupB(allErrors, path, lines, offset)
+
+	linksChecked := 0
+	if l.config.IsEnabled("external-link") {
+		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.urlCache)
+		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
+		linksChecked = count
+	}
+
+	lineCount := strings.Count(content, "\n") + 1
+	return allErrors, lineCount, linksChecked
+}
+
+//go:noinline
+func (l *Linter) collectGroupA(allErrors []rule.LintError, path, body string, lines []string, offset int) []rule.LintError {
+	if l.config.IsEnabled("final-blank-line") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckFinalBlankLine(path, lines, offset), "final-blank-line")...)
+	}
+	if l.config.IsEnabled("unclosed-code-block") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckUnclosedCodeBlocks(path, lines, offset), "unclosed-code-block")...)
+	}
+	if l.config.IsEnabled("empty-alt-text") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckEmptyAltText(path, lines, offset), "empty-alt-text")...)
+	}
+	if l.config.IsEnabled("heading-level") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckHeadingLevels(path, lines, offset, l.headingMinLevel()), "heading-level")...)
+	}
+	if l.config.IsEnabled("fenced-code-language") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckFencedCodeLanguage(path, lines, offset), "fenced-code-language")...)
+	}
+	if l.config.IsEnabled("duplicate-heading") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckDuplicateHeadings(path, lines, offset), "duplicate-heading")...)
+	}
+	if l.config.IsEnabled("no-trailing-spaces") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoTrailingSpaces(path, body, lines, offset), "no-trailing-spaces")...)
+	}
+	return allErrors
+}
+
+//go:noinline
+func (l *Linter) collectGroupB(allErrors []rule.LintError, path string, lines []string, offset int) []rule.LintError {
+	if l.config.IsEnabled("no-multiple-blank-lines") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoMultipleBlankLines(path, lines, offset), "no-multiple-blank-lines")...)
+	}
+	if l.config.IsEnabled("no-setext-headings") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoSetextHeadings(path, lines, offset), "no-setext-headings")...)
+	}
+	if l.config.IsEnabled("single-h1") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckSingleH1(path, lines, offset), "single-h1")...)
+	}
+	if l.config.IsEnabled("blanks-around-headings") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckBlanksAroundHeadings(path, lines, offset), "blanks-around-headings")...)
+	}
+	if l.config.IsEnabled("no-bare-urls") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoBareURLs(path, lines, offset), "no-bare-urls")...)
+	}
+	if l.config.IsEnabled("no-empty-links") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
+	}
+	return allErrors
+}
+
+// LintContentSplit is like LintContent but uses the split approach.
+func (l *Linter) LintContentSplit(path string, content string) ([]rule.LintError, int, int) {
+	return l.collectErrorsSplit(path, content)
+}

--- a/internal/rule/no_trailing_spaces.go
+++ b/internal/rule/no_trailing_spaces.go
@@ -1,0 +1,92 @@
+package rule
+
+import "strings"
+
+// stripCR removes a trailing carriage return from a line, if present.
+// This normalises CRLF input so that trailing-space detection works correctly
+// on files with Windows line endings.
+func stripCR(line string) string {
+	if len(line) > 0 && line[len(line)-1] == '\r' {
+		return line[:len(line)-1]
+	}
+	return line
+}
+
+// bodyHasTrailingWhitespace reports whether body contains any line ending with
+// a space or tab. It uses strings.IndexByte to locate each '\n' — IndexByte is
+// backed by AVX2 assembly on amd64 (1-byte SIMD search), which is far faster
+// than strings.Contains for 2-byte patterns on that architecture.
+// Total bytes scanned equals len(body): each call advances past the found '\n'.
+func bodyHasTrailingWhitespace(body string) bool {
+	s := body
+	for len(s) > 0 {
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			break
+		}
+		if i > 0 {
+			prev := s[i-1]
+			if prev == ' ' || prev == '\t' {
+				return true
+			}
+			// CRLF: "text   \r\n" — check byte before the \r
+			if prev == '\r' && i >= 2 && (s[i-2] == ' ' || s[i-2] == '\t') {
+				return true
+			}
+		}
+		s = s[i+1:]
+	}
+	// Handle trailing whitespace at EOF (file without a final newline)
+	n := len(body)
+	return n > 0 && (body[n-1] == ' ' || body[n-1] == '\t')
+}
+
+// CheckNoTrailingSpaces flags lines that end with one or more space or tab
+// characters. Lines inside fenced code blocks are ignored.
+//
+// body is the raw document string (before splitting); it is used for a fast-path
+// check via bodyHasTrailingWhitespace, which uses IndexByte (AVX2 on amd64) to
+// locate newlines efficiently. lines is the same content split on "\n".
+func CheckNoTrailingSpaces(filename, body string, lines []string, offset int) []LintError {
+	if !bodyHasTrailingWhitespace(body) {
+		return nil
+	}
+
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		line = stripCR(line)
+
+		if inBlock {
+			if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		// Only compute TrimSpace for potential fence opener lines (starts with ` or ~).
+		if len(line) >= 3 && (line[0] == '`' || line[0] == '~') {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
+		}
+
+		if len(line) > 0 {
+			last := line[len(line)-1]
+			if last == ' ' || last == '\t' {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "no-trailing-spaces: trailing whitespace found",
+				})
+			}
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/noop_rule.go
+++ b/internal/rule/noop_rule.go
@@ -1,0 +1,9 @@
+package rule
+
+// CheckNoop is a no-op rule that immediately returns nil.
+// Used only for benchmark investigation to test whether adding a 13th
+// call site in collectErrors causes a regression independent of any
+// rule logic.
+func CheckNoop(_ string, _ []string, _ int) []LintError {
+	return nil
+}

--- a/internal/rule/noop_rule.go
+++ b/internal/rule/noop_rule.go
@@ -1,9 +1,19 @@
 package rule
 
-// CheckNoop is a no-op rule that immediately returns nil.
-// Used only for benchmark investigation to test whether adding a 13th
-// call site in collectErrors causes a regression independent of any
-// rule logic.
-func CheckNoop(_ string, _ []string, _ int) []LintError {
-	return nil
-}
+// CheckNoop* are no-op rules that immediately return nil.
+// Used only for benchmark investigation to test compiler effects
+// of varying numbers of if-blocks in collectErrors.
+
+func CheckNoop1(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop2(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop3(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop4(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop5(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop6(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop7(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop8(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop9(_ string, _ []string, _ int) []LintError  { return nil }
+func CheckNoop10(_ string, _ []string, _ int) []LintError { return nil }
+func CheckNoop11(_ string, _ []string, _ int) []LintError { return nil }
+func CheckNoop12(_ string, _ []string, _ int) []LintError { return nil }
+func CheckNoop13(_ string, _ []string, _ int) []LintError { return nil }


### PR DESCRIPTION
## Purpose

Investigating why PR #125 (no-trailing-spaces rule) shows +14-18% benchmark regression on CI (AMD EPYC amd64) but no measurable difference on Apple M4 (arm64).

This PR is for investigation only and will be closed after analysis.

## What we know so far

- All 7 CI runs of PR #125 consistently show +14-18% time/op regression
- On M4 locally with `-count=8`: statistically no difference (p=0.505)
- The regression is the same regardless of fast-path implementation (lines-based, body-based, or no fast-path at all)
- Memory and allocations are unchanged

## Tests included

| Test | Question |
|------|----------|
| 12 vs 13 rules (count=6) | Confirm the regression with statistical significance |
| 12 vs 13 rules XL (count=6) | Does it scale super-linearly? |
| 12+noop vs 13+noop | Does a no-op 13th rule cause the same regression? |
| Per-rule isolation | How expensive is each rule individually on EPYC? |
| CPU profile | Where does time go in full linting? |