### PR TITLE
docs: add CLAUDE.md for AI assistant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+## Build & Test
+
+Use `make` targets — do not run raw `go build` / `go test` commands.
+
+| Task | Command |
+|---|---|
+| Build | `make build` |
+| Unit tests | `make test` |
+| E2E tests | `make test-e2e` |
+| All tests | `make test-all` |
+| Benchmarks | `make bench` |
+| Static analysis | `make static-lint` |
+
+## Git
+
+- **Commits**: no `Co-Authored-By` trailer
+- **Updating a feature branch**: `git fetch origin main && git rebase origin/main` — never merge main into a feature branch
+
+## GitHub (issues, PRs, comments, commit messages)
+
+Write in **English**. Japanese is for direct conversation only.
+
+### Rule implementation issues
+
+When creating an issue for a new lint rule:
+
+1. Write the issue body with: Overview, Problem, Proposed rule key, Detection logic (with examples table), Fix, References.
+2. Add a follow-up **comment** titled `## Implementation Plan` containing:
+   - `### Files to create` — new files list
+   - `### Files to modify` — modified files list
+   - `### Checklist` — implementation, tests, config registration, linter integration, e2e, `go test ./...`
+
+See [#106](https://github.com/shinagawa-web/gomarklint/issues/106#issuecomment-4205193874) as the canonical example.
+
+## Project context
+
+- **#76**: master tracking issue for rule expansion (Priority 1 → 2 → 3)
+- **#123**: migration guide from markdownlint/remark-lint/textlint — start after #76 Priority 2 rules land

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -7,16 +7,22 @@ weight: 2
 
 `gomarklint` currently runs the following checks (ordered as executed):
 
-| Rule key                       | What it detects                                         | Notes / Options                                                                                        |
-| ------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `final-blank-line`             | Missing final blank line at EOF                         | Toggle: `--enable-final-blank-line-check` (default **on**)                                             |
-| `unclosed-code-block`          | Unclosed fenced code blocks (`` ``` ``)                 | Always on                                                                                              |
-| `empty-alt-text`               | Image syntax with an empty alt text                     | Always on                                                                                              |
-| `heading-level`                | Invalid heading level progression (e.g., H2 → H4 skip) | Toggle: `--enable-heading-level-check` (default **on**) / `--min-heading` (default **2**)              |
-| `duplicate-heading`            | Duplicate headings within one file                      | Toggle: `--enable-duplicate-heading-check` (default **on**)                                            |
-| `no-multiple-blank-lines`      | Multiple consecutive blank lines                        | Toggle: `--enable-no-multiple-blank-lines-check` (default **on**)                                      |
-| `external-link`                | External links that fail validation                     | Toggle: `--enable-link-check` (default **off**). Skips URLs that match `--skip-link-patterns` (regex). |
-| `no-setext-headings`           | Setext heading used instead of ATX style                | Toggle: `--enable-no-setext-headings-check` (default **on**)                                           |
+| Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `final-blank-line`             | Missing final blank line at EOF                                         | Default **on**                                                                                        |
+| `unclosed-code-block`          | Unclosed fenced code blocks (`` ``` ``)                                 | Default **on**                                                                                        |
+| `empty-alt-text`               | Image syntax with an empty alt text                                     | Default **on**                                                                                        |
+| `heading-level`                | Invalid heading level progression (e.g., H2 → H4 skip)                 | Default **on**. Option: `minLevel` (default `2`)                                                      |
+| `fenced-code-language`         | Fenced code blocks without a language identifier                        | Default **on**                                                                                        |
+| `duplicate-heading`            | Duplicate headings within one file                                      | Default **on**                                                                                        |
+| `no-multiple-blank-lines`      | Multiple consecutive blank lines                                        | Default **on**                                                                                        |
+| `no-setext-headings`           | Setext heading used instead of ATX style                                | Default **on**                                                                                        |
+| `single-h1`                    | More than one H1 heading in a file                                      | Default **on**                                                                                        |
+| `blanks-around-headings`       | Headings not surrounded by blank lines                                  | Default **on**                                                                                        |
+| `no-bare-urls`                 | HTTP/HTTPS URLs written as bare text instead of proper Markdown links   | Default **on**                                                                                        |
+| `no-empty-links`               | Links or images with an empty destination (`[]()`, `[](#)`, `[](<>)`)  | Default **on**                                                                                        |
+| `no-emphasis-as-heading`       | Bold/italic text used as a heading substitute instead of ATX headings   | Default **on**. Punctuation-ending spans (`. , ; : ! ? 。 、 ； ： ！ ？`) are excluded              |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
 
 ## Execution details
 

--- a/e2e/config-no-emphasis-as-heading.json
+++ b/e2e/config-no-emphasis-as-heading.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "no-emphasis-as-heading": true
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -233,6 +233,25 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "link has empty destination: ![broken image](<>)")
 		assertOutputContains(t, output, "3 issues found")
 	})
