### PR TITLE
docs: update .gomarklint.example.json to v2 config format

### DIFF
--- a/.claude/rule-implementation-checklist.md
+++ b/.claude/rule-implementation-checklist.md
@@ -12,6 +12,7 @@ Follow this checklist whenever adding a new rule (e.g. `fenced-code-language`, `
 
 - [ ] `internal/config/config.go` — add to `Default()` AND `DefaultConfigJSON` (keep in sync)
 - [ ] `internal/linter/linter.go` — register in `collectErrors()`
+- [ ] `.gomarklint.example.json` — copy exact content from `DefaultConfigJSON` (do not hand-write)
 - [ ] `e2e/e2e_test.go` — add E2E test case, update file/violation counts if needed
 
 ## Code review checklist

--- a/.gomarklint.example.json
+++ b/.gomarklint.example.json
@@ -18,7 +18,7 @@
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
-  "include": ["README.md", "docs"],
+  "include": ["README.md", "testdata"],
   "ignore": [],
   "output": "text"
 }

--- a/.gomarklint.example.json
+++ b/.gomarklint.example.json
@@ -1,13 +1,24 @@
 {
-  "minHeadingLevel": 2,
-  "enableLinkCheck": false,
-  "skipLinkPatterns": [
-    "localhost",
-    "example.com"
-  ],
+  "default": true,
+  "rules": {
+    "final-blank-line": true,
+    "unclosed-code-block": true,
+    "empty-alt-text": true,
+    "fenced-code-language": true,
+    "heading-level": { "severity": "error", "minLevel": 2 },
+    "duplicate-heading": true,
+    "no-multiple-blank-lines": true,
+    "no-setext-headings": true,
+    "single-h1": true,
+    "blanks-around-headings": true,
+    "no-bare-urls": true,
+    "no-empty-links": true,
+    "no-emphasis-as-heading": true,
+    "blanks-around-lists": true,
+    "max-line-length": { "enabled": false, "lineLength": 80 },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
+  },
+  "include": ["README.md", "docs"],
   "ignore": [],
-  "output": "text",
-  "enableDuplicateHeadingCheck": true,
-  "enableHeadingLevelCheck": true,
-  "enableNoMultipleBlankLinesCheck": true
+  "output": "text"
 }

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,8 @@
 
 [English](README.md) | 日本語
 
+[![Demo](https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif)](https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a)
+
 > Go 製の超高速 Markdown リンター — **100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要、HTTP リンクバリデーション機能を内蔵。
 
 **かんたんインストール**（macOS / Linux）:

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,7 @@ npm install -g @shinagawa-web/gomarklint
 **`go install` を使う場合:**
 
 ```sh
-go install github.com/shinagawa-web/gomarklint@latest
+go install github.com/shinagawa-web/gomarklint/v2@latest
 ```
 
 - **100,000 行以上を約 170ms** で処理 — JIT ウォームアップなし、ランタイムオーバーヘッドなし。

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install -g @shinagawa-web/gomarklint
 **Via `go install`:**
 
 ```sh
-go install github.com/shinagawa-web/gomarklint@latest
+go install github.com/shinagawa-web/gomarklint/v2@latest
 ```
 
 - **100,000+ lines in ~170ms** — single binary, no JIT warmup, no runtime overhead.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 English | [日本語](README.ja.md)
 
+[![Demo](https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif)](https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a)
+
 > Blazing-fast Markdown linter built in Go — **100,000+ lines in ~170ms**. Single binary, no Node.js required, and built-in HTTP link validation.
 
 **Quick install** (macOS / Linux):

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -10,6 +10,8 @@ title: "gomarklint"
 [![Go Reference](https://pkg.go.dev/badge/github.com/shinagawa-web/gomarklint.svg)](https://pkg.go.dev/github.com/shinagawa-web/gomarklint)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/shinagawa-web/gomarklint/blob/main/LICENSE)
 
+[![Demo](https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif)](https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a)
+
 > Lint your Markdown like you lint your code.
 > A fast Markdown linter built in Go — for local dev and CI alike.
 


### PR DESCRIPTION
Closes the config example drift introduced by v2 migration.