### PR TITLE
feature: add .pre-commit-hooks.yaml and improve README discoverability

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: gomarklint
+  name: gomarklint
+  description: Lint Markdown files with gomarklint
+  language: golang
+  entry: gomarklint
+  types: [markdown]

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,9 +63,20 @@ go install github.com/shinagawa-web/gomarklint@latest
 ### GitHub Actions
 
 ```yaml
-- uses: shinagawa-web/gomarklint-action@v1
-  with:
-    args: '.'
+name: gomarklint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shinagawa-web/gomarklint-action@v1
+        with:
+          args: '.'
 ```
 
 オプションの詳細: [gomarklint-action](https://github.com/shinagawa-web/gomarklint-action)

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 [English](README.md) | 日本語
 
-> 高速・実用的な Markdown リンター。Go 製、CI 向け設計。
+> Go 製の高速 Markdown リンター。シングルバイナリで Node.js 不要 — HTTP リンクバリデーション機能を内蔵。
 
 **かんたんインストール**（macOS / Linux）:
 
@@ -57,6 +57,30 @@ go install github.com/shinagawa-web/gomarklint@latest
 - 予測可能な構造を強制（「なぜ H2 の下に H4 があるの？」をなくす）。
 - 人間にも機械にも優しい出力（JSON 対応）。
 - **100,000 行以上を約 170ms** で処理 — ローカル開発にもCI にも十分な速さ。
+
+## CI 連携
+
+### GitHub Actions
+
+```yaml
+- uses: shinagawa-web/gomarklint-action@v1
+  with:
+    args: '.'
+```
+
+オプションの詳細: [gomarklint-action](https://github.com/shinagawa-web/gomarklint-action)
+
+### pre-commit
+
+`.pre-commit-config.yaml` に追加:
+
+```yaml
+repos:
+  - repo: https://github.com/shinagawa-web/gomarklint
+    rev: v2.8.0
+    hooks:
+      - id: gomarklint
+```
 
 ## ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,20 @@ go install github.com/shinagawa-web/gomarklint@latest
 ### GitHub Actions
 
 ```yaml
-- uses: shinagawa-web/gomarklint-action@v1
-  with:
-    args: '.'
+name: gomarklint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shinagawa-web/gomarklint-action@v1
+        with:
+          args: '.'
 ```
 
 Full options and examples: [gomarklint-action](https://github.com/shinagawa-web/gomarklint-action)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 English | [日本語](README.ja.md)
 
-> A fast, opinionated Markdown linter. Built in Go, designed for CI.
+> A fast Markdown linter built in Go. Single binary, no Node.js required — with built-in HTTP link validation.
 
 **Quick install** (macOS / Linux):
 
@@ -57,6 +57,30 @@ go install github.com/shinagawa-web/gomarklint@latest
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
 - Process **100,000+ lines in ~170ms** — fast enough for local dev, robust enough for CI.
+
+## CI Integration
+
+### GitHub Actions
+
+```yaml
+- uses: shinagawa-web/gomarklint-action@v1
+  with:
+    args: '.'
+```
+
+Full options and examples: [gomarklint-action](https://github.com/shinagawa-web/gomarklint-action)
+
+### pre-commit
+
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/shinagawa-web/gomarklint
+    rev: v2.8.0
+    hooks:
+      - id: gomarklint
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Add `.pre-commit-hooks.yaml` to enable pre-commit framework integration
- Add **CI Integration** section to README with GitHub Actions and pre-commit usage examples
- Improve the one-liner tagline to highlight key differentiators: single binary, no Node.js, built-in link validation
- Apply the same changes to `README.ja.md`

## Test plan

- [ ] Verify `.pre-commit-hooks.yaml` is valid by running `pre-commit try-repo . gomarklint` locally
- [ ] Review README rendering on GitHub for formatting

Closes #137