+
+	t.Run("NoEmphasisAsHeadingValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/no_emphasis_as_heading_valid.md", "--config", "config-no-emphasis-as-heading.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "emphasis used as heading")
+	})
+
+	t.Run("NoEmphasisAsHeadingViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/no_emphasis_as_heading_violation.md", "--config", "config-no-emphasis-as-heading.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/no_emphasis_as_heading_violation.md:")
+		assertOutputContains(t, output, "fixtures/no_emphasis_as_heading_violation.md:3:")
+		assertOutputContains(t, output, "emphasis used as heading, use ATX heading instead: **Section Title**")
+		assertOutputContains(t, output, "fixtures/no_emphasis_as_heading_violation.md:5:")
+		assertOutputContains(t, output, "emphasis used as heading, use ATX heading instead: _Another Heading_")
+		assertOutputContains(t, output, "2 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -356,7 +375,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "bare URL found")
 		assertOutputContains(t, output, "Errors in fixtures/no_empty_links_violation.md:")
 		assertOutputContains(t, output, "link has empty destination")
-		assertOutputContains(t, output, "Checked 31 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/no_emphasis_as_heading_violation.md:")
+		assertOutputContains(t, output, "emphasis used as heading")
+		assertOutputContains(t, output, "Checked 33 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")
@@ -365,6 +386,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_headings_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_bare_urls_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/no_emphasis_as_heading_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/no_emphasis_as_heading_valid.md
+++ b/e2e/fixtures/no_emphasis_as_heading_valid.md
@@ -1,0 +1,7 @@
+## Valid Emphasis Usage
+
+This paragraph uses **bold** inline for emphasis.
+
+Use *italic* text to stress a point, not as a heading.
+
+**Note:** This ends with punctuation so it is not flagged.

--- a/e2e/fixtures/no_emphasis_as_heading_violation.md
+++ b/e2e/fixtures/no_emphasis_as_heading_violation.md
@@ -1,0 +1,7 @@
+## Violations
+
+**Section Title**
+
+_Another Heading_
+
+Some valid text here.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const DefaultConfigJSON = `{
     "blanks-around-headings": true,
     "no-bare-urls": true,
     "no-empty-links": true,
+    "no-emphasis-as-heading": true,
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
@@ -254,6 +255,11 @@ func Default() Config {
 				Options:  map[string]interface{}{},
 			},
 			"no-empty-links": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{},
+			},
+			"no-emphasis-as-heading": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -209,6 +209,9 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	if l.config.IsEnabled("no-empty-links") {
 		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
 	}
+	if l.config.IsEnabled("no-emphasis-as-heading") {
+		allErrors = append(allErrors, l.withSeverity(rule.CheckNoEmphasisAsHeading(path, lines, offset), "no-emphasis-as-heading")...)
+	}
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -478,6 +478,25 @@ func TestRun_NoEmptyLinks(t *testing.T) {
 	}
 }
 
+func TestRun_NoEmphasisAsHeading(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-emphasis-as-heading"] = on()
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "emphasis-heading.md")
+	if err := os.WriteFile(testFile, []byte("**Section Title**\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors == 0 {
+		t.Error("expected error for emphasis used as heading")
+	}
+}
+
 func TestRun_WarningSeverity(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-setext-headings"] = &config.RuleConfig{

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -112,24 +112,21 @@ func CheckNoEmphasisAsHeading(filename string, lines []string, offset int) []Lin
 			continue
 		}
 
-		// Strip inline code before checking so that e.g. `**bold**` is ignored.
-		scanned := trimmed
-		if strings.ContainsRune(trimmed, '`') {
-			scanned = strings.TrimSpace(stripInlineCode(trimmed))
-		}
-
-		inner, ok := emphasisContent(scanned)
+		inner, ok := emphasisContent(trimmed)
 		if !ok {
 			continue
 		}
