### PR TITLE
feat: add max-line-length rule (MD013)

### DIFF
--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -64,6 +64,7 @@ func BenchmarkFullLinting(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["max-line-length"].Enabled = true
 
 	lint := linter.New(cfg)
 
@@ -77,6 +78,7 @@ func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
 	content := generateComplexMarkdown(5000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
+	cfg.Rules["max-line-length"].Enabled = true
 
 	lint := linter.New(cfg)
 

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -64,7 +64,11 @@ func BenchmarkFullLinting(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["max-line-length"].Enabled = true
+	cfg.Rules["max-line-length"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"lineLength": float64(120)},
+	}
 
 	lint := linter.New(cfg)
 
@@ -78,7 +82,11 @@ func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
 	content := generateComplexMarkdown(5000)
 	cfg := config.Default()
 	cfg.Rules["external-link"].Enabled = false
-	cfg.Rules["max-line-length"].Enabled = true
+	cfg.Rules["max-line-length"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"lineLength": float64(120)},
+	}
 
 	lint := linter.New(cfg)
 

--- a/e2e/config-max-line-length.json
+++ b/e2e/config-max-line-length.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "max-line-length": { "enabled": true, "lineLength": 80 }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -280,6 +280,23 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "list must be followed by a blank line")
 		assertOutputContains(t, output, "2 issues found")
 	})
+
+	t.Run("MaxLineLengthValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/max_line_length_valid.md", "--config", "config-max-line-length.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "line exceeds")
+	})
+
+	t.Run("MaxLineLengthViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/max_line_length_violation.md", "--config", "config-max-line-length.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/max_line_length_violation.md:")
+		assertOutputContains(t, output, "fixtures/max_line_length_violation.md:5:")
+		assertOutputContains(t, output, "line exceeds 80 characters (100)")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -407,7 +424,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "emphasis used as heading")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_lists_violation.md:")
 		assertOutputContains(t, output, "list must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 36 file(s)")
+		assertOutputContains(t, output, "Checked 38 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -294,7 +294,7 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		}
 		assertOutputContains(t, output, "Errors in fixtures/max_line_length_violation.md:")
 		assertOutputContains(t, output, "fixtures/max_line_length_violation.md:5:")
-		assertOutputContains(t, output, "line exceeds 80 characters (100)")
+		assertOutputContains(t, output, "line exceeds 80 bytes (100)")
 		assertOutputContains(t, output, "1 issues found")
 	})
 }

--- a/e2e/fixtures/max_line_length_valid.md
+++ b/e2e/fixtures/max_line_length_valid.md
@@ -1,0 +1,13 @@
+## Max Line Length Valid
+
+All lines in this file are within the 80-character limit.
+
+Short prose that fits easily.
+
+- Item one
+- Item two
+
+```go
+fmt.Println("hello")
+```
+

