### PR TITLE
fix(no-bare-urls): skip URLs inside HTML attributes and comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: shinagawa-web/gomarklint
-          files: ./coverage.txt
+          files: ./coverage/coverage.out
           fail_ci_if_error: true
 
       - name: Lint README

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: shinagawa-web/gomarklint
-          files: ./coverage/coverage.out
+          files: ./coverage.txt
           fail_ci_if_error: true
 
       - name: Lint README

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -200,6 +200,25 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputNotContains(t, output, "bare URL found")
 	})
 
+	t.Run("NoBareURLsHTMLAttributeValid", func(t *testing.T) {
+		// URLs inside href/src attributes must not be flagged.
+		output := runTest(t, "fixtures/no_bare_urls_valid.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/no_bare_urls_valid.md:9:")
+	})
+
+	t.Run("NoBareURLsHTMLCommentValid", func(t *testing.T) {
+		// URLs inside single-line HTML comments must not be flagged.
+		output := runTest(t, "fixtures/no_bare_urls_valid.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/no_bare_urls_valid.md:7:")
+	})
+
+	t.Run("NoBareURLsMultipleCommentsOnLineValid", func(t *testing.T) {
+		// URL inside second unclosed comment on same line must not be flagged.
+		output := runTest(t, "fixtures/no_bare_urls_valid.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/no_bare_urls_valid.md:11:")
+	})
+
+
 	t.Run("NoBareURLsViolation", func(t *testing.T) {
 		output, err := runTestWithCmd(t, "fixtures/no_bare_urls_violation.md", "--config", "config-no-bare-urls.json")
 		if err == nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -218,6 +218,13 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputNotContains(t, output, "fixtures/no_bare_urls_valid.md:11:")
 	})
 
