### PR TITLE
feat: allow disabling rules via inline comments

### DIFF
--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -9,9 +9,7 @@ import (
 	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
 )
 
-// generateComplexMarkdown generates a realistic markdown file with mixed content,
-// including gomarklint-disable directives scattered throughout so the disable-comment
-// parse and filter path is exercised on branches that support it.
+// generateComplexMarkdown generates a realistic markdown file with mixed content.
 func generateComplexMarkdown(sections int) string {
 	var sb strings.Builder
 
@@ -52,24 +50,6 @@ func generateComplexMarkdown(sections int) string {
 		// Image
 		if i%4 == 0 {
 			fmt.Fprintf(&sb, "![Diagram %d](diagram%d.png)\n\n", i, i)
-		}
-
-		// Every 5th section: block disable/enable
-		if i%5 == 0 {
-			sb.WriteString("<!-- gomarklint-disable no-bare-urls -->\n")
-			fmt.Fprintf(&sb, "https://suppressed-%d.example.com\n", i)
-			sb.WriteString("<!-- gomarklint-enable no-bare-urls -->\n\n")
-		}
-
-		// Every 7th section: disable-line
-		if i%7 == 0 {
-			fmt.Fprintf(&sb, "https://inline-%d.example.com <!-- gomarklint-disable-line no-bare-urls -->\n\n", i)
-		}
-
-		// Every 11th section: disable-next-line
-		if i%11 == 0 {
-			sb.WriteString("<!-- gomarklint-disable-next-line no-bare-urls -->\n")
-			fmt.Fprintf(&sb, "https://nextline-%d.example.com\n\n", i)
 		}
 
 		// Subsection

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
 )
 
-// generateComplexMarkdown generates a realistic markdown file with mixed content.
+// generateComplexMarkdown generates a realistic markdown file with mixed content,
+// including gomarklint-disable directives scattered throughout so the disable-comment
+// parse and filter path is exercised on branches that support it.
 func generateComplexMarkdown(sections int) string {
 	var sb strings.Builder
 
@@ -52,49 +54,25 @@ func generateComplexMarkdown(sections int) string {
 			fmt.Fprintf(&sb, "![Diagram %d](diagram%d.png)\n\n", i, i)
 		}
 
-		// Subsection
-		fmt.Fprintf(&sb, "### Subsection %d.1\n\n", i)
-		sb.WriteString("More detailed information goes here.\n\n")
-	}
-
-	return sb.String()
-}
-
-// generateComplexMarkdownWithDisableComments generates markdown with gomarklint-disable
-// directives scattered throughout, exercising the parse and filter path.
-func generateComplexMarkdownWithDisableComments(sections int) string {
-	var sb strings.Builder
-
-	sb.WriteString("# Main Title\n\n")
-	sb.WriteString("This is the introduction to the document.\n\n")
-
-	for i := 1; i <= sections; i++ {
-		fmt.Fprintf(&sb, "## Section %d\n\n", i)
-		sb.WriteString("This section contains important information.\n\n")
-
-		sb.WriteString("Key points:\n\n")
-		sb.WriteString("- First important point\n")
-		sb.WriteString("- Second critical detail\n")
-		sb.WriteString("- Third consideration\n\n")
-
-		// Every 5th section: block disable/enable suppressing a bare URL
+		// Every 5th section: block disable/enable
 		if i%5 == 0 {
 			sb.WriteString("<!-- gomarklint-disable no-bare-urls -->\n")
 			fmt.Fprintf(&sb, "https://suppressed-%d.example.com\n", i)
 			sb.WriteString("<!-- gomarklint-enable no-bare-urls -->\n\n")
 		}
 
-		// Every 7th section: disable-line suppressing a bare URL
+		// Every 7th section: disable-line
 		if i%7 == 0 {
 			fmt.Fprintf(&sb, "https://inline-%d.example.com <!-- gomarklint-disable-line no-bare-urls -->\n\n", i)
 		}
 
-		// Every 11th section: disable-next-line suppressing a bare URL
+		// Every 11th section: disable-next-line
 		if i%11 == 0 {
 			sb.WriteString("<!-- gomarklint-disable-next-line no-bare-urls -->\n")
 			fmt.Fprintf(&sb, "https://nextline-%d.example.com\n\n", i)
 		}
 
+		// Subsection
 		fmt.Fprintf(&sb, "### Subsection %d.1\n\n", i)
 		sb.WriteString("More detailed information goes here.\n\n")
 	}
@@ -119,34 +97,6 @@ func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
 	content := generateComplexMarkdown(5000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
-
-	lint := linter.New(cfg)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-func BenchmarkFullLinting_WithDisableComments(b *testing.B) {
-	content := generateComplexMarkdownWithDisableComments(1000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["no-bare-urls"].Enabled = true
-
-	lint := linter.New(cfg)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
-	}
-}
-
-func BenchmarkFullLinting_WithDisableComments_ExtraLarge(b *testing.B) {
-	content := generateComplexMarkdownWithDisableComments(5000)
-	cfg := config.Default()
-	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["no-bare-urls"].Enabled = true
 
 	lint := linter.New(cfg)
 

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -60,6 +60,48 @@ func generateComplexMarkdown(sections int) string {
 	return sb.String()
 }
 
+// generateComplexMarkdownWithDisableComments generates markdown with gomarklint-disable
+// directives scattered throughout, exercising the parse and filter path.
+func generateComplexMarkdownWithDisableComments(sections int) string {
+	var sb strings.Builder
+
+	sb.WriteString("# Main Title\n\n")
+	sb.WriteString("This is the introduction to the document.\n\n")
+
+	for i := 1; i <= sections; i++ {
+		fmt.Fprintf(&sb, "## Section %d\n\n", i)
+		sb.WriteString("This section contains important information.\n\n")
+
+		sb.WriteString("Key points:\n\n")
+		sb.WriteString("- First important point\n")
+		sb.WriteString("- Second critical detail\n")
+		sb.WriteString("- Third consideration\n\n")
+
+		// Every 5th section: block disable/enable suppressing a bare URL
+		if i%5 == 0 {
+			sb.WriteString("<!-- gomarklint-disable no-bare-urls -->\n")
+			fmt.Fprintf(&sb, "https://suppressed-%d.example.com\n", i)
+			sb.WriteString("<!-- gomarklint-enable no-bare-urls -->\n\n")
+		}
+
+		// Every 7th section: disable-line suppressing a bare URL
+		if i%7 == 0 {
+			fmt.Fprintf(&sb, "https://inline-%d.example.com <!-- gomarklint-disable-line no-bare-urls -->\n\n", i)
+		}
+
+		// Every 11th section: disable-next-line suppressing a bare URL
+		if i%11 == 0 {
+			sb.WriteString("<!-- gomarklint-disable-next-line no-bare-urls -->\n")
+			fmt.Fprintf(&sb, "https://nextline-%d.example.com\n\n", i)
+		}
+
+		fmt.Fprintf(&sb, "### Subsection %d.1\n\n", i)
+		sb.WriteString("More detailed information goes here.\n\n")
+	}
+
+	return sb.String()
+}
+
 func BenchmarkFullLinting(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := config.Default()
@@ -77,6 +119,34 @@ func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
 	content := generateComplexMarkdown(5000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
+
+	lint := linter.New(cfg)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+func BenchmarkFullLinting_WithDisableComments(b *testing.B) {
+	content := generateComplexMarkdownWithDisableComments(1000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["no-bare-urls"].Enabled = true
+
+	lint := linter.New(cfg)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
+func BenchmarkFullLinting_WithDisableComments_ExtraLarge(b *testing.B) {
+	content := generateComplexMarkdownWithDisableComments(5000)
+	cfg := config.Default()
+	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["no-bare-urls"].Enabled = true
 
 	lint := linter.New(cfg)
 

--- a/docs/content/docs/cli.md
+++ b/docs/content/docs/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "CLI"
-weight: 3
+weight: 4
 ---
 
 # CLI

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-weight: 4
+weight: 5
 ---
 
 # Configuration

--- a/docs/content/docs/disable-comments.md
+++ b/docs/content/docs/disable-comments.md
@@ -1,0 +1,79 @@
+---
+title: "Disable Comments"
+weight: 3
+---
+
+# Disable Comments
+
+You can suppress lint violations for specific lines or blocks by adding HTML comment directives directly in your Markdown file.
+
+## Directives
+
+### Block disable / enable
+
+Disable all rules from the directive line onward until re-enabled:
+
+```markdown
+<!-- gomarklint-disable -->
+https://example.com
+<!-- gomarklint-enable -->
+```
+
+Disable specific rules only:
+
+```markdown
+<!-- gomarklint-disable no-bare-urls -->
+https://example.com
+<!-- gomarklint-enable no-bare-urls -->
+```
+
+Re-enable a specific rule inside a block that disabled everything:
+
+```markdown
+<!-- gomarklint-disable -->
+https://example.com
+<!-- gomarklint-enable no-bare-urls -->
+https://example.com   ← no-bare-urls is checked again here
+<!-- gomarklint-enable -->
+```
+
+### Single-line disable
+
+Suppress violations on the same line the directive appears:
+
+```markdown
+https://example.com <!-- gomarklint-disable-line -->
+
+https://example.com <!-- gomarklint-disable-line no-bare-urls -->
+```
+
+### Next-line disable
+
+Suppress violations on the line immediately following the directive:
+
+```markdown
+<!-- gomarklint-disable-next-line -->
+https://example.com
+
+<!-- gomarklint-disable-next-line no-bare-urls -->
+https://example.com
+```
+
+## Directive reference
+
+| Directive | Scope | Effect |
+|---|---|---|
+| `<!-- gomarklint-disable -->` | block start | Disable all rules |
+| `<!-- gomarklint-disable rule [rule…] -->` | block start | Disable named rules |
+| `<!-- gomarklint-enable -->` | block end | Re-enable all rules |
+| `<!-- gomarklint-enable rule [rule…] -->` | block end | Re-enable named rules |
+| `<!-- gomarklint-disable-line -->` | current line | Disable all rules |
+| `<!-- gomarklint-disable-line rule [rule…] -->` | current line | Disable named rules |
+| `<!-- gomarklint-disable-next-line -->` | next line | Disable all rules |
+| `<!-- gomarklint-disable-next-line rule [rule…] -->` | next line | Disable named rules |
+
+## Notes
+
+- A directive that disables all rules takes priority over one that disables only named rules when both apply to the same line.
+- Files without any `gomarklint-disable` comment are parsed with zero overhead — the directive scanner is skipped entirely.
+- Rule names match the keys listed in [Rules](../rules).

--- a/docs/content/docs/github-actions.md
+++ b/docs/content/docs/github-actions.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub Actions"
-weight: 7
+weight: 8
 ---
 
 # GitHub Actions Integration

--- a/docs/content/docs/migration-v2.md
+++ b/docs/content/docs/migration-v2.md
@@ -1,6 +1,6 @@
 ---
 title: "Migrating to v2"
-weight: 9
+weight: 10
 ---
 
 # Migrating to v2

--- a/docs/content/docs/output.md
+++ b/docs/content/docs/output.md
@@ -1,6 +1,6 @@
 ---
 title: "Output"
-weight: 5
+weight: 6
 ---
 
 # Output

--- a/docs/content/docs/performance.md
+++ b/docs/content/docs/performance.md
@@ -1,6 +1,6 @@
 ---
 title: "Performance"
-weight: 6
+weight: 7
 ---
 
 # Performance

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: "Roadmap"
-weight: 8
+weight: 9
 ---
 
 # Roadmap (Post v1.0.0)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -642,32 +642,59 @@ func TestE2E_Severity(t *testing.T) {
 }
 
 func TestE2E_DisableComments(t *testing.T) {
-	t.Run("BlockDisableSuppressesViolation", func(t *testing.T) {
-		output, err := runTestWithCmd(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
-		if err == nil {
-			t.Error("expected exit 1 (unreachable violations remain)")
-		}
-		// line 4 suppressed by block disable
+	// fixture line map:
+	//  4  suppressed: <!-- gomarklint-disable -->
+	//  6  reported:   after <!-- gomarklint-enable -->
+	//  9  suppressed: <!-- gomarklint-disable no-bare-urls -->
+	// 11  reported:   after <!-- gomarklint-enable no-bare-urls -->
+	// 13  suppressed: <!-- gomarklint-disable-line -->
+	// 15  suppressed: <!-- gomarklint-disable-line no-bare-urls -->
+	// 18  suppressed: <!-- gomarklint-disable-next-line -->
+	// 21  suppressed: <!-- gomarklint-disable-next-line no-bare-urls -->
+
+	t.Run("BlockDisableAll", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
 		assertOutputNotContains(t, output, "fixtures/disable_comment.md:4:")
 	})
 
-	t.Run("DisableLineSuppressesViolation", func(t *testing.T) {
-		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
-		// line 7 suppressed by disable-line
-		assertOutputNotContains(t, output, "fixtures/disable_comment.md:7:")
-	})
-
-	t.Run("DisableNextLineSuppressesViolation", func(t *testing.T) {
-		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
-		// line 10 suppressed by disable-next-line
-		assertOutputNotContains(t, output, "fixtures/disable_comment.md:10:")
-	})
-
-	t.Run("ViolationOutsideDirectiveIsReported", func(t *testing.T) {
+	t.Run("EnableAll", func(t *testing.T) {
 		output, err := runTestWithCmd(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
 		if err == nil {
-			t.Error("expected exit 1: line 12 has no directive and should be reported")
+			t.Error("expected exit 1: violations after enable should be reported")
 		}
-		assertOutputContains(t, output, "fixtures/disable_comment.md:12:")
+		assertOutputContains(t, output, "fixtures/disable_comment.md:6:")
+	})
+
+	t.Run("BlockDisableNamedRule", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:9:")
+	})
+
+	t.Run("EnableNamedRule", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		if err == nil {
+			t.Error("expected exit 1: violations after enable should be reported")
+		}
+		assertOutputContains(t, output, "fixtures/disable_comment.md:11:")
+	})
+
+	t.Run("DisableLineAll", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:13:")
+	})
+
+	t.Run("DisableLineNamedRule", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:15:")
+	})
+
+	t.Run("DisableNextLineAll", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:18:")
+	})
+
+	t.Run("DisableNextLineNamedRule", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:21:")
 	})
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -407,7 +407,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "emphasis used as heading")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_lists_violation.md:")
 		assertOutputContains(t, output, "list must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 35 file(s)")
+		assertOutputContains(t, output, "Checked 36 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")
@@ -638,5 +638,36 @@ func TestE2E_Severity(t *testing.T) {
 		}
 		assertOutputContains(t, output, "No issues found")
 		assertOutputNotContains(t, output, "Setext heading found")
+	})
+}
+
+func TestE2E_DisableComments(t *testing.T) {
+	t.Run("BlockDisableSuppressesViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		if err == nil {
+			t.Error("expected exit 1 (unreachable violations remain)")
+		}
+		// line 4 suppressed by block disable
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:4:")
+	})
+
+	t.Run("DisableLineSuppressesViolation", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		// line 7 suppressed by disable-line
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:7:")
+	})
+
+	t.Run("DisableNextLineSuppressesViolation", func(t *testing.T) {
+		output := runTest(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		// line 10 suppressed by disable-next-line
+		assertOutputNotContains(t, output, "fixtures/disable_comment.md:10:")
+	})
+
+	t.Run("ViolationOutsideDirectiveIsReported", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/disable_comment.md", "--config", "config-no-bare-urls.json")
+		if err == nil {
+			t.Error("expected exit 1: line 12 has no directive and should be reported")
+		}
+		assertOutputContains(t, output, "fixtures/disable_comment.md:12:")
 	})
 }

