### PR TITLE
feat: add -v / --version flag to print version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,8 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/shinagawa-web/gomarklint/v2/cmd.version={{.Version}}
     goos:
       - linux
       - windows

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,8 @@ func runLint(cmd *cobra.Command, args []string) error {
 }
 
 func init() {
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate("gomarklint version {{.Version}}\n")
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 	rootCmd.Flags().StringVar(&configFilePath, "config", ".gomarklint.json", "path to config file (default: .gomarklint.json)")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,5 @@
+package cmd
+
+// version is set at build time via ldflags.
+// Development builds default to "dev".
+var version = "dev"


### PR DESCRIPTION
## Summary

- Add `cmd/version.go` with `var version = "dev"` (overridden at release via ldflags)
- Set `rootCmd.Version = version` and `SetVersionTemplate` in `cmd/root.go`
- Add `-X github.com/shinagawa-web/gomarklint/v2/cmd.version={{.Version}}` to ldflags in `.goreleaser.yaml`

Closes #152

## Test plan

- [x] `make build && ./gomarklint -v` → `gomarklint version dev`
- [x] `make build && ./gomarklint --version` → `gomarklint version dev`
- [x] `make test-all` passes