### PR TITLE
docs: add CLAUDE.md for AI assistant guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ When creating an issue for a new lint rule:
 2. Add a follow-up **comment** titled `## Implementation Plan` containing:
    - `### Files to create` — new files list
    - `### Files to modify` — modified files list
-   - `### Checklist` — implementation, tests, config registration, linter integration, e2e, `go test ./...`
+   - `### Checklist` — implementation, tests, config registration, linter integration, e2e, `make test-all`
 
 See [#106](https://github.com/shinagawa-web/gomarklint/issues/106#issuecomment-4205193874) as the canonical example.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Use `make` targets — do not run raw `go build` / `go test` commands.
 
 - **Commits**: no `Co-Authored-By` trailer
 - **Updating a feature branch**: `git fetch origin main && git rebase origin/main` — never merge main into a feature branch
+- **Pre-push hook**: run `make install-hooks` once after cloning to automatically run lint and unit tests before each push
 
 ## GitHub (issues, PRs, comments, commit messages)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+## Build & Test
+
+Use `make` targets — do not run raw `go build` / `go test` commands.
+
+| Task | Command |
+|---|---|
+| Build | `make build` |
+| Unit tests | `make test` |
+| E2E tests | `make test-e2e` |
+| All tests | `make test-all` |
+| Benchmarks | `make bench` |
+| Static analysis | `make static-lint` |
+
+## Git
+
+- **Commits**: no `Co-Authored-By` trailer
+- **Updating a feature branch**: `git fetch origin main && git rebase origin/main` — never merge main into a feature branch
+
+## GitHub (issues, PRs, comments, commit messages)
+
+Write in **English**. Japanese is for direct conversation only.
+
+### Rule implementation issues
+
+When creating an issue for a new lint rule:
+
+1. Write the issue body with: Overview, Problem, Proposed rule key, Detection logic (with examples table), Fix, References.
+2. Add a follow-up **comment** titled `## Implementation Plan` containing:
+   - `### Files to create` — new files list
+   - `### Files to modify` — modified files list
+   - `### Checklist` — implementation, tests, config registration, linter integration, e2e, `go test ./...`
+
+See [#106](https://github.com/shinagawa-web/gomarklint/issues/106#issuecomment-4205193874) as the canonical example.
+
+## Project context
+
+- **#76**: master tracking issue for rule expansion (Priority 1 → 2 → 3)
+- **#123**: migration guide from markdownlint/remark-lint/textlint — start after #76 Priority 2 rules land


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` to document conventions for AI-assisted development in this repo

## What's included

- Build & test commands (use `make`, not raw `go` commands)
- Git conventions (no Co-Authored-By, rebase over merge)
- GitHub content language policy (English)
- Rule implementation issue format (body + Implementation Plan comment, per #106)
- Project context pointers (#76, #123)