+	t.Run("NoBareURLsFenceInsideCommentValid", func(t *testing.T) {
+		// Fence opener inside multi-line HTML comment must not be treated as a
+		// code block by either no-bare-urls or fenced-code-language.
+		output := runTest(t, "fixtures/no_bare_urls_valid.md", "--config", "config-no-bare-urls.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "Fenced code block must have a language identifier")
+	})
 
 	t.Run("NoBareURLsViolation", func(t *testing.T) {
 		output, err := runTestWithCmd(t, "fixtures/no_bare_urls_violation.md", "--config", "config-no-bare-urls.json")

--- a/e2e/fixtures/no_bare_urls_valid.md
+++ b/e2e/fixtures/no_bare_urls_valid.md
@@ -7,3 +7,7 @@ Use a Markdown link: [Example](https://example.com)
 <!-- FIXME update when issue is fixed https://example.com/ -->
 
 <a href="https://example.com"><img src="https://example.com/image.gif" width="800" alt="Demo"></a>
+
+<!-- closed comment --> <!-- unclosed with URL https://example.com
+still inside the second comment
+-->

--- a/e2e/fixtures/no_bare_urls_valid.md
+++ b/e2e/fixtures/no_bare_urls_valid.md
@@ -11,3 +11,9 @@ Use a Markdown link: [Example](https://example.com)
 <!-- closed comment --> <!-- unclosed with URL https://example.com
 still inside the second comment
 -->
+
+<!--
+```
+https://example.com
+```
+-->

--- a/e2e/fixtures/no_bare_urls_valid.md
+++ b/e2e/fixtures/no_bare_urls_valid.md
@@ -3,3 +3,7 @@
 Use angle brackets: <https://example.com>
 
 Use a Markdown link: [Example](https://example.com)
+
+<!-- FIXME update when issue is fixed https://example.com/ -->
+
+<a href="https://example.com"><img src="https://example.com/image.gif" width="800" alt="Demo"></a>

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -12,7 +12,7 @@ var (
 	// Link pattern matchers
 	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://[^\s)]+)\)`)
 	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^\s)]+)\)`)
-	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://[^\s<>()]+).*?$`)
+	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://[^\s<>"'()]+).*?$`)
 )
 
 type cacheResult struct {

--- a/internal/rule/fenced_code_language.go
+++ b/internal/rule/fenced_code_language.go
@@ -16,8 +16,19 @@ func CheckFencedCodeLanguage(filename string, lines []string, offset int) []Lint
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""
+	inComment := false
 
 	for i, line := range lines {
+		// HTML comments take priority: fences inside comments are ignored.
+		if inComment {
+			if idx := strings.Index(line, "-->"); idx != -1 {
+				inComment = false
+				line = strings.Repeat(" ", idx+3) + line[idx+3:]
+			} else {
+				continue
+			}
+		}
+
 		trimmed := strings.TrimSpace(line)
 
 		if inBlock {
@@ -26,6 +37,14 @@ func CheckFencedCodeLanguage(filename string, lines []string, offset int) []Lint
 				fenceMarker = ""
 			}
 			continue
+		}
+
+		if strings.Contains(line, "<!--") {
+			_, endedInComment := stripHTMLComments(line)
+			if endedInComment {
+				inComment = true
+				continue
+			}
 		}
 
 		marker := openingFenceMarker(trimmed)

--- a/internal/rule/fenced_code_language_test.go
+++ b/internal/rule/fenced_code_language_test.go
@@ -125,6 +125,28 @@ func TestCheckFencedCodeLanguage(t *testing.T) {
 			content:  "~~~py\ncode\n~~~~~\n",
 			wantErrs: nil,
 		},
+		{
+			name:     "fence opener inside single-line HTML comment is ignored",
+			content:  "<!-- ```\nsome text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "fence opener inside multi-line HTML comment is ignored",
+			content:  "<!--\n```\ncode\n```\n-->\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "fence after closed multi-line HTML comment is flagged",
+			content: "<!--\ncomment\n-->\n```\ncode\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 4, Message: "Fenced code block must have a language identifier"},
+			},
+		},
+		{
+			name:     "fence opener on same line as --> closing comment is not flagged",
+			content:  "<!-- comment --> ``` not a fence\ntext\n",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -17,7 +17,7 @@ func countBacktickRun(s string, start int) int {
 
 // stripInlineCode replaces content inside backtick spans (including the
 // delimiters) with spaces so that URLs within inline code are not scanned.
-// Handles both single-backtick (` “ `) and multi-backtick (` “ `) spans per
+// Handles both single-backtick (` " `) and multi-backtick (` " `) spans per
 // CommonMark: a code span opens with a run of N backticks and closes with the
 // next run of exactly N backticks.
 func stripInlineCode(s string) string {
@@ -68,14 +68,14 @@ func stripInlineCode(s string) string {
 }
 
 // isURLBodyChar returns true for characters allowed in a URL body
-// (everything except whitespace and <>()[].)
+// (everything except whitespace, <>, ()[], and quotes).
 func isURLBodyChar(c byte) bool {
-	return c > ' ' && c != '<' && c != '>' && c != '(' && c != ')' && c != '[' && c != ']'
+	return c > ' ' && c != '<' && c != '>' && c != '(' && c != ')' && c != '[' && c != ']' && c != '"' && c != '\''
 }
 
 // isWrappedURL returns true if the URL starting at start in line is wrapped
 // in angle brackets, is a Markdown link/image destination, or appears inside
-// an HTML attribute value (quoted with " or ').
+// an HTML attribute value (a quote immediately preceded by '=').
 func isWrappedURL(line string, start int) bool {
 	if start > 0 && line[start-1] == '<' {
 		return true
@@ -83,13 +83,23 @@ func isWrappedURL(line string, start int) bool {
 	if start > 1 && line[start-1] == '(' && line[start-2] == ']' {
 		return true
 	}
-	return start > 0 && (line[start-1] == '"' || line[start-1] == '\'')
+	// HTML attribute value: require an '=' before the opening quote,
+	// optionally separated by whitespace (e.g. href="..." or attr = "...").
+	if start > 0 && (line[start-1] == '"' || line[start-1] == '\'') {
+		i := start - 2
+		for i >= 0 && (line[i] == ' ' || line[i] == '\t') {
+			i--
+		}
+		return i >= 0 && line[i] == '='
+	}
+	return false
 }
 
 // stripHTMLComments replaces content inside <!-- ... --> spans (including the
 // delimiters) with spaces so that URLs within HTML comments are not scanned.
-// Only handles comments that open and close on the same line.
-func stripHTMLComments(s string) string {
+// It handles multiple comment spans on a single line. The second return value
+// reports whether the line ended inside an unclosed comment.
+func stripHTMLComments(s string) (string, bool) {
 	var b strings.Builder
 	b.Grow(len(s))
 	for i := 0; i < len(s); {
@@ -100,7 +110,7 @@ func stripHTMLComments(s string) string {
 				for k := i; k < len(s); k++ {
 					b.WriteByte(' ')
 				}
-				return b.String()
+				return b.String(), true
 			}
 			spanLen := 4 + end + 3
 			for k := 0; k < spanLen; k++ {
@@ -112,7 +122,7 @@ func stripHTMLComments(s string) string {
 			i++
 		}
 	}
-	return b.String()
+	return b.String(), false
 }
 
 // scanURLEnd returns the end index of the URL body starting at bodyStart.
@@ -161,9 +171,37 @@ func findBareURLs(line string) []string {
 	return urls
 }
 
+// advanceComment advances a line that is currently inside a multi-line HTML
+// comment. It returns the (possibly modified) line and the updated inComment
+// state. If "-->" is found, inComment becomes false and the remainder of the
+// line after "-->" is returned for further processing.
+func advanceComment(line string) (string, bool) {
+	idx := strings.Index(line, "-->")
+	if idx == -1 {
+		return line, true
+	}
+	return strings.Repeat(" ", idx+3) + line[idx+3:], false
+}
+
+// prepareScanned strips inline code and HTML comments from line, returning the
+// sanitized string and whether the line ended inside an unclosed comment.
+func prepareScanned(line string) (string, bool) {
+	scanned := line
+	if strings.ContainsRune(scanned, '`') {
+		scanned = stripInlineCode(scanned)
+	}
+	if strings.Contains(scanned, "<!--") {
+		var endedInComment bool
+		scanned, endedInComment = stripHTMLComments(scanned)
+		return scanned, endedInComment
+	}
+	return scanned, false
+}
+
 // CheckNoBareURLs flags HTTP/HTTPS URLs that appear as bare text rather than
 // being wrapped in angle brackets or used inside a Markdown link or image.
-// URLs inside fenced code blocks and inline code spans are ignored.
+// URLs inside fenced code blocks, inline code spans, HTML comments, and HTML
+// attribute values are ignored.
 func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
 	inBlock := false
@@ -171,6 +209,18 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 	inComment := false
 
 	for i, line := range lines {
+		// Multi-line HTML comment tracking takes priority: fences inside
+		// comments are not treated as code block delimiters.
+		if inComment {
+			var stillInComment bool
+			line, stillInComment = advanceComment(line)
+			if stillInComment {
+				continue
+			}
+			inComment = false
+			// Fall through to process the remainder of the line.
+		}
+
 		trimmed := strings.TrimSpace(line)
 
 		if inBlock {
@@ -181,40 +231,22 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
+		if marker := openingFenceMarker(trimmed); marker != "" {
 			inBlock = true
 			fenceMarker = marker
 			continue
 		}
 
-		// Multi-line HTML comment tracking.
-		if inComment {
-			if idx := strings.Index(line, "-->"); idx != -1 {
-				inComment = false
-				line = strings.Repeat(" ", idx+3) + line[idx+3:]
-			} else {
-				continue
-			}
-		}
-
 		if !strings.Contains(line, "http") {
-			// Still check for comment open even on non-http lines.
-			if strings.Contains(line, "<!--") && !strings.Contains(line, "-->") {
-				inComment = true
+			if strings.Contains(line, "<!--") {
+				_, inComment = stripHTMLComments(line)
 			}
 			continue
 		}
 
-		scanned := line
-		if strings.ContainsRune(scanned, '`') {
-			scanned = stripInlineCode(scanned)
-		}
-		if strings.Contains(scanned, "<!--") {
-			if !strings.Contains(scanned[strings.Index(scanned, "<!--")+4:], "-->") {
-				inComment = true
-			}
-			scanned = stripHTMLComments(scanned)
+		scanned, endedInComment := prepareScanned(line)
+		if endedInComment {
+			inComment = true
 		}
 
 		for _, url := range findBareURLs(scanned) {

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -74,12 +74,45 @@ func isURLBodyChar(c byte) bool {
 }
 
 // isWrappedURL returns true if the URL starting at start in line is wrapped
-// in angle brackets or is a Markdown link/image destination.
+// in angle brackets, is a Markdown link/image destination, or appears inside
+// an HTML attribute value (quoted with " or ').
 func isWrappedURL(line string, start int) bool {
 	if start > 0 && line[start-1] == '<' {
 		return true
 	}
-	return start > 1 && line[start-1] == '(' && line[start-2] == ']'
+	if start > 1 && line[start-1] == '(' && line[start-2] == ']' {
+		return true
+	}
+	return start > 0 && (line[start-1] == '"' || line[start-1] == '\'')
+}
+
+// stripHTMLComments replaces content inside <!-- ... --> spans (including the
+// delimiters) with spaces so that URLs within HTML comments are not scanned.
+// Only handles comments that open and close on the same line.
+func stripHTMLComments(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+4 <= len(s) && s[i:i+4] == "<!--" {
+			end := strings.Index(s[i+4:], "-->")
+			if end == -1 {
+				// Unclosed comment — blank the rest of the line.
+				for k := i; k < len(s); k++ {
+					b.WriteByte(' ')
+				}
+				return b.String()
+			}
+			spanLen := 4 + end + 3
+			for k := 0; k < spanLen; k++ {
+				b.WriteByte(' ')
+			}
+			i += spanLen
+		} else {
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return b.String()
 }
 
 // scanURLEnd returns the end index of the URL body starting at bodyStart.
@@ -135,6 +168,7 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""
+	inComment := false
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -154,13 +188,33 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 			continue
 		}
 
+		// Multi-line HTML comment tracking.
+		if inComment {
+			if idx := strings.Index(line, "-->"); idx != -1 {
+				inComment = false
+				line = strings.Repeat(" ", idx+3) + line[idx+3:]
+			} else {
+				continue
+			}
+		}
+
 		if !strings.Contains(line, "http") {
+			// Still check for comment open even on non-http lines.
+			if strings.Contains(line, "<!--") && !strings.Contains(line, "-->") {
+				inComment = true
+			}
 			continue
 		}
 
 		scanned := line
-		if strings.ContainsRune(line, '`') {
-			scanned = stripInlineCode(line)
+		if strings.ContainsRune(scanned, '`') {
+			scanned = stripInlineCode(scanned)
+		}
+		if strings.Contains(scanned, "<!--") {
+			if !strings.Contains(scanned[strings.Index(scanned, "<!--")+4:], "-->") {
+				inComment = true
+			}
+			scanned = stripHTMLComments(scanned)
 		}
 
 		for _, url := range findBareURLs(scanned) {

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -159,6 +159,43 @@ func TestCheckNoBareURLs(t *testing.T) {
 			content:  "<https://example.com>\n",
 			wantErrs: nil,
 		},
+		{
+			name:     "valid: URL inside HTML href attribute",
+			content:  `<a href="https://example.com">link</a>` + "\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: URL inside HTML src attribute",
+			content:  `<img src="https://example.com/image.gif" alt="Demo">` + "\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: multiple URLs inside HTML attributes on one line",
+			content:  `<a href="https://example.com"><img src="https://example.com/image.gif" width="800" alt="Demo"></a>` + "\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: URL inside single-quoted HTML attribute",
+			content:  `<a href='https://example.com'>link</a>` + "\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: URL inside single-line HTML comment",
+			content:  "<!-- FIXME update when fixed https://example.com/ -->\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: URL inside multi-line HTML comment",
+			content:  "<!--\nhttps://example.com\n-->\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: bare URL after closed HTML comment on same line",
+			content: "<!-- comment --> https://example.com\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -190,6 +190,11 @@ func TestCheckNoBareURLs(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
+			name:     "valid: URL on same line as opening HTML comment tag (unclosed on that line)",
+			content:  "<!-- https://example.com\n-->\nMore text\n",
+			wantErrs: nil,
+		},
+		{
 			name:    "invalid: bare URL after closed HTML comment on same line",
 			content: "<!-- comment --> https://example.com\n",
 			wantErrs: []LintError{

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -201,6 +201,32 @@ func TestCheckNoBareURLs(t *testing.T) {
 				{File: "test.md", Line: 1, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
 			},
 		},
+		{
+			name:    "invalid: URL surrounded by double quotes in normal prose is still flagged",
+			content: "See \"https://example.com\" for details.\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
+			},
+		},
+		{
+			name:    "invalid: URL surrounded by single quotes in normal prose is still flagged",
+			content: "See 'https://example.com' for details.\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
+			},
+		},
+		{
+			name:     "valid: multiple HTML comments on one line — second unclosed sets inComment",
+			content:  "<!-- closed --> <!-- https://example.com\nstill inside comment\n-->\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "valid: fence opener inside multi-line HTML comment is not treated as code block",
+			content: "<!--\n```\nhttps://example.com\n```\n-->\nhttps://after.example.com is bare\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 6, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://after.example.com"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- URLs inside HTML attribute values (`href="..."`, `src='...'`) are no longer flagged as bare URLs
- URLs inside HTML comments (`<!-- ... -->`) are no longer flagged, including multi-line comments
- `external-link`: fixed `bareURLPattern` regex to exclude `"` and `'` from URL body, preventing `https://example.com"` false positives

Closes #150

## How it works

**no-bare-urls:**
- `isWrappedURL`: added check for `"` or `'` preceding the URL
- `stripHTMLComments`: new helper that replaces `<!-- ... -->` spans with spaces (same approach as `stripInlineCode`)
- `CheckNoBareURLs`: added `inComment` state tracking for multi-line HTML comments

**external-link:**
- `bareURLPattern`: added `"'` to excluded characters so attribute quotes are not included in extracted URLs

## Test plan

- [x] Unit tests added for HTML attributes (double/single quote, multiple), single-line comments, multi-line comments, bare URL after closed comment
- [x] e2e fixture `no_bare_urls_valid.md` updated with HTML comment and HTML tag examples
- [x] `make test-all` passes
- [x] `make static-lint` passes