--- a/e2e/fixtures/disable_comment.md
+++ b/e2e/fixtures/disable_comment.md
@@ -1,12 +1,21 @@
 # Disable Comment Test
 
-<!-- gomarklint-disable no-bare-urls -->
-https://suppressed.example.com
-<!-- gomarklint-enable no-bare-urls -->
+<!-- gomarklint-disable -->
+https://block-all-suppressed.example.com
+<!-- gomarklint-enable -->
+https://after-enable-all.example.com
 
-https://reported.example.com <!-- gomarklint-disable-line no-bare-urls -->
+<!-- gomarklint-disable no-bare-urls -->
+https://block-named-suppressed.example.com
+<!-- gomarklint-enable no-bare-urls -->
+https://after-enable-named.example.com
+
+https://disable-line-all.example.com <!-- gomarklint-disable-line -->
+
+https://disable-line-named.example.com <!-- gomarklint-disable-line no-bare-urls -->
+
+<!-- gomarklint-disable-next-line -->
+https://next-line-all-suppressed.example.com
 
 <!-- gomarklint-disable-next-line no-bare-urls -->
-https://suppressed-next.example.com
-
-https://also-reported.example.com
+https://next-line-named-suppressed.example.com

--- a/e2e/fixtures/disable_comment.md
+++ b/e2e/fixtures/disable_comment.md
@@ -1,0 +1,12 @@
+# Disable Comment Test
+
+<!-- gomarklint-disable no-bare-urls -->
+https://suppressed.example.com
+<!-- gomarklint-enable no-bare-urls -->
+
+https://reported.example.com <!-- gomarklint-disable-line no-bare-urls -->
+
+<!-- gomarklint-disable-next-line no-bare-urls -->
+https://suppressed-next.example.com
+
+https://also-reported.example.com

