### PR TITLE
docs: update roadmap — remove Docker image, mark inline-disable as done

### DIFF
--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -42,7 +42,7 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 
 ## Extensibility
 
-- [ ] Allow disabling rules via inline comments (e.g. `<!-- gomarklint-disable -->`)
+- [x] Allow disabling rules via inline comments (e.g. `<!-- gomarklint-disable -->`)
 - [ ] Plugin system for custom rules (via Go interface or external binary)
 
 ## Distribution & CI
@@ -51,7 +51,6 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] Prebuilt binaries via `goreleaser` (macOS/Linux/Windows)
 - [x] Homebrew tap (`brew install shinagawa-web/tap/gomarklint`)
 - [x] npm package (`npm install -g @shinagawa-web/gomarklint`)
-- [ ] Docker image (e.g. `ghcr.io/shinagawa-web/gomarklint`)
 
 ## Developer UX
 


### PR DESCRIPTION
## Summary

- Remove Docker image (`ghcr.io/shinagawa-web/gomarklint`) from the roadmap — goreleaser binaries and GitHub Actions already cover the CI use case, and a static binary linter does not benefit from containerization
- Mark "Allow disabling rules via inline comments" as completed (`[x]`)