### PR TITLE
docs: add FAQ & Troubleshooting page

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -104,6 +104,7 @@ repos:
 - [CLI リファレンス](https://shinagawa-web.github.io/gomarklint/docs/cli/)
 - [設定](https://shinagawa-web.github.io/gomarklint/docs/configuration/)
 - [GitHub Actions 連携](https://shinagawa-web.github.io/gomarklint/docs/github-actions/)
+- [FAQ & トラブルシューティング](https://shinagawa-web.github.io/gomarklint/docs/faq/)
 
 ## コントリビュート
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Full documentation is available at **[shinagawa-web.github.io/gomarklint](https:
 - [CLI Reference](https://shinagawa-web.github.io/gomarklint/docs/cli/)
 - [Configuration](https://shinagawa-web.github.io/gomarklint/docs/configuration/)
 - [GitHub Actions Integration](https://shinagawa-web.github.io/gomarklint/docs/github-actions/)
+- [FAQ & Troubleshooting](https://shinagawa-web.github.io/gomarklint/docs/faq/)
 
 ## Contributing
 

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -11,9 +11,9 @@ Quick answers to the most common problems. Each entry gives an immediate fix and
 
 ## Configuration
 
-### Config options are ignored / "unknown field" error
+### `unknown field: <field-name>`
 
-You are likely using a v1 config file with a v2 binary. v2 replaced the flat boolean fields (`enableLinkCheck`, `minHeadingLevel`, etc.) with a unified `rules` map.
+You are using a v1 config file with a v2 binary. v2 replaced the flat boolean fields (`enableLinkCheck`, `minHeadingLevel`, etc.) with a unified `rules` map.
 
 Run `gomarklint init` to generate a fresh v2 config, then migrate your settings.
 

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -43,7 +43,7 @@ Rule severity must be one of: `true`, `false`, `"error"`, `"warning"`, or `"off"
 
 ### `failed to access config file`
 
-The path passed to `--config` does not exist or is not readable. Check the path and verify the file is committed if running in CI.
+The file at the path passed to `--config` exists but cannot be accessed (for example, a permission error on the parent directory). If the file does not exist, `LoadOrDefault` falls back to the default configuration without an error. Check the file permissions and verify the file is committed if running in CI.
 
 → [CLI Reference](../cli/)
 
@@ -104,8 +104,8 @@ Go's default `User-Agent` (`Go-http-client/1.1`) is blocked by CDN-level bot pro
 
 **Workarounds:**
 
-- Add `"allowedStatuses": [403]` to your config to stop treating 403 as an error.
-- Add the domain to `skipPatterns` to skip it entirely.
+- Add the domain to `skipPatterns` to skip it during external link checks.
+- If only a few links are affected, verify them manually before treating the report as a real broken link.
 
 → [Configuration](../configuration/)
 

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -1,0 +1,148 @@
+---
+title: "FAQ & Troubleshooting"
+weight: 11
+---
+
+# FAQ & Troubleshooting
+
+Quick answers to the most common problems. Each entry gives an immediate fix and points to deeper docs where useful.
+
+---
+
+## Configuration
+
+### Config options are ignored / "unknown field" error
+
+You are likely using a v1 config file with a v2 binary. v2 replaced the flat boolean fields (`enableLinkCheck`, `minHeadingLevel`, etc.) with a unified `rules` map.
+
+Run `gomarklint init` to generate a fresh v2 config, then migrate your settings.
+
+→ [Migrating to v2](../migration-v2/)
+
+---
+
+### `failed to parse config file`
+
+The config file contains invalid JSON or an unsupported rule value. Common causes:
+
+- Trailing comma in JSON
+- Rule value is a string other than `"error"`, `"warning"`, or `"off"`
+- Numeric value where a string or boolean is expected
+
+→ [Configuration](../configuration/)
+
+---
+
+### `invalid rule value`
+
+Rule severity must be one of: `true`, `false`, `"error"`, `"warning"`, or `"off"`.
+
+→ [Configuration](../configuration/)
+
+---
+
+### `failed to access config file`
+
+The path passed to `--config` does not exist or is not readable. Check the path and verify the file is committed if running in CI.
+
+→ [CLI Reference](../cli/)
+
+---
+
+### `unknown flag: --enable-*`
+
+The `--enable-*` flags were removed in v2. Use the `rules` map in your config file instead.
+
+→ [Migrating to v2](../migration-v2/)
+
+---
+
+## Running the linter
+
+### `unknown shorthand flag: 'v'`
+
+The `-v` shorthand is not yet supported. Use `--version` instead. (Tracking: #152)
+
+---
+
+### No violations reported
+
+Three common causes:
+
+1. **Wrong path** — the glob or directory passed to gomarklint does not match your files.
+2. **Rule disabled** — the rule is set to `false` or `"off"` in your config.
+3. **Severity filter** — if you are using `--severity`, violations below the threshold are suppressed.
+
+→ [Configuration](../configuration/), [CLI Reference](../cli/)
+
+---
+
+### Lint passes locally but fails in CI
+
+Usually a version mismatch or a config file that is not committed. Check that:
+
+- The same gomarklint version is pinned in CI as you use locally.
+- `.gomarklint.json` (or your config file) is committed to the repository.
+
+→ [GitHub Actions Integration](../github-actions/)
+
+---
+
+## External link checking
+
+### Link check is slow or timing out
+
+Increase `timeoutSeconds` in your config, or skip known-slow domains with `skipPatterns`.
+
+→ [Configuration](../configuration/)
+
+---
+
+### Valid links reported as broken (403 errors)
+
+Go's default `User-Agent` (`Go-http-client/1.1`) is blocked by CDN-level bot protection (Cloudflare, Akamai, and others). The server returns 403 — not because the link is broken, but because it refuses automated clients.
+
+**Workarounds:**
+
+- Add `"allowedStatuses": [403]` to your config to stop treating 403 as an error.
+- Add the domain to `skipPatterns` to skip it entirely.
+
+→ [Configuration](../configuration/)
+
+---
+
+### Academic or journal links are always flagged (doi.org, Wikipedia, etc.)
+
+These sites aggressively block automated HTTP clients regardless of User-Agent. `skipPatterns` is the most reliable workaround:
+
+```json
+{
+  "skipPatterns": ["doi\\.org", "wikipedia\\.org"]
+}
+```
+
+External link checking has inherent limits — the tool flags candidates, but final judgment stays with the author.
+
+→ [Configuration](../configuration/)
+
+---
+
+### Not sure if a link is truly broken
+
+Before opening an issue, verify the link using the same User-Agent gomarklint uses:
+
+```sh
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -A "Go-http-client/1.1" \
+  https://your-url-here
+```
+
+| Status | Meaning |
+|--------|---------|
+| 2xx | Reachable — the report is a false-positive |
+| 3xx | Redirect — still reachable |
+| 403 | Bot protection blocking automated clients — not a broken link |
+| 404 | Genuinely broken link |
+| 000 / connection error | Network issue or domain does not exist |
+
+If the curl output shows 2xx or 3xx, the link is fine. Include the curl output when filing an issue about a suspected false-positive.


### PR DESCRIPTION
## Summary

Closes #153

Adds a FAQ & Troubleshooting page to the documentation site and links it from both READMEs.

## Changes

- `docs/content/docs/faq.md` — new FAQ page covering:
  - Config issues: v1→v2 migration, parse errors, invalid values, wrong path, removed v1 flags
  - Runtime issues: no violations reported, CI/local mismatch, slow link checks
  - External link false-positives: 403/bot-protection, academic domains, curl verify-before-filing guide
- `README.md` — added FAQ link under Documentation section
- `README.ja.md` — added FAQ link under Documentation section

## Test plan

- [x] `make test-all` passes
- [x] Documentation only — no logic changes