--- a/internal/linter/disable_comment.go
+++ b/internal/linter/disable_comment.go
@@ -3,55 +3,56 @@ package linter
 import "strings"
 
 // disabledSet maps absolute line numbers to disabled rule names.
-// A nil map value means all rules are disabled on that line.
-type disabledSet map[int]map[string]struct{}
+// An empty (non-nil) slice means all rules are disabled on that line.
+// A non-empty slice lists the specific disabled rule names.
+type disabledSet map[int][]string
 
 func (d disabledSet) isDisabled(line int, ruleName string) bool {
 	rules, ok := d[line]
 	if !ok {
 		return false
 	}
-	if rules == nil {
-		return true
+	if len(rules) == 0 {
+		return true // all rules disabled
 	}
-	_, found := rules[ruleName]
-	return found
+	for _, r := range rules {
+		if r == ruleName {
+			return true
+		}
+	}
+	return false
 }
 
 func (d disabledSet) addLine(line int, ruleNames []string) {
 	if len(ruleNames) == 0 {
-		d[line] = nil
+		d[line] = []string{} // empty non-nil = all rules
 		return
 	}
-	if existing, exists := d[line]; exists && existing == nil {
-		return // already all-disabled; nil takes priority
+	existing, exists := d[line]
+	if exists && len(existing) == 0 {
+		return // all-disabled takes priority
 	}
-	if _, exists := d[line]; !exists {
-		d[line] = make(map[string]struct{})
-	}
-	for _, r := range ruleNames {
-		d[line][r] = struct{}{}
-	}
+	d[line] = append(existing, ruleNames...)
 }
 
 // applyBlockState stamps the current block-level disable state onto absLine in set.
 func applyBlockState(set disabledSet, absLine int, blockAllDisabled bool, blockRules map[string]struct{}) {
 	if blockAllDisabled {
-		set[absLine] = nil
+		set[absLine] = []string{}
 		return
 	}
 	if len(blockRules) == 0 {
 		return
 	}
-	if existing, exists := set[absLine]; exists && existing == nil {
-		return // nil (all-disabled) takes priority
+	existing, exists := set[absLine]
+	if exists && len(existing) == 0 {
+		return // all-disabled takes priority
 	}
-	if _, exists := set[absLine]; !exists {
-		set[absLine] = make(map[string]struct{})
-	}
+	names := make([]string, 0, len(blockRules))
 	for r := range blockRules {
-		set[absLine][r] = struct{}{}
+		names = append(names, r)
 	}
+	set[absLine] = append(existing, names...)
 }
 
 // parseDisableComments scans lines for gomarklint-disable directives and returns

--- a/internal/linter/disable_comment.go
+++ b/internal/linter/disable_comment.go
@@ -2,20 +2,24 @@ package linter
 
 import "strings"
 
-// disabledSet maps absolute line numbers to disabled rule names.
-// An empty (non-nil) slice means all rules are disabled on that line.
-// A non-empty slice lists the specific disabled rule names.
-type disabledSet map[int][]string
+// lineDisable describes which rules are disabled on a single line.
+// If allDisabled is true, all rules are disabled except those listed in names (exceptions).
+// If allDisabled is false, only the rules listed in names are disabled.
+type lineDisable struct {
+	allDisabled bool
+	names       []string
+}
 
-func (d disabledSet) isDisabled(line int, ruleName string) bool {
-	rules, ok := d[line]
-	if !ok {
-		return false
+func (ld lineDisable) isRuleDisabled(ruleName string) bool {
+	if ld.allDisabled {
+		for _, r := range ld.names {
+			if r == ruleName {
+				return false // exception: explicitly re-enabled
+			}
+		}
+		return true
 	}
-	if len(rules) == 0 {
-		return true // all rules disabled
-	}
-	for _, r := range rules {
+	for _, r := range ld.names {
 		if r == ruleName {
 			return true
 		}
@@ -23,36 +27,57 @@ func (d disabledSet) isDisabled(line int, ruleName string) bool {
 	return false
 }
 
-func (d disabledSet) addLine(line int, ruleNames []string) {
-	if len(ruleNames) == 0 {
-		d[line] = []string{} // empty non-nil = all rules
-		return
+// disabledSet maps absolute line numbers to their disable state.
+type disabledSet map[int]lineDisable
+
+func (d disabledSet) isDisabled(line int, ruleName string) bool {
+	ld, ok := d[line]
+	if !ok {
+		return false
 	}
-	existing, exists := d[line]
-	if exists && len(existing) == 0 {
-		return // all-disabled takes priority
-	}
-	d[line] = append(existing, ruleNames...)
+	return ld.isRuleDisabled(ruleName)
 }
 
-// applyBlockState stamps the current block-level disable state onto absLine in set.
-func applyBlockState(set disabledSet, absLine int, blockAllDisabled bool, blockRules map[string]struct{}) {
-	if blockAllDisabled {
-		set[absLine] = []string{}
+func (d disabledSet) addLine(line int, ruleNames []string) {
+	existing, exists := d[line]
+	if exists && existing.allDisabled && len(existing.names) == 0 {
+		return // all-disabled (no exceptions) takes priority
+	}
+	if len(ruleNames) == 0 {
+		d[line] = lineDisable{allDisabled: true}
 		return
 	}
-	if len(blockRules) == 0 {
+	d[line] = lineDisable{names: append(existing.names, ruleNames...)}
+}
+
+// blockState holds the current block-level disable state while scanning lines.
+type blockState struct {
+	allDisabled bool
+	exceptions  []string // re-enabled rules when allDisabled=true
+	rules       []string // named disabled rules when allDisabled=false
+}
+
+func (bs *blockState) applyTo(set disabledSet, absLine int) {
+	if !bs.allDisabled && len(bs.rules) == 0 {
 		return
 	}
 	existing, exists := set[absLine]
-	if exists && len(existing) == 0 {
+	if bs.allDisabled {
+		if !exists {
+			set[absLine] = lineDisable{allDisabled: true, names: bs.exceptions}
+			return
+		}
+		if existing.allDisabled && len(existing.names) == 0 {
+			return // already fully disabled; keep it
+		}
+		set[absLine] = lineDisable{allDisabled: true, names: bs.exceptions}
+		return
+	}
+	// named-disable mode
+	if exists && existing.allDisabled {
 		return // all-disabled takes priority
 	}
-	names := make([]string, 0, len(blockRules))
-	for r := range blockRules {
-		names = append(names, r)
-	}
-	set[absLine] = append(existing, names...)
+	set[absLine] = lineDisable{names: append(existing.names, bs.rules...)}
 }
 
 // parseDisableComments scans lines for gomarklint-disable directives and returns
@@ -60,8 +85,7 @@ func applyBlockState(set disabledSet, absLine int, blockAllDisabled bool, blockR
 // offset is the frontmatter line count used to compute absolute line numbers.
 func parseDisableComments(lines []string, offset int) disabledSet {
 	set := make(disabledSet)
-	blockAllDisabled := false
-	blockRules := make(map[string]struct{})
+	var bs blockState
 
 	for i, line := range lines {
 		absLine := i + 1 + offset
@@ -70,21 +94,17 @@ func parseDisableComments(lines []string, offset int) disabledSet {
 		switch directive {
 		case "disable":
 			if len(ruleNames) == 0 {
-				blockAllDisabled = true
-				blockRules = make(map[string]struct{})
+				bs = blockState{allDisabled: true}
 			} else {
-				for _, r := range ruleNames {
-					blockRules[r] = struct{}{}
-				}
+				bs.rules = append(bs.rules, ruleNames...)
 			}
 		case "enable":
 			if len(ruleNames) == 0 {
-				blockAllDisabled = false
-				blockRules = make(map[string]struct{})
+				bs = blockState{}
+			} else if bs.allDisabled {
+				bs.exceptions = append(bs.exceptions, ruleNames...)
 			} else {
-				for _, r := range ruleNames {
-					delete(blockRules, r)
-				}
+				bs.rules = removeAll(bs.rules, ruleNames)
 			}
 		case "disable-line":
 			set.addLine(absLine, ruleNames)
@@ -94,10 +114,28 @@ func parseDisableComments(lines []string, offset int) disabledSet {
 			}
 		}
 
-		applyBlockState(set, absLine, blockAllDisabled, blockRules)
+		bs.applyTo(set, absLine)
 	}
 
 	return set
+}
+
+// removeAll returns s with all elements in remove filtered out.
+func removeAll(s []string, remove []string) []string {
+	result := s[:0]
+	for _, v := range s {
+		found := false
+		for _, r := range remove {
+			if v == r {
+				found = true
+				break
+			}
+		}
+		if !found {
+			result = append(result, v)
+		}
+	}
+	return result
 }
 
 // parseDirectiveLine extracts the directive keyword and optional rule names

--- a/internal/linter/disable_comment.go
+++ b/internal/linter/disable_comment.go
@@ -1,0 +1,129 @@
+package linter
+
+import "strings"
+
+// disabledSet maps absolute line numbers to disabled rule names.
+// A nil map value means all rules are disabled on that line.
+type disabledSet map[int]map[string]struct{}
+
+func (d disabledSet) isDisabled(line int, ruleName string) bool {
+	rules, ok := d[line]
+	if !ok {
+		return false
+	}
+	if rules == nil {
+		return true
+	}
+	_, found := rules[ruleName]
+	return found
+}
+
+func (d disabledSet) addLine(line int, ruleNames []string) {
+	if len(ruleNames) == 0 {
+		d[line] = nil
+		return
+	}
+	if existing, exists := d[line]; exists && existing == nil {
+		return // already all-disabled; nil takes priority
+	}
+	if _, exists := d[line]; !exists {
+		d[line] = make(map[string]struct{})
+	}
+	for _, r := range ruleNames {
+		d[line][r] = struct{}{}
+	}
+}
+
+// applyBlockState stamps the current block-level disable state onto absLine in set.
+func applyBlockState(set disabledSet, absLine int, blockAllDisabled bool, blockRules map[string]struct{}) {
+	if blockAllDisabled {
+		set[absLine] = nil
+		return
+	}
+	if len(blockRules) == 0 {
+		return
+	}
+	if existing, exists := set[absLine]; exists && existing == nil {
+		return // nil (all-disabled) takes priority
+	}
+	if _, exists := set[absLine]; !exists {
+		set[absLine] = make(map[string]struct{})
+	}
+	for r := range blockRules {
+		set[absLine][r] = struct{}{}
+	}
+}
+
+// parseDisableComments scans lines for gomarklint-disable directives and returns
+// a disabledSet mapping absolute line numbers to the set of disabled rules.
+// offset is the frontmatter line count used to compute absolute line numbers.
+func parseDisableComments(lines []string, offset int) disabledSet {
+	set := make(disabledSet)
+	blockAllDisabled := false
+	blockRules := make(map[string]struct{})
+
+	for i, line := range lines {
+		absLine := i + 1 + offset
+		directive, ruleNames := parseDirectiveLine(line)
+
+		switch directive {
+		case "disable":
+			if len(ruleNames) == 0 {
+				blockAllDisabled = true
+				blockRules = make(map[string]struct{})
+			} else {
+				for _, r := range ruleNames {
+					blockRules[r] = struct{}{}
+				}
+			}
+		case "enable":
+			if len(ruleNames) == 0 {
+				blockAllDisabled = false
+				blockRules = make(map[string]struct{})
+			} else {
+				for _, r := range ruleNames {
+					delete(blockRules, r)
+				}
+			}
+		case "disable-line":
+			set.addLine(absLine, ruleNames)
+		case "disable-next-line":
+			if i+1 < len(lines) {
+				set.addLine(absLine+1, ruleNames)
+			}
+		}
+
+		applyBlockState(set, absLine, blockAllDisabled, blockRules)
+	}
+
+	return set
+}
+
+// parseDirectiveLine extracts the directive keyword and optional rule names
+// from a gomarklint HTML comment directive on a line.
+// Returns ("", nil) when no valid directive is found.
+func parseDirectiveLine(line string) (directive string, ruleNames []string) {
+	start := strings.Index(line, "<!--")
+	if start == -1 {
+		return "", nil
+	}
+	end := strings.Index(line[start:], "-->")
+	if end == -1 {
+		return "", nil
+	}
+	inner := strings.TrimSpace(line[start+4 : start+end])
+	const prefix = "gomarklint-"
+	if !strings.HasPrefix(inner, prefix) {
+		return "", nil
+	}
+	parts := strings.Fields(inner[len(prefix):])
+	if len(parts) == 0 {
+		return "", nil
+	}
+	switch parts[0] {
+	case "disable", "enable", "disable-line", "disable-next-line":
+		return parts[0], parts[1:]
+	default:
+		return "", nil
+	}
+}

--- a/internal/linter/disable_comment_test.go
+++ b/internal/linter/disable_comment_test.go
@@ -215,16 +215,16 @@ func TestParseDisableComments_WithFrontmatterOffset(t *testing.T) {
 
 func TestDisabledSet_IsDisabled(t *testing.T) {
 	set := make(disabledSet)
-	set[10] = nil // all rules
+	set[10] = []string{} // empty non-nil = all rules
 
 	if !set.isDisabled(10, "any-rule") {
-		t.Error("nil entry should disable all rules")
+		t.Error("empty slice entry should disable all rules")
 	}
 	if set.isDisabled(11, "any-rule") {
 		t.Error("unregistered line should not be disabled")
 	}
 
-	set[20] = map[string]struct{}{"no-bare-urls": {}}
+	set[20] = []string{"no-bare-urls"}
 	if !set.isDisabled(20, "no-bare-urls") {
 		t.Error("named rule should be disabled")
 	}

--- a/internal/linter/disable_comment_test.go
+++ b/internal/linter/disable_comment_test.go
@@ -79,6 +79,11 @@ func TestParseDirectiveLine(t *testing.T) {
 			line:          "<!-- gomarklint-disable",
 			wantDirective: "",
 		},
+		{
+			name:          "prefix only, no command",
+			line:          "<!-- gomarklint- -->",
+			wantDirective: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -258,5 +263,81 @@ func TestParseDisableComments_EnableNamedRuleInsideBlockDisableAll(t *testing.T)
 	}
 	if set.isDisabled(6, "no-bare-urls") {
 		t.Error("line 6 should be fully enabled")
+	}
+}
+
+// addLine: all-disabled (no exceptions) priority when line already fully disabled
+func TestAddLine_AllDisabledTakesPriority(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable-next-line -->", // line 1: addLine(2, nil)
+		"x <!-- gomarklint-disable-line -->",    // line 2: addLine(2, nil) again — should be no-op
+	}
+	set := parseDisableComments(lines, 0)
+
+	if !set.isDisabled(2, "any-rule") {
+		t.Error("line 2 should still be all-disabled")
+	}
+}
+
+// applyTo: block-all-disabled skips line already fully disabled (set by disable-next-line)
+func TestApplyTo_BlockAllDisabledSkipsAlreadyFullyDisabledLine(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable -->",           // line 1
+		"<!-- gomarklint-disable-next-line -->", // line 2: addLine(3, nil)
+		"https://example.com",                   // line 3: applyTo sees existing all-disabled
+		"<!-- gomarklint-enable -->",            // line 4
+	}
+	set := parseDisableComments(lines, 0)
+
+	if !set.isDisabled(3, "any-rule") {
+		t.Error("line 3 should be all-disabled")
+	}
+}
+
+// applyTo: block-named-disable skips line already all-disabled (set by disable-next-line)
+func TestApplyTo_BlockNamedDisableSkipsAllDisabledLine(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable no-bare-urls -->", // line 1
+		"<!-- gomarklint-disable-next-line -->",    // line 2: addLine(3, nil) → all-disabled
+		"https://example.com",                      // line 3
+		"<!-- gomarklint-enable no-bare-urls -->",  // line 4
+	}
+	set := parseDisableComments(lines, 0)
+
+	if !set.isDisabled(3, "heading-level") {
+		t.Error("line 3 should be all-disabled (disable-next-line wins)")
+	}
+}
+
+// applyTo: block-all-disable overwrites an existing named-disable entry
+func TestApplyTo_BlockAllDisabledOverwritesNamedDisabledLine(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable-next-line no-bare-urls -->", // line 1: addLine(2, ["no-bare-urls"])
+		"<!-- gomarklint-disable -->",                        // line 2: applyTo sees existing named entry, overwrites with all-disabled
+		"https://example.com",                                // line 3
+		"<!-- gomarklint-enable -->",                         // line 4
+	}
+	set := parseDisableComments(lines, 0)
+
+	// line 2 should be all-disabled (block-all overwrites the named-disable from disable-next-line)
+	if !set.isDisabled(2, "heading-level") {
+		t.Error("line 2 should be all-disabled after block-all overwrite")
+	}
+}
+
+// removeAll: keeps rules not in the remove list
+func TestRemoveAll_KeepsUnmatchedRules(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable no-bare-urls heading-level -->", // line 1
+		"<!-- gomarklint-enable no-bare-urls -->",                // line 2: only no-bare-urls re-enabled
+		"https://example.com",                                    // line 3
+	}
+	set := parseDisableComments(lines, 0)
+
+	if set.isDisabled(3, "no-bare-urls") {
+		t.Error("line 3 no-bare-urls should be re-enabled")
+	}
+	if !set.isDisabled(3, "heading-level") {
+		t.Error("line 3 heading-level should still be disabled")
 	}
 }

--- a/internal/linter/disable_comment_test.go
+++ b/internal/linter/disable_comment_test.go
@@ -215,20 +215,48 @@ func TestParseDisableComments_WithFrontmatterOffset(t *testing.T) {
 
 func TestDisabledSet_IsDisabled(t *testing.T) {
 	set := make(disabledSet)
-	set[10] = []string{} // empty non-nil = all rules
+	set[10] = lineDisable{allDisabled: true} // all rules
 
 	if !set.isDisabled(10, "any-rule") {
-		t.Error("empty slice entry should disable all rules")
+		t.Error("allDisabled entry should disable all rules")
 	}
 	if set.isDisabled(11, "any-rule") {
 		t.Error("unregistered line should not be disabled")
 	}
 
-	set[20] = []string{"no-bare-urls"}
+	set[20] = lineDisable{names: []string{"no-bare-urls"}}
 	if !set.isDisabled(20, "no-bare-urls") {
 		t.Error("named rule should be disabled")
 	}
 	if set.isDisabled(20, "heading-level") {
 		t.Error("other rule should not be disabled")
+	}
+}
+
+func TestParseDisableComments_EnableNamedRuleInsideBlockDisableAll(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable -->",             // line 1
+		"https://example.com",                     // line 2: both rules disabled
+		"<!-- gomarklint-enable no-bare-urls -->", // line 3
+		"https://example.com",                     // line 4: no-bare-urls re-enabled, heading-level still disabled
+		"<!-- gomarklint-enable -->",              // line 5
+		"https://example.com",                     // line 6: everything enabled
+	}
+	set := parseDisableComments(lines, 0)
+
+	if !set.isDisabled(2, "no-bare-urls") {
+		t.Error("line 2 should be disabled for no-bare-urls")
+	}
+	if !set.isDisabled(2, "heading-level") {
+		t.Error("line 2 should be disabled for heading-level")
+	}
+	if set.isDisabled(4, "no-bare-urls") {
+		t.Error("line 4 no-bare-urls should be re-enabled")
+	}
+	if !set.isDisabled(4, "heading-level") {
+		t.Error("line 4 heading-level should still be disabled")
+	}
+	if set.isDisabled(6, "no-bare-urls") {
+		t.Error("line 6 should be fully enabled")
 	}
 }

--- a/internal/linter/disable_comment_test.go
+++ b/internal/linter/disable_comment_test.go
@@ -1,0 +1,234 @@
+package linter
+
+import (
+	"testing"
+)
+
+func TestParseDirectiveLine(t *testing.T) {
+	tests := []struct {
+		name          string
+		line          string
+		wantDirective string
+		wantRules     []string
+	}{
+		{
+			name:          "no comment",
+			line:          "plain text",
+			wantDirective: "",
+		},
+		{
+			name:          "unrelated comment",
+			line:          "<!-- some comment -->",
+			wantDirective: "",
+		},
+		{
+			name:          "disable all",
+			line:          "<!-- gomarklint-disable -->",
+			wantDirective: "disable",
+			wantRules:     []string{},
+		},
+		{
+			name:          "disable named rules",
+			line:          "<!-- gomarklint-disable no-bare-urls heading-level -->",
+			wantDirective: "disable",
+			wantRules:     []string{"no-bare-urls", "heading-level"},
+		},
+		{
+			name:          "enable all",
+			line:          "<!-- gomarklint-enable -->",
+			wantDirective: "enable",
+			wantRules:     []string{},
+		},
+		{
+			name:          "enable named rule",
+			line:          "<!-- gomarklint-enable no-bare-urls -->",
+			wantDirective: "enable",
+			wantRules:     []string{"no-bare-urls"},
+		},
+		{
+			name:          "disable-line all",
+			line:          "text <!-- gomarklint-disable-line -->",
+			wantDirective: "disable-line",
+			wantRules:     []string{},
+		},
+		{
+			name:          "disable-line named rule",
+			line:          "https://example.com <!-- gomarklint-disable-line no-bare-urls -->",
+			wantDirective: "disable-line",
+			wantRules:     []string{"no-bare-urls"},
+		},
+		{
+			name:          "disable-next-line all",
+			line:          "<!-- gomarklint-disable-next-line -->",
+			wantDirective: "disable-next-line",
+			wantRules:     []string{},
+		},
+		{
+			name:          "disable-next-line named rule",
+			line:          "<!-- gomarklint-disable-next-line duplicate-heading -->",
+			wantDirective: "disable-next-line",
+			wantRules:     []string{"duplicate-heading"},
+		},
+		{
+			name:          "unknown directive",
+			line:          "<!-- gomarklint-ignore -->",
+			wantDirective: "",
+		},
+		{
+			name:          "unclosed comment",
+			line:          "<!-- gomarklint-disable",
+			wantDirective: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDir, gotRules := parseDirectiveLine(tt.line)
+			if gotDir != tt.wantDirective {
+				t.Errorf("directive = %q, want %q", gotDir, tt.wantDirective)
+			}
+			if tt.wantDirective == "" {
+				return
+			}
+			if len(gotRules) != len(tt.wantRules) {
+				t.Fatalf("rules = %v, want %v", gotRules, tt.wantRules)
+			}
+			for i, r := range tt.wantRules {
+				if gotRules[i] != r {
+					t.Errorf("rules[%d] = %q, want %q", i, gotRules[i], r)
+				}
+			}
+		})
+	}
+}
+
+func TestParseDisableComments_BlockDisableAll(t *testing.T) {
+	lines := []string{
+		"# Heading",                   // line 1
+		"<!-- gomarklint-disable -->", // line 2
+		"https://example.com",         // line 3
+		"<!-- gomarklint-enable -->",  // line 4
+		"https://example.com",         // line 5
+	}
+	set := parseDisableComments(lines, 0)
+
+	if set.isDisabled(1, "no-bare-urls") {
+		t.Error("line 1 should not be disabled")
+	}
+	if !set.isDisabled(2, "no-bare-urls") {
+		t.Error("line 2 (directive line) should be disabled")
+	}
+	if !set.isDisabled(3, "no-bare-urls") {
+		t.Error("line 3 should be disabled")
+	}
+	if !set.isDisabled(3, "heading-level") {
+		t.Error("line 3 should be disabled for all rules")
+	}
+	if set.isDisabled(4, "no-bare-urls") {
+		t.Error("line 4 (enable directive) should not be disabled")
+	}
+	if set.isDisabled(5, "no-bare-urls") {
+		t.Error("line 5 after enable should not be disabled")
+	}
+}
+
+func TestParseDisableComments_BlockDisableNamedRule(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable no-bare-urls -->", // line 1
+		"https://example.com",                      // line 2
+		"<!-- gomarklint-enable no-bare-urls -->",  // line 3
+		"https://example.com",                      // line 4
+	}
+	set := parseDisableComments(lines, 0)
+
+	if !set.isDisabled(2, "no-bare-urls") {
+		t.Error("line 2 should be disabled for no-bare-urls")
+	}
+	if set.isDisabled(2, "heading-level") {
+		t.Error("line 2 should not be disabled for heading-level")
+	}
+	if set.isDisabled(4, "no-bare-urls") {
+		t.Error("line 4 after enable should not be disabled")
+	}
+}
+
+func TestParseDisableComments_DisableLine(t *testing.T) {
+	lines := []string{
+		"# Heading", // line 1
+		"https://example.com <!-- gomarklint-disable-line -->", // line 2
+		"https://example.com", // line 3
+	}
+	set := parseDisableComments(lines, 0)
+
+	if set.isDisabled(1, "no-bare-urls") {
+		t.Error("line 1 should not be disabled")
+	}
+	if !set.isDisabled(2, "no-bare-urls") {
+		t.Error("line 2 should be disabled")
+	}
+	if !set.isDisabled(2, "heading-level") {
+		t.Error("line 2 should be disabled for all rules")
+	}
+	if set.isDisabled(3, "no-bare-urls") {
+		t.Error("line 3 should not be disabled")
+	}
+}
+
+func TestParseDisableComments_DisableNextLine(t *testing.T) {
+	lines := []string{
+		"# Heading",                             // line 1
+		"<!-- gomarklint-disable-next-line -->", // line 2
+		"https://example.com",                   // line 3
+		"https://example.com",                   // line 4
+	}
+	set := parseDisableComments(lines, 0)
+
+	if set.isDisabled(1, "no-bare-urls") {
+		t.Error("line 1 should not be disabled")
+	}
+	if set.isDisabled(2, "no-bare-urls") {
+		t.Error("line 2 (directive itself) should not be disabled")
+	}
+	if !set.isDisabled(3, "no-bare-urls") {
+		t.Error("line 3 should be disabled")
+	}
+	if set.isDisabled(4, "no-bare-urls") {
+		t.Error("line 4 should not be disabled")
+	}
+}
+
+func TestParseDisableComments_WithFrontmatterOffset(t *testing.T) {
+	lines := []string{
+		"<!-- gomarklint-disable-next-line no-bare-urls -->", // body line 1 → abs line 4
+		"https://example.com",                                // body line 2 → abs line 5
+	}
+	offset := 3
+	set := parseDisableComments(lines, offset)
+
+	if set.isDisabled(4, "no-bare-urls") {
+		t.Error("abs line 4 (directive) should not be disabled")
+	}
+	if !set.isDisabled(5, "no-bare-urls") {
+		t.Error("abs line 5 should be disabled")
+	}
+}
+
+func TestDisabledSet_IsDisabled(t *testing.T) {
+	set := make(disabledSet)
+	set[10] = nil // all rules
+
+	if !set.isDisabled(10, "any-rule") {
+		t.Error("nil entry should disable all rules")
+	}
+	if set.isDisabled(11, "any-rule") {
+		t.Error("unregistered line should not be disabled")
+	}
+
+	set[20] = map[string]struct{}{"no-bare-urls": {}}
+	if !set.isDisabled(20, "no-bare-urls") {
+		t.Error("named rule should be disabled")
+	}
+	if set.isDisabled(20, "heading-level") {
+		t.Error("other rule should not be disabled")
+	}
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -135,10 +135,11 @@ func (l *Linter) LintContent(path string, content string) ([]rule.LintError, int
 	return l.collectErrors(path, content)
 }
 
-// withSeverity tags each error in errs with the configured severity for ruleName.
+// withSeverity tags each error in errs with the configured severity and rule name.
 func (l *Linter) withSeverity(errs []rule.LintError, ruleName string) []rule.LintError {
 	sev := l.config.RuleSeverity(ruleName)
 	for i := range errs {
+		errs[i].Rule = ruleName
 		errs[i].Severity = sev
 	}
 	return errs
@@ -219,6 +220,11 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 	body, offset := file.StripFrontmatter(content)
 	lines := strings.Split(body, "\n")
 
+	var disabled disabledSet
+	if strings.Contains(body, "gomarklint-disable") {
+		disabled = parseDisableComments(lines, offset)
+	}
+
 	allErrors := l.collectLineErrors(path, lines, offset)
 
 	linksChecked := 0
@@ -226,6 +232,16 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.urlCache)
 		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
 		linksChecked = count
+	}
+
+	if len(disabled) > 0 {
+		filtered := allErrors[:0]
+		for _, e := range allErrors {
+			if !disabled.isDisabled(e.Line, e.Rule) {
+				filtered = append(filtered, e)
+			}
+		}
+		allErrors = filtered
 	}
 
 	sort.Slice(allErrors, func(i, j int) bool {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -551,3 +551,101 @@ func TestRun_WarningSeverity(t *testing.T) {
 		}
 	}
 }
+
+func TestRun_DisableComment_BlockDisableAll(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-bare-urls"] = on()
+
+	content := "# Heading\n\n<!-- gomarklint-disable -->\nhttps://example.com\n<!-- gomarklint-enable -->\nhttps://example.com\n"
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", content)
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error (line 6), got %d: %v", len(errors), errors)
+	}
+	if errors[0].Line != 6 {
+		t.Errorf("expected error on line 6, got line %d", errors[0].Line)
+	}
+}
+
+func TestRun_DisableComment_BlockDisableNamedRule(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-bare-urls"] = on()
+	cfg.Rules["no-empty-links"] = on()
+
+	content := "<!-- gomarklint-disable no-bare-urls -->\nhttps://example.com\n[]()\n<!-- gomarklint-enable no-bare-urls -->\nhttps://example.com\n"
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", content)
+
+	// line 3 (empty link) should still be reported; line 2 (bare URL) should be suppressed
+	// line 5 (bare URL after enable) should be reported
+	var lines []int
+	for _, e := range errors {
+		lines = append(lines, e.Line)
+	}
+	for _, e := range errors {
+		if e.Line == 2 && e.Rule == "no-bare-urls" {
+			t.Errorf("line 2 no-bare-urls should be suppressed, got %v", e)
+		}
+	}
+	reported := map[int]bool{}
+	for _, e := range errors {
+		reported[e.Line] = true
+	}
+	if !reported[3] {
+		t.Errorf("line 3 (empty link) should be reported, errors: %v", lines)
+	}
+	if !reported[5] {
+		t.Errorf("line 5 (bare URL after enable) should be reported, errors: %v", lines)
+	}
+}
+
+func TestRun_DisableComment_DisableLine(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-bare-urls"] = on()
+
+	content := "https://example.com <!-- gomarklint-disable-line no-bare-urls -->\nhttps://example.com\n"
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", content)
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error (line 2), got %d: %v", len(errors), errors)
+	}
+	if errors[0].Line != 2 {
+		t.Errorf("expected error on line 2, got line %d", errors[0].Line)
+	}
+}
+
+func TestRun_DisableComment_DisableNextLine(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-bare-urls"] = on()
+
+	content := "<!-- gomarklint-disable-next-line no-bare-urls -->\nhttps://example.com\nhttps://example.com\n"
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", content)
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error (line 3), got %d: %v", len(errors), errors)
+	}
+	if errors[0].Line != 3 {
+		t.Errorf("expected error on line 3, got line %d", errors[0].Line)
+	}
+}
+
+func TestRun_DisableComment_NoDisableKeyword_NoOverhead(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["no-bare-urls"] = on()
+
+	content := "<!-- some comment -->\nhttps://example.com\n"
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", content)
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+}

--- a/internal/rule/heading_level.go
+++ b/internal/rule/heading_level.go
@@ -8,6 +8,7 @@ import (
 type LintError struct {
 	File     string `json:"file"`
 	Line     int    `json:"line"`
+	Rule     string `json:"rule,omitempty"`
 	Message  string `json:"message"`
 	Severity string `json:"severity"`
 }


### PR DESCRIPTION
Closes #136

## Summary

- Add `<!-- gomarklint-disable -->` / `<!-- gomarklint-enable -->` block directives
- Add `<!-- gomarklint-disable-line -->` single-line directive
- Add `<!-- gomarklint-disable-next-line -->` next-line directive
- All directives accept optional rule names (e.g. `<!-- gomarklint-disable no-bare-urls -->`)
- Add `Rule` field to `LintError` so per-rule filtering is possible (also improves JSON output)
- Guard parse step with `strings.Contains` to avoid overhead on files with no directives

## Test plan

- [ ] Unit tests for `parseDirectiveLine` covering all directive types and edge cases
- [ ] Unit tests for `parseDisableComments` covering block, disable-line, disable-next-line, frontmatter offset
- [ ] Integration tests in `linter_test.go` for each directive variant end-to-end
- [ ] E2E tests (`TestE2E_DisableComments`) verifying suppressed vs. reported violations in a real binary run
- [ ] `make test-all` passes (unit + e2e + static-lint)