### PR TITLE
docs: highlight speed as the primary selling point in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 [English](README.md) | 日本語
 
-> Go 製の高速 Markdown リンター。シングルバイナリで Node.js 不要 — HTTP リンクバリデーション機能を内蔵。
+> Go 製の超高速 Markdown リンター — **100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要、HTTP リンクバリデーション機能を内蔵。
 
 **かんたんインストール**（macOS / Linux）:
 
@@ -53,10 +53,10 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint@latest
 ```
 
+- **100,000 行以上を約 170ms** で処理 — JIT ウォームアップなし、ランタイムオーバーヘッドなし。
 - リンク切れや見出しの問題をドキュメント公開前にキャッチ。
 - 予測可能な構造を強制（「なぜ H2 の下に H4 があるの？」をなくす）。
 - 人間にも機械にも優しい出力（JSON 対応）。
-- **100,000 行以上を約 170ms** で処理 — ローカル開発にもCI にも十分な速さ。
 
 ## CI 連携
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 English | [日本語](README.ja.md)
 
-> Blazing-fast Markdown linter built in Go — **100,000+ lines in ~170ms**. Single binary, no Node.js required, with built-in HTTP link validation.
+> Blazing-fast Markdown linter built in Go — **100,000+ lines in ~170ms**. Single binary, no Node.js required, and built-in HTTP link validation.
 
 **Quick install** (macOS / Linux):
 
@@ -53,7 +53,7 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint@latest
 ```
 
-- **100,000+ lines in ~170ms** — faster than markdownlint, no JIT warmup, no runtime overhead.
+- **100,000+ lines in ~170ms** — single binary, no JIT warmup, no runtime overhead.
 - Catch broken links and headings before your docs ship.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 English | [日本語](README.ja.md)
 
-> A fast Markdown linter built in Go. Single binary, no Node.js required — with built-in HTTP link validation.
+> Blazing-fast Markdown linter built in Go — **100,000+ lines in ~170ms**. Single binary, no Node.js required, with built-in HTTP link validation.
 
 **Quick install** (macOS / Linux):
 
@@ -53,10 +53,10 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint@latest
 ```
 
+- **100,000+ lines in ~170ms** — faster than markdownlint, no JIT warmup, no runtime overhead.
 - Catch broken links and headings before your docs ship.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
-- Process **100,000+ lines in ~170ms** — fast enough for local dev, robust enough for CI.
 
 ## CI Integration
 


### PR DESCRIPTION
## Summary

- Move the speed stat (**100,000+ lines in ~170ms**) to the tagline and to the top of the bullet list in both `README.md` and `README.ja.md`
- Strengthen the tagline from "A fast" to "Blazing-fast" with the concrete number inline
- Reframe the speed bullet: "faster than markdownlint, no JIT warmup, no runtime overhead"

## Test plan

- [x] Verify README renders correctly on GitHub