-		if endsWithPunctuation(inner) {
+		// Trim nested emphasis delimiters from inner before the punctuation
+		// check so that e.g. "***Note:***" (inner="*Note:*") is correctly
+		// recognized as ending with ':' rather than '*'.
+		if endsWithPunctuation(strings.TrimRight(inner, "*_")) {
 			continue
 		}
 
 		errs = append(errs, LintError{
 			File:    filename,
 			Line:    offset + i + 1,
-			Message: fmt.Sprintf("no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: %s", scanned),
+			Message: fmt.Sprintf("no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: %s", trimmed),
 		})
 	}
 

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -59,10 +59,8 @@ var punctuationChars = map[rune]struct{}{
 
 // endsWithPunctuation reports whether s ends with sentence-ending punctuation.
 // When true, the emphasis is likely inline prose, not a heading.
+// s is always non-empty when called from CheckNoEmphasisAsHeading.
 func endsWithPunctuation(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
 	runes := []rune(s)
 	_, ok := punctuationChars[runes[len(runes)-1]]
 	return ok

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -5,45 +5,62 @@ import (
 	"strings"
 )
 
+// matchDoubleDelim returns the inner text if line is entirely wrapped in a
+// two-character delimiter (e.g. "**" or "__"). The inner text must not contain
+// the delimiter itself.
+func matchDoubleDelim(line, delim string) (string, bool) {
+	if len(line) <= len(delim)*2 {
+		return "", false
+	}
+	if !strings.HasPrefix(line, delim) || !strings.HasSuffix(line, delim) {
+		return "", false
+	}
+	inner := line[len(delim) : len(line)-len(delim)]
+	if strings.Contains(inner, delim) {
+		return "", false
+	}
+	return inner, true
+}
+
+// matchSingleDelim returns the inner text if line is entirely wrapped in a
+// single-character delimiter (e.g. '*' or '_') that is not doubled. The inner
+// text must not contain the delimiter character.
+func matchSingleDelim(line string, ch byte) (string, bool) {
+	double := string([]byte{ch, ch})
+	if len(line) <= 2 || line[0] != ch || line[len(line)-1] != ch {
+		return "", false
+	}
+	if strings.HasPrefix(line, double) {
+		return "", false
+	}
+	inner := line[1 : len(line)-1]
+	if strings.ContainsRune(inner, rune(ch)) {
+		return "", false
+	}
+	return inner, true
+}
+
 // emphasisContent extracts the inner text if line is entirely a single bold or
 // italic span. Returns ("", false) when the line is not a bare emphasis span.
 //
-// Recognised forms (CommonMark):
+// Recognized forms (CommonMark):
 //
 //	**text**   __text__   (strong)
 //	*text*     _text_     (emphasis)
 //
 // The span must cover the entire trimmed line — no surrounding text allowed.
 func emphasisContent(line string) (string, bool) {
-	// Strong: **...**
-	if strings.HasPrefix(line, "**") && strings.HasSuffix(line, "**") && len(line) > 4 {
-		inner := line[2 : len(line)-2]
-		if !strings.Contains(inner, "**") {
-			return inner, true
-		}
+	if inner, ok := matchDoubleDelim(line, "**"); ok {
+		return inner, true
 	}
-	// Strong: __...__
-	if strings.HasPrefix(line, "__") && strings.HasSuffix(line, "__") && len(line) > 4 {
-		inner := line[2 : len(line)-2]
-		if !strings.Contains(inner, "__") {
-			return inner, true
-		}
+	if inner, ok := matchDoubleDelim(line, "__"); ok {
+		return inner, true
 	}
-	// Emphasis: *...*  (not **)
-	if len(line) > 2 && line[0] == '*' && line[len(line)-1] == '*' &&
-		!strings.HasPrefix(line, "**") {
-		inner := line[1 : len(line)-1]
-		if !strings.Contains(inner, "*") {
-			return inner, true
-		}
+	if inner, ok := matchSingleDelim(line, '*'); ok {
+		return inner, true
 	}
-	// Emphasis: _..._  (not __)
-	if len(line) > 2 && line[0] == '_' && line[len(line)-1] == '_' &&
-		!strings.HasPrefix(line, "__") {
-		inner := line[1 : len(line)-1]
-		if !strings.Contains(inner, "_") {
-			return inner, true
-		}
+	if inner, ok := matchSingleDelim(line, '_'); ok {
+		return inner, true
 	}
 	return "", false
 }

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -1,0 +1,122 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// emphasisContent extracts the inner text if line is entirely a single bold or
+// italic span. Returns ("", false) when the line is not a bare emphasis span.
+//
+// Recognised forms (CommonMark):
+//
+//	**text**   __text__   (strong)
+//	*text*     _text_     (emphasis)
+//
+// The span must cover the entire trimmed line — no surrounding text allowed.
+func emphasisContent(line string) (string, bool) {
+	// Strong: **...**
+	if strings.HasPrefix(line, "**") && strings.HasSuffix(line, "**") && len(line) > 4 {
+		inner := line[2 : len(line)-2]
+		if !strings.Contains(inner, "**") {
+			return inner, true
+		}
+	}
+	// Strong: __...__
+	if strings.HasPrefix(line, "__") && strings.HasSuffix(line, "__") && len(line) > 4 {
+		inner := line[2 : len(line)-2]
+		if !strings.Contains(inner, "__") {
+			return inner, true
+		}
+	}
+	// Emphasis: *...*  (not **)
+	if len(line) > 2 && line[0] == '*' && line[len(line)-1] == '*' &&
+		!strings.HasPrefix(line, "**") {
+		inner := line[1 : len(line)-1]
+		if !strings.Contains(inner, "*") {
+			return inner, true
+		}
+	}
+	// Emphasis: _..._  (not __)
+	if len(line) > 2 && line[0] == '_' && line[len(line)-1] == '_' &&
+		!strings.HasPrefix(line, "__") {
+		inner := line[1 : len(line)-1]
+		if !strings.Contains(inner, "_") {
+			return inner, true
+		}
+	}
+	return "", false
+}
+
+// punctuationChars is the set of sentence-ending punctuation characters that
+// indicate the emphasis is prose rather than a heading substitute.
+// Includes ASCII and full-width equivalents used in CJK writing systems.
+// Mirrors the default punctuation list used by markdownlint MD036.
+var punctuationChars = map[rune]struct{}{
+	'.': {}, ',': {}, ';': {}, ':': {}, '!': {}, '?': {}, // ASCII
+	'。': {}, '、': {}, '；': {}, '：': {}, '！': {}, '？': {}, // Full-width / CJK
+}
+
+// endsWithPunctuation reports whether s ends with sentence-ending punctuation.
+// When true, the emphasis is likely inline prose, not a heading.
+func endsWithPunctuation(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	runes := []rune(s)
+	_, ok := punctuationChars[runes[len(runes)-1]]
+	return ok
+}
+
+// CheckNoEmphasisAsHeading flags lines where bold or italic text is used as a
+// substitute for an ATX heading (MD036). A violation is reported when:
+//  1. The trimmed line consists entirely of a single bold/italic span.
+//  2. The inner text does not end with sentence-ending punctuation.
+//
+// Lines inside fenced code blocks and inline code spans are ignored.
+func CheckNoEmphasisAsHeading(filename string, lines []string, offset int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		marker := openingFenceMarker(trimmed)
+		if marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		// Strip inline code before checking so that e.g. `**bold**` is ignored.
+		scanned := trimmed
+		if strings.ContainsRune(trimmed, '`') {
+			scanned = strings.TrimSpace(stripInlineCode(trimmed))
+		}
+
+		inner, ok := emphasisContent(scanned)
+		if !ok {
+			continue
+		}
+		if endsWithPunctuation(inner) {
+			continue
+		}
+
+		errs = append(errs, LintError{
+			File:    filename,
+			Line:    offset + i + 1,
+			Message: fmt.Sprintf("no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: %s", scanned),
+		})
+	}
+
+	return errs
+}

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -163,9 +163,9 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 			},
 		},
 		{
-			name:   "invalid: offset shifts line numbers",
+			name:    "invalid: offset shifts line numbers",
 			content: "**Heading**\n",
-			offset: 10,
+			offset:  10,
 			wantErrs: []LintError{
 				{File: "test.md", Line: 11, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Heading**"},
 			},
@@ -181,6 +181,27 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 		{
 			name:     "valid: empty file",
 			content:  "",
+			wantErrs: nil,
+		},
+		// ── delimiter inside span (not a heading) ────────────────────────────
+		{
+			name:     "valid: double-asterisk with nested delimiter",
+			content:  "**bold**text**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: double-underscore with nested delimiter",
+			content:  "__under__score__\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: single-asterisk with nested delimiter",
+			content:  "*ital*ic*\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: single-underscore with nested delimiter",
+			content:  "_under_score_\n",
 			wantErrs: nil,
 		},
 	}

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -1,0 +1,209 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNoEmphasisAsHeading(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		wantErrs []LintError
+	}{
+		// ── valid cases ──────────────────────────────────────────────────────
+		{
+			name:     "valid: ATX heading",
+			content:  "## Section\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: plain text",
+			content:  "This is some text.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with period",
+			content:  "**This is a sentence.**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: italic ending with comma",
+			content:  "*Some clause,*\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with question mark",
+			content:  "**Are you sure?**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with exclamation",
+			content:  "**Watch out!**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: emphasis inside fenced code block",
+			content:  "```\n**Heading**\n```\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: emphasis inside tilde fence",
+			content:  "~~~\n**Heading**\n~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: emphasis inside inline code",
+			content:  "Use `**bold**` for styling.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold with surrounding text",
+			content:  "This is **important** text.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: empty line",
+			content:  "\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with colon",
+			content:  "**Note:**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with semicolon",
+			content:  "**Warning;**\n",
+			wantErrs: nil,
+		},
+		// ── full-width / CJK punctuation ─────────────────────────────────────
+		{
+			name:     "valid: bold ending with ideographic full stop",
+			content:  "**これは文章です。**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with Japanese comma",
+			content:  "**ここで区切り、**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with full-width exclamation",
+			content:  "**注意！**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with full-width question mark",
+			content:  "**本当？**\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: bold ending with full-width colon",
+			content:  "**補足：**\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: Japanese heading without punctuation",
+			content: "**はじめに**\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **はじめに**"},
+			},
+		},
+		{
+			name:    "invalid: italic Japanese heading",
+			content: "*概要*\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: *概要*"},
+			},
+		},
+
+		// ── invalid cases ────────────────────────────────────────────────────
+		{
+			name:    "invalid: double-asterisk bold",
+			content: "**Section Title**\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Section Title**"},
+			},
+		},
+		{
+			name:    "invalid: double-underscore bold",
+			content: "__Section Title__\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: __Section Title__"},
+			},
+		},
+		{
+			name:    "invalid: single-asterisk italic",
+			content: "*Section Title*\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: *Section Title*"},
+			},
+		},
+		{
+			name:    "invalid: single-underscore italic",
+			content: "_Section Title_\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: _Section Title_"},
+			},
+		},
+		{
+			name:    "invalid: bold with leading whitespace",
+			content: "  **Indented Bold**\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Indented Bold**"},
+			},
+		},
+		{
+			name:    "invalid: second line",
+			content: "# Title\n\n**Subsection**\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Subsection**"},
+			},
+		},
+		{
+			name:   "invalid: offset shifts line numbers",
+			content: "**Heading**\n",
+			offset: 10,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 11, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Heading**"},
+			},
+		},
+		{
+			name:    "invalid: multiple violations",
+			content: "**First**\n\n__Second__\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **First**"},
+				{File: "test.md", Line: 3, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: __Second__"},
+			},
+		},
+		{
+			name:     "valid: empty file",
+			content:  "",
+			wantErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckNoEmphasisAsHeading("test.md", lines, tt.offset)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i].File != tt.wantErrs[i].File {
+					t.Errorf("[%d] file: got %q, want %q", i, got[i].File, tt.wantErrs[i].File)
+				}
+				if got[i].Line != tt.wantErrs[i].Line {
+					t.Errorf("[%d] line: got %d, want %d", i, got[i].Line, tt.wantErrs[i].Line)
+				}
+				if got[i].Message != tt.wantErrs[i].Message {
+					t.Errorf("[%d] message: got %q, want %q", i, got[i].Message, tt.wantErrs[i].Message)
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -183,6 +183,35 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 			content:  "",
 			wantErrs: nil,
 		},
+		// ── inline code on same line ─────────────────────────────────────────
+		{
+			name:     "valid: emphasis plus inline code on same line",
+			content:  "**Heading** `code`\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: entire line is inline code span",
+			content:  "`**bold**`\n",
+			wantErrs: nil,
+		},
+		// ── nested emphasis with trailing punctuation ─────────────────────────
+		{
+			name:     "valid: triple-asterisk bold-italic ending with colon",
+			content:  "***Note:***\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: triple-asterisk bold-italic ending with period",
+			content:  "***This is a sentence.***\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: triple-asterisk bold-italic without punctuation",
+			content: "***Section Title***\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: ***Section Title***"},
+			},
+		},
 		// ── delimiter inside span (not a heading) ────────────────────────────
 		{
 			name:     "valid: double-asterisk with nested delimiter",


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` to document conventions for AI-assisted development in this repo

## What's included

- Build & test commands (use `make`, not raw `go` commands)
- Git conventions (no Co-Authored-By, rebase over merge)
- GitHub content language policy (English)
- Rule implementation issue format (body + Implementation Plan comment, per #106)
- Project context pointers (#76, #123)