### PR TITLE
feat: add no-trailing-spaces rule (MD009)

### DIFF
--- a/e2e/config-no-trailing-spaces.json
+++ b/e2e/config-no-trailing-spaces.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "no-trailing-spaces": true
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -385,6 +385,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_headings_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_bare_urls_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/no_trailing_spaces_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -233,6 +233,24 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "link has empty destination: ![broken image](<>)")
 		assertOutputContains(t, output, "3 issues found")
 	})
+
+	t.Run("NoTrailingSpacesValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/no_trailing_spaces_valid.md", "--config", "config-no-trailing-spaces.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "trailing whitespace found")
+	})
+
+	t.Run("NoTrailingSpacesViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/no_trailing_spaces_violation.md", "--config", "config-no-trailing-spaces.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/no_trailing_spaces_violation.md:")
+		assertOutputContains(t, output, "fixtures/no_trailing_spaces_violation.md:3:")
+		assertOutputContains(t, output, "trailing whitespace found")
+		assertOutputContains(t, output, "fixtures/no_trailing_spaces_violation.md:7:")
+		assertOutputContains(t, output, "2 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -356,7 +374,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "bare URL found")
 		assertOutputContains(t, output, "Errors in fixtures/no_empty_links_violation.md:")
 		assertOutputContains(t, output, "link has empty destination")
-		assertOutputContains(t, output, "Checked 31 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/no_trailing_spaces_violation.md:")
+		assertOutputContains(t, output, "trailing whitespace found")
+		assertOutputContains(t, output, "Checked 33 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")

--- a/e2e/fixtures/no_trailing_spaces_valid.md
+++ b/e2e/fixtures/no_trailing_spaces_valid.md
@@ -1,0 +1,5 @@
+## Clean Document
+
+This file has no trailing whitespace on any line.
+
+All lines are properly trimmed.

--- a/e2e/fixtures/no_trailing_spaces_violation.md
+++ b/e2e/fixtures/no_trailing_spaces_violation.md
@@ -1,0 +1,7 @@
+## Trailing Spaces
+
+This line has trailing spaces   
+
+This line is clean.
+
+This line has a trailing tab	

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const DefaultConfigJSON = `{
     "blanks-around-headings": true,
     "no-bare-urls": true,
     "no-empty-links": true,
+    "no-trailing-spaces": true,
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
@@ -254,6 +255,11 @@ func Default() Config {
 				Options:  map[string]interface{}{},
 			},
 			"no-empty-links": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{},
+			},
+			"no-trailing-spaces": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -209,6 +209,9 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	if l.config.IsEnabled("no-empty-links") {
 		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
 	}
+	if l.config.IsEnabled("no-trailing-spaces") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoTrailingSpaces(path, lines, offset), "no-trailing-spaces")...)
+	}
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {

--- a/internal/rule/no_trailing_spaces.go
+++ b/internal/rule/no_trailing_spaces.go
@@ -1,0 +1,41 @@
+package rule
+
+import "strings"
+
+// CheckNoTrailingSpaces flags lines that end with one or more space or tab
+// characters. Lines inside fenced code blocks are ignored.
+func CheckNoTrailingSpaces(filename string, lines []string, offset int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		// Strip trailing CR to handle CRLF line endings.
+		stripped := strings.TrimRight(line, "\r")
+		if len(stripped) > 0 && (stripped[len(stripped)-1] == ' ' || stripped[len(stripped)-1] == '\t') {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + i + 1,
+				Message: "no-trailing-spaces: trailing whitespace found",
+			})
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/no_trailing_spaces.go
+++ b/internal/rule/no_trailing_spaces.go
@@ -27,7 +27,7 @@ func CheckNoTrailingSpaces(filename string, lines []string, offset int) []LintEr
 		}
 
 		// Strip trailing CR to handle CRLF line endings.
-		stripped := strings.TrimRight(line, "\r")
+		stripped := strings.TrimSuffix(line, "\r")
 		if len(stripped) > 0 && (stripped[len(stripped)-1] == ' ' || stripped[len(stripped)-1] == '\t') {
 			errs = append(errs, LintError{
 				File:    filename,

--- a/internal/rule/no_trailing_spaces_test.go
+++ b/internal/rule/no_trailing_spaces_test.go
@@ -1,0 +1,145 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNoTrailingSpaces(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		wantErrs []LintError
+	}{
+		{
+			name:     "valid: no trailing whitespace",
+			content:  "This is a clean line\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: CRLF line endings without trailing spaces",
+			content:  "Clean line\r\nAnother clean line\r\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: trailing space on CRLF line",
+			content: "This line has trailing spaces   \r\nClean line\r\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: trailing tab on CRLF line",
+			content: "This line has a trailing tab\t\r\nClean line\r\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:     "valid: empty file",
+			content:  "",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: blank line",
+			content:  "\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: single trailing space",
+			content: "This line has a trailing space \n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: multiple trailing spaces",
+			content: "This line has trailing spaces   \n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: trailing tab",
+			content: "This line has a trailing tab\t\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: mixed trailing whitespace",
+			content: "Trailing mix \t\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: multiple lines with violations",
+			content: "Line one \nLine two\nLine three \n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+				{File: "test.md", Line: 3, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:     "valid: trailing space inside fenced code block is ignored",
+			content:  "```\ncode line   \n```\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: trailing space inside tilde fence is ignored",
+			content:  "~~~\ncode line   \n~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: trailing space inside indented fenced code block is ignored",
+			content:  "   ```\ncode line   \n   ```\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: trailing space before fenced block",
+			content: "Text before \n```\ncode\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "invalid: trailing space after fenced block",
+			content: "```\ncode\n```\nText after \n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 4, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+		{
+			name:    "offset shifts line numbers",
+			content: "trailing space \n",
+			offset:  5,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 6, Message: "no-trailing-spaces: trailing whitespace found"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckNoTrailingSpaces("test.md", lines, tt.offset)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i].File != tt.wantErrs[i].File {
+					t.Errorf("[%d] file: got %q, want %q", i, got[i].File, tt.wantErrs[i].File)
+				}
+				if got[i].Line != tt.wantErrs[i].Line {
+					t.Errorf("[%d] line: got %d, want %d", i, got[i].Line, tt.wantErrs[i].Line)
+				}
+				if got[i].Message != tt.wantErrs[i].Message {
+					t.Errorf("[%d] message: got %q, want %q", i, got[i].Message, tt.wantErrs[i].Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Implements the `no-trailing-spaces` rule (MD009 / remark-lint `hard-break-spaces`).

Alternative to #125 with a simplified implementation.

Closes #124. Closes part of #76.

## Key differences from #125

- Standard rule signature `CheckNoTrailingSpaces(filename string, lines []string, offset int)` — no extra `body` parameter
- No separate `bodyHasTrailingWhitespace` fast-path or `stripCR` helper
- Indented fence detection fixed: always calls `strings.TrimSpace` before `openingFenceMarker`, matching the pattern used by all other rules

## Changes

- `internal/rule/no_trailing_spaces.go` — rule implementation
- `internal/rule/no_trailing_spaces_test.go` — 17 unit test cases including indented fence coverage
- `internal/config/config.go` — registered in `DefaultConfigJSON` and `Default()`
- `internal/linter/linter.go` — registered in `collectErrors()`
- `e2e/fixtures/no_trailing_spaces_valid.md` + `no_trailing_spaces_violation.md` — E2E fixtures
- `e2e/config-no-trailing-spaces.json` — E2E config
- `e2e/e2e_test.go` — valid and violation E2E test cases

## Test plan

- [x] Unit tests pass (`go test ./internal/rule/...`)
- [x] All unit tests pass (`go test ./... -skip TestE2E`)
- [x] E2E tests pass (`make test-e2e`)