--- a/e2e/fixtures/max_line_length_violation.md
+++ b/e2e/fixtures/max_line_length_violation.md
@@ -1,0 +1,6 @@
+## Max Line Length Violation
+
+This line is fine.
+
+This line is way too long and exceeds the eighty character limit set by the rule configuration here.
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const DefaultConfigJSON = `{
     "no-empty-links": true,
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
+    "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
@@ -218,6 +219,11 @@ func Default() Config {
 			"no-empty-links":          enabledRule(),
 			"no-emphasis-as-heading":  enabledRule(),
 			"blanks-around-lists":     enabledRule(),
+			"max-line-length": {
+				Enabled:  false,
+				Severity: SeverityOff,
+				Options:  map[string]interface{}{"lineLength": float64(80)},
+			},
 			"heading-level": {
 				Enabled:  true,
 				Severity: SeverityError,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -156,6 +156,17 @@ func (l *Linter) headingMinLevel() int {
 	return minLevel
 }
 
+// maxLineLength returns the configured lineLength for the max-line-length rule.
+func (l *Linter) maxLineLength() int {
+	lineLength := 80
+	if v, ok := l.config.RuleOptions("max-line-length")["lineLength"]; ok {
+		if f, ok := v.(float64); ok && int(f) > 0 {
+			lineLength = int(f)
+		}
+	}
+	return lineLength
+}
+
 // externalLinkTimeout returns the configured timeoutSeconds for the external-link rule.
 func (l *Linter) externalLinkTimeout() int {
 	timeoutSeconds := 5
@@ -211,6 +222,9 @@ func (l *Linter) collectLineErrors(path string, lines []string, offset int) []ru
 	}
 	if l.config.IsEnabled("blanks-around-lists") {
 		errs = append(errs, l.withSeverity(rule.CheckBlanksAroundLists(path, lines, offset), "blanks-around-lists")...)
+	}
+	if l.config.IsEnabled("max-line-length") {
+		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)
 	}
 	return errs
 }

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -178,50 +178,39 @@ func (l *Linter) externalLinkTimeout() int {
 	return timeoutSeconds
 }
 
+// simpleRules lists rules whose check function takes only (path, lines, offset).
+// Rules that require additional options are handled separately below.
+var simpleRules = []struct {
+	name string
+	fn   func(string, []string, int) []rule.LintError
+}{
+	{"final-blank-line", rule.CheckFinalBlankLine},
+	{"unclosed-code-block", rule.CheckUnclosedCodeBlocks},
+	{"empty-alt-text", rule.CheckEmptyAltText},
+	{"fenced-code-language", rule.CheckFencedCodeLanguage},
+	{"duplicate-heading", rule.CheckDuplicateHeadings},
+	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
+	{"no-setext-headings", rule.CheckNoSetextHeadings},
+	{"single-h1", rule.CheckSingleH1},
+	{"blanks-around-headings", rule.CheckBlanksAroundHeadings},
+	{"no-bare-urls", rule.CheckNoBareURLs},
+	{"no-empty-links", rule.CheckNoEmptyLinks},
+	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
+	{"blanks-around-lists", rule.CheckBlanksAroundLists},
+}
+
 // collectLineErrors runs all non-network rule checks and returns their errors.
 func (l *Linter) collectLineErrors(path string, lines []string, offset int) []rule.LintError {
 	var errs []rule.LintError
-	if l.config.IsEnabled("final-blank-line") {
-		errs = append(errs, l.withSeverity(rule.CheckFinalBlankLine(path, lines, offset), "final-blank-line")...)
+
+	for _, r := range simpleRules {
+		if l.config.IsEnabled(r.name) {
+			errs = append(errs, l.withSeverity(r.fn(path, lines, offset), r.name)...)
+		}
 	}
-	if l.config.IsEnabled("unclosed-code-block") {
-		errs = append(errs, l.withSeverity(rule.CheckUnclosedCodeBlocks(path, lines, offset), "unclosed-code-block")...)
-	}
-	if l.config.IsEnabled("empty-alt-text") {
-		errs = append(errs, l.withSeverity(rule.CheckEmptyAltText(path, lines, offset), "empty-alt-text")...)
-	}
+
 	if l.config.IsEnabled("heading-level") {
 		errs = append(errs, l.withSeverity(rule.CheckHeadingLevels(path, lines, offset, l.headingMinLevel()), "heading-level")...)
-	}
-	if l.config.IsEnabled("fenced-code-language") {
-		errs = append(errs, l.withSeverity(rule.CheckFencedCodeLanguage(path, lines, offset), "fenced-code-language")...)
-	}
-	if l.config.IsEnabled("duplicate-heading") {
-		errs = append(errs, l.withSeverity(rule.CheckDuplicateHeadings(path, lines, offset), "duplicate-heading")...)
-	}
-	if l.config.IsEnabled("no-multiple-blank-lines") {
-		errs = append(errs, l.withSeverity(rule.CheckNoMultipleBlankLines(path, lines, offset), "no-multiple-blank-lines")...)
-	}
-	if l.config.IsEnabled("no-setext-headings") {
-		errs = append(errs, l.withSeverity(rule.CheckNoSetextHeadings(path, lines, offset), "no-setext-headings")...)
-	}
-	if l.config.IsEnabled("single-h1") {
-		errs = append(errs, l.withSeverity(rule.CheckSingleH1(path, lines, offset), "single-h1")...)
-	}
-	if l.config.IsEnabled("blanks-around-headings") {
-		errs = append(errs, l.withSeverity(rule.CheckBlanksAroundHeadings(path, lines, offset), "blanks-around-headings")...)
-	}
-	if l.config.IsEnabled("no-bare-urls") {
-		errs = append(errs, l.withSeverity(rule.CheckNoBareURLs(path, lines, offset), "no-bare-urls")...)
-	}
-	if l.config.IsEnabled("no-empty-links") {
-		errs = append(errs, l.withSeverity(rule.CheckNoEmptyLinks(path, lines, offset), "no-empty-links")...)
-	}
-	if l.config.IsEnabled("no-emphasis-as-heading") {
-		errs = append(errs, l.withSeverity(rule.CheckNoEmphasisAsHeading(path, lines, offset), "no-emphasis-as-heading")...)
-	}
-	if l.config.IsEnabled("blanks-around-lists") {
-		errs = append(errs, l.withSeverity(rule.CheckBlanksAroundLists(path, lines, offset), "blanks-around-lists")...)
 	}
 	if l.config.IsEnabled("max-line-length") {
 		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -636,6 +636,73 @@ func TestRun_DisableComment_DisableNextLine(t *testing.T) {
 	}
 }
 
+func TestRun_MaxLineLength_DefaultLimit(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["max-line-length"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"lineLength": float64(80)},
+	}
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "long.md")
+	longLine := "This line is intentionally long and exceeds the eighty character limit set here!!\n"
+	if err := os.WriteFile(testFile, []byte(longLine), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors == 0 {
+		t.Error("expected error for line exceeding 80 characters")
+	}
+}
+
+func TestRun_MaxLineLength_CustomLimit(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["max-line-length"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"lineLength": float64(120)},
+	}
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "long.md")
+	// 100 chars — within 120 limit
+	shortEnough := make([]byte, 100)
+	for i := range shortEnough {
+		shortEnough[i] = 'a'
+	}
+	content := string(shortEnough) + "\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors != 0 {
+		t.Errorf("expected no errors for 100-char line with limit=120, got %d", result.TotalErrors)
+	}
+}
+
+func TestRun_MaxLineLength_NoOptionFallsBackToDefault(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["max-line-length"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{},
+	}
+
+	linter := New(cfg)
+	if linter.maxLineLength() != 80 {
+		t.Errorf("expected default maxLineLength 80, got %d", linter.maxLineLength())
+	}
+}
+
 func TestRun_DisableComment_NoDisableKeyword_NoOverhead(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-bare-urls"] = on()

--- a/internal/rule/max_line_length.go
+++ b/internal/rule/max_line_length.go
@@ -5,14 +5,25 @@ import (
 	"strings"
 )
 
-// isBareURLLine reports whether the trimmed line consists solely of a URL
-// (http:// or https://), possibly wrapped in angle brackets.
+// isBareURLLine reports whether the trimmed line consists solely of a single
+// URL token (http:// or https://), possibly wrapped in angle brackets.
+// Lines like "https://example.com extra text" are NOT exempt.
 func isBareURLLine(trimmed string) bool {
 	s := trimmed
 	if strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">") {
 		s = s[1 : len(s)-1]
 	}
-	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+	var schemeLen int
+	if strings.HasPrefix(s, "https://") {
+		schemeLen = len("https://")
+	} else if strings.HasPrefix(s, "http://") {
+		schemeLen = len("http://")
+	} else {
+		return false
+	}
+	// The body after the scheme must not contain whitespace — ensuring
+	// the entire line is exactly one URL token with no surrounding text.
+	return !strings.ContainsAny(s[schemeLen:], " \t")
 }
 
 // CheckMaxLineLength flags lines whose byte length exceeds lineLength.
@@ -41,7 +52,7 @@ func CheckMaxLineLength(filename string, lines []string, offset int, lineLength 
 			continue
 		}
 
-		if strings.HasPrefix(trimmed, "#") {
+		if isATXHeading(trimmed) {
 			continue
 		}
 
@@ -53,7 +64,7 @@ func CheckMaxLineLength(filename string, lines []string, offset int, lineLength 
 			errs = append(errs, LintError{
 				File:    filename,
 				Line:    offset + i + 1,
-				Message: fmt.Sprintf("max-line-length: line exceeds %d characters (%d)", lineLength, len(line)),
+				Message: fmt.Sprintf("max-line-length: line exceeds %d bytes (%d)", lineLength, len(line)),
 			})
 		}
 	}

--- a/internal/rule/max_line_length.go
+++ b/internal/rule/max_line_length.go
@@ -1,0 +1,62 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// isBareURLLine reports whether the trimmed line consists solely of a URL
+// (http:// or https://), possibly wrapped in angle brackets.
+func isBareURLLine(trimmed string) bool {
+	s := trimmed
+	if strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">") {
+		s = s[1 : len(s)-1]
+	}
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// CheckMaxLineLength flags lines whose byte length exceeds lineLength.
+// Lines inside fenced code blocks, ATX heading lines, and lines that consist
+// solely of a URL are exempt.
+func CheckMaxLineLength(filename string, lines []string, offset int, lineLength int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		marker := openingFenceMarker(trimmed)
+		if marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if isBareURLLine(trimmed) {
+			continue
+		}
+
+		if len(line) > lineLength {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + i + 1,
+				Message: fmt.Sprintf("max-line-length: line exceeds %d characters (%d)", lineLength, len(line)),
+			})
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/max_line_length_bench_test.go
+++ b/internal/rule/max_line_length_bench_test.go
@@ -1,0 +1,27 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func generateMarkdownWithLongLines(sections int) string {
+	var sb strings.Builder
+	for i := 1; i <= sections; i++ {
+		sb.WriteString(fmt.Sprintf("## Section %d\n\n", i))
+		sb.WriteString("Short line.\n\n")
+		// one long line per section
+		sb.WriteString(strings.Repeat("a", 100) + "\n\n")
+	}
+	return sb.String()
+}
+
+func BenchmarkCheckMaxLineLength(b *testing.B) {
+	content := generateMarkdownWithLongLines(1000)
+	lines := strings.Split(content, "\n")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		CheckMaxLineLength("bench.md", lines, 0, 80)
+	}
+}

--- a/internal/rule/max_line_length_test.go
+++ b/internal/rule/max_line_length_test.go
@@ -41,19 +41,19 @@ func TestCheckMaxLineLength(t *testing.T) {
 		},
 		{
 			name:       "valid: bare https URL line exempt",
-			content:    "https://example.com/very/long/path/that/exceeds/eighty/characters/in/total/length\n",
+			content:    "https://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/length\n",
 			lineLength: 80,
 			wantErrs:   nil,
 		},
 		{
 			name:       "valid: bare http URL line exempt",
-			content:    "http://example.com/very/long/path/that/exceeds/eighty/characters/in/total/length\n",
+			content:    "http://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/length\n",
 			lineLength: 80,
 			wantErrs:   nil,
 		},
 		{
 			name:       "valid: angle-bracket URL line exempt",
-			content:    "<https://example.com/very/long/path/that/exceeds/eighty/characters/in/total/>\n",
+			content:    "<https://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/>\n",
 			lineLength: 80,
 			wantErrs:   nil,
 		},
@@ -75,13 +75,19 @@ func TestCheckMaxLineLength(t *testing.T) {
 			lineLength: 80,
 			wantErrs:   nil,
 		},
+		{
+			name:       "valid: URL-only line with no extra text exempt",
+			content:    "https://example.com/very/long/path/that/exceeds/eighty/characters/total/length/x\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
 		// ── invalid cases ────────────────────────────────────────────────────
 		{
 			name:       "invalid: line one char over limit",
 			content:    strings.Repeat("a", 81) + "\n",
 			lineLength: 80,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 characters (81)"},
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 bytes (81)"},
 			},
 		},
 		{
@@ -89,8 +95,8 @@ func TestCheckMaxLineLength(t *testing.T) {
 			content:    strings.Repeat("a", 85) + "\n" + "ok\n" + strings.Repeat("b", 90) + "\n",
 			lineLength: 80,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 characters (85)"},
-				{File: "test.md", Line: 3, Message: "max-line-length: line exceeds 80 characters (90)"},
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 bytes (85)"},
+				{File: "test.md", Line: 3, Message: "max-line-length: line exceeds 80 bytes (90)"},
 			},
 		},
 		{
@@ -98,7 +104,7 @@ func TestCheckMaxLineLength(t *testing.T) {
 			content:    strings.Repeat("a", 101) + "\n",
 			lineLength: 100,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 100 characters (101)"},
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 100 bytes (101)"},
 			},
 		},
 		{
@@ -107,7 +113,7 @@ func TestCheckMaxLineLength(t *testing.T) {
 			lineLength: 80,
 			offset:     5,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 6, Message: "max-line-length: line exceeds 80 characters (81)"},
+				{File: "test.md", Line: 6, Message: "max-line-length: line exceeds 80 bytes (81)"},
 			},
 		},
 		{
@@ -116,7 +122,7 @@ func TestCheckMaxLineLength(t *testing.T) {
 			content:    "See https://example.com for details on " + strings.Repeat("a", 50) + ".\n",
 			lineLength: 80,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: fmt.Sprintf("max-line-length: line exceeds 80 characters (%d)", len("See https://example.com for details on "+strings.Repeat("a", 50)+"."))},
+				{File: "test.md", Line: 1, Message: fmt.Sprintf("max-line-length: line exceeds 80 bytes (%d)", len("See https://example.com for details on "+strings.Repeat("a", 50)+"."))},
 			},
 		},
 		{
@@ -124,7 +130,25 @@ func TestCheckMaxLineLength(t *testing.T) {
 			content:    "```go\n" + strings.Repeat("x", 100) + "\n```\n" + strings.Repeat("y", 81) + "\n",
 			lineLength: 80,
 			wantErrs: []LintError{
-				{File: "test.md", Line: 4, Message: "max-line-length: line exceeds 80 characters (81)"},
+				{File: "test.md", Line: 4, Message: "max-line-length: line exceeds 80 bytes (81)"},
+			},
+		},
+		{
+			name: "invalid: hash-tag line is not a heading and must be checked",
+			// "#not-a-heading" has no space after #, so it is not an ATX heading
+			content:    "#" + strings.Repeat("a", 80) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 bytes (81)"},
+			},
+		},
+		{
+			name: "invalid: URL at start of line with trailing text is not exempt",
+			// starts with a URL but has additional text after a space
+			content:    "https://example.com " + strings.Repeat("a", 65) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: fmt.Sprintf("max-line-length: line exceeds 80 bytes (%d)", len("https://example.com "+strings.Repeat("a", 65)))},
 			},
 		},
 	}

--- a/internal/rule/max_line_length_test.go
+++ b/internal/rule/max_line_length_test.go
@@ -1,0 +1,153 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCheckMaxLineLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		lineLength int
+		offset     int
+		wantErrs   []LintError
+	}{
+		// ── valid cases ──────────────────────────────────────────────────────
+		{
+			name:       "valid: short line",
+			content:    "Short line.\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: line exactly at limit",
+			content:    strings.Repeat("a", 80) + "\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: heading exempt",
+			content:    "## " + strings.Repeat("a", 100) + "\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: h1 heading exempt",
+			content:    "# " + strings.Repeat("a", 100) + "\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: bare https URL line exempt",
+			content:    "https://example.com/very/long/path/that/exceeds/eighty/characters/in/total/length\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: bare http URL line exempt",
+			content:    "http://example.com/very/long/path/that/exceeds/eighty/characters/in/total/length\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: angle-bracket URL line exempt",
+			content:    "<https://example.com/very/long/path/that/exceeds/eighty/characters/in/total/>\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: long line inside fenced code block",
+			content:    "```go\n" + strings.Repeat("x", 100) + "\n```\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: long line inside tilde fence",
+			content:    "~~~sh\n" + strings.Repeat("y", 100) + "\n~~~\n",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		{
+			name:       "valid: empty file",
+			content:    "",
+			lineLength: 80,
+			wantErrs:   nil,
+		},
+		// ── invalid cases ────────────────────────────────────────────────────
+		{
+			name:       "invalid: line one char over limit",
+			content:    strings.Repeat("a", 81) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 characters (81)"},
+			},
+		},
+		{
+			name:       "invalid: multiple violations",
+			content:    strings.Repeat("a", 85) + "\n" + "ok\n" + strings.Repeat("b", 90) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 80 characters (85)"},
+				{File: "test.md", Line: 3, Message: "max-line-length: line exceeds 80 characters (90)"},
+			},
+		},
+		{
+			name:       "invalid: custom line length",
+			content:    strings.Repeat("a", 101) + "\n",
+			lineLength: 100,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "max-line-length: line exceeds 100 characters (101)"},
+			},
+		},
+		{
+			name:       "invalid: offset shifts line numbers",
+			content:    strings.Repeat("a", 81) + "\n",
+			lineLength: 80,
+			offset:     5,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 6, Message: "max-line-length: line exceeds 80 characters (81)"},
+			},
+		},
+		{
+			name: "invalid: prose line with URL in middle",
+			// "See https://example.com for details on " (39) + 50 "a"s + "." = 90 chars
+			content:    "See https://example.com for details on " + strings.Repeat("a", 50) + ".\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: fmt.Sprintf("max-line-length: line exceeds 80 characters (%d)", len("See https://example.com for details on "+strings.Repeat("a", 50)+"."))},
+			},
+		},
+		{
+			name:       "valid: long line after closing fence is checked",
+			content:    "```go\n" + strings.Repeat("x", 100) + "\n```\n" + strings.Repeat("y", 81) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 4, Message: "max-line-length: line exceeds 80 characters (81)"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckMaxLineLength("test.md", lines, tt.offset, tt.lineLength)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i].File != tt.wantErrs[i].File {
+					t.Errorf("[%d] file: got %q, want %q", i, got[i].File, tt.wantErrs[i].File)
+				}
+				if got[i].Line != tt.wantErrs[i].Line {
+					t.Errorf("[%d] line: got %d, want %d", i, got[i].Line, tt.wantErrs[i].Line)
+				}
+				if got[i].Message != tt.wantErrs[i].Message {
+					t.Errorf("[%d] message: got %q, want %q", i, got[i].Message, tt.wantErrs[i].Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `max-line-length` rule that flags lines exceeding a configurable byte limit (default: 80)
- Heading lines, fenced code block contents, and bare URL-only lines are exempt
- Rule is disabled by default (opt-in via config `"max-line-length": { "enabled": true, "lineLength": 80 }`)
- Refactor `collectLineErrors` into a `simpleRules` table to keep cyclomatic complexity within lint limits

Closes #144
Part of #76 (Priority 2)

## Test plan

- [x] Unit tests: valid lines, exact limit, 1-over, multiple violations, custom `lineLength`, code block exempt, heading exempt, URL-only line exempt, offset shift
- [x] Benchmark added
- [x] E2E: valid fixture (no violations) and violation fixture (line 5, 100 chars)
- [x] `make test-all` passes (unit + e2e + static lint)
- [x] Coverage: `max_line_length.go` 100%