### PR TITLE
chore: set up GitHub Community Standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report a problem with gomarklint
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## Overview
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to reproduce
+
+1. Create a Markdown file with the following content:
+   ```md
+   <!-- paste your example here -->
+   ```
+2. Run: `gomarklint <file>`
+3. See error / unexpected output
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+
+<!-- What actually happened? Paste the full output. -->
+
+## Environment
+
+- gomarklint version: <!-- run `gomarklint --version` -->
+- OS: <!-- e.g. macOS 14, Ubuntu 22.04, Windows 11 -->
+- Go version (if building from source): <!-- `go version` -->
+
+## Additional context
+
+<!-- Any other context, config file contents, or screenshots. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Suggest a new lint rule or other improvement
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Overview
+
+<!-- A clear and concise description of the feature or new rule you'd like. -->
+
+## Problem
+
+<!-- What problem does this solve? What is currently missing or broken? -->
+
+## Proposed solution
+
+<!-- Describe the behavior you'd like. For a new lint rule, include:
+  - Rule key (e.g. MD999)
+  - Detection logic
+  - Examples of passing / failing Markdown
+-->
+
+### Examples
+
+| Input | Expected result |
+|-------|----------------|
+| `...` | pass / fail     |
+
+## References
+
+<!-- Links to markdownlint, remark-lint, or CommonMark spec for comparable rules. -->
+
+## Additional context
+
+<!-- Any other context or screenshots. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do? Link the related issue: Closes #NNN -->
+
+## Changes
+
+<!-- Bullet list of the key changes made. -->
+
+## Test plan
+
+- [ ] `make test` passes
+- [ ] `make test-e2e` passes
+- [ ] `make static-lint` passes
+- [ ] New behavior is covered by tests
+- [ ] `make test-all` passes locally
+
+## Notes
+
+<!-- Anything reviewers should pay special attention to, trade-offs made, or follow-up work. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in this project a welcoming and respectful experience for everyone, regardless of background or identity.
+
+## Expected behavior
+
+- Be respectful and considerate in all interactions
+- Welcome newcomers and help them get started
+- Give and accept constructive feedback graciously
+- Focus on what is best for the community and the project
+
+## Unacceptable behavior
+
+- Harassment, intimidation, or discrimination of any kind
+- Offensive or derogatory comments
+- Personal attacks or trolling
+- Publishing others' private information without permission
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening a private issue or contacting the maintainers directly. All reports will be reviewed and investigated promptly and fairly.
+
+Maintainers have the right to remove, edit, or reject contributions that do not align with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ We are committed to making participation in this project a welcoming and respect
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported by opening a private issue or contacting the maintainers directly. All reports will be reviewed and investigated promptly and fairly.
+Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainers directly via email. All reports will be reviewed and investigated promptly and fairly.
 
 Maintainers have the right to remove, edit, or reject contributions that do not align with this Code of Conduct.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,6 @@ Always run `make test-all` before opening a pull request.
 - Use the imperative mood: _"Add rule MD013"_, not _"Added rule MD013"_
 - Reference the related issue number: `feat: add max-line-length rule (MD013) (#145)`
 - Keep the subject line under 72 characters
-- No `Co-Authored-By` trailer
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,12 @@ Always run `make test-all` before opening a pull request.
 
 ## Adding a new lint rule
 
-1. Create the rule implementation under `internal/rules/`.
+1. Create the rule implementation under `internal/rule/`.
 2. Register the rule in the linter.
-3. Add unit tests in `internal/rules/`.
+3. Add unit tests in `internal/rule/`.
 4. Add a testdata fixture under `testdata/`.
 5. Add an E2E test.
-6. Document the rule in `docs/`.
+6. Document the rule in `docs/content/docs/`.
 7. Update the config example if applicable.
 
 See the issue for rule [#106](https://github.com/shinagawa-web/gomarklint/issues/106) as a canonical example of the expected issue format and implementation plan.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ Thank you for your interest in contributing! This guide explains how to set up t
 ## Getting started
 
 ```sh
-git clone https://github.com/shinagawa-web/gomarklint.git
+# Fork the repository on GitHub, then clone your fork
+git clone https://github.com/<your-username>/gomarklint.git
 cd gomarklint
 
 # Install pre-push hooks (runs lint + unit tests before every push)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to gomarklint
+
+Thank you for your interest in contributing! This guide explains how to set up the development environment, run tests, and submit changes.
+
+## Prerequisites
+
+- **Go 1.23+** — [install](https://go.dev/dl/)
+- **Make** — standard on macOS/Linux; on Windows use WSL or Git Bash
+- **Git**
+
+## Getting started
+
+```sh
+git clone https://github.com/shinagawa-web/gomarklint.git
+cd gomarklint
+
+# Install pre-push hooks (runs lint + unit tests before every push)
+make install-hooks
+```
+
+## Development workflow
+
+### Build & test
+
+| Task | Command |
+|---|---|
+| Build binary | `make build` |
+| Unit tests | `make test` |
+| E2E tests | `make test-e2e` |
+| All tests | `make test-all` |
+| Benchmarks | `make bench` |
+| Static analysis | `make static-lint` |
+
+Always run `make test-all` before opening a pull request.
+
+### Making changes
+
+1. **Open an issue first.** For anything beyond a trivial typo fix, open (or find) an issue and discuss the approach before writing code. This avoids wasted effort on work that won't be merged.
+2. **Create a feature branch** from `main`:
+   ```sh
+   git checkout -b your-branch-name
+   ```
+3. **Keep your branch up to date** with rebase, never merge:
+   ```sh
+   git fetch origin main && git rebase origin/main
+   ```
+4. **Write tests** for any new behavior. New lint rules require both unit tests and an E2E test.
+5. **Run `make test-all`** to confirm everything passes before pushing.
+
+## Commit messages
+
+- Use the imperative mood: _"Add rule MD013"_, not _"Added rule MD013"_
+- Reference the related issue number: `feat: add max-line-length rule (MD013) (#145)`
+- Keep the subject line under 72 characters
+- No `Co-Authored-By` trailer
+
+## Pull requests
+
+- Title should match the conventional-commits style used in this repo (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
+- Fill in the PR template completely
+- Link the PR to the issue it resolves (`Closes #NNN`)
+- A maintainer will review; please address feedback promptly
+
+## Adding a new lint rule
+
+1. Create the rule implementation under `internal/rules/`.
+2. Register the rule in the linter.
+3. Add unit tests in `internal/rules/`.
+4. Add a testdata fixture under `testdata/`.
+5. Add an E2E test.
+6. Document the rule in `docs/`.
+7. Update the config example if applicable.
+
+See the issue for rule [#106](https://github.com/shinagawa-web/gomarklint/issues/106) as a canonical example of the expected issue format and implementation plan.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Please be respectful and inclusive in all interactions.


### PR DESCRIPTION
## Summary

Closes #154

Adds all missing GitHub Community Standards files so new contributors have clear guidance when landing on the repo.

## Changes

- `CONTRIBUTING.md` — dev environment setup, `make` targets, branch/commit conventions, issue-before-PR workflow, new lint rule checklist
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request / new rule template
- `.github/pull_request_template.md` — PR checklist
- `CODE_OF_CONDUCT.md` — contributor conduct guidelines

## Test plan

- [ ] No code changes; files are documentation/templates only
- [ ] Verified all files render correctly as Markdown