### PR TITLE
fix(StripFrontmatter): prevent false positive in final-blank-line for frontmatter-only files

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -450,9 +450,10 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "emphasis used as heading")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_lists_violation.md:")
 		assertOutputContains(t, output, "list must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 38 file(s)")
+		assertOutputContains(t, output, "Checked 39 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
+		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid_external_links.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/mixed_link_types.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/longer_closing_fence.md")
@@ -506,6 +507,12 @@ func TestE2E_EdgeCases(t *testing.T) {
 		output := runTest(t, "fixtures/with_frontmatter.md", "--config", ".gomarklint.json")
 		assertOutputContains(t, output, "No issues found")
 		assertOutputNotContains(t, output, "Errors")
+	})
+
+	t.Run("FrontmatterOnlyNoFalsePositive", func(t *testing.T) {
+		output := runTest(t, "fixtures/frontmatter_only.md", "--config", ".gomarklint.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "Missing final blank line")
 	})
 
 	t.Run("MultipleViolationsInSingleFile", func(t *testing.T) {

--- a/e2e/fixtures/frontmatter_only.md
+++ b/e2e/fixtures/frontmatter_only.md
@@ -1,0 +1,4 @@
+---
+title: "Docs"
+weight: 1
+---

--- a/internal/file/reader.go
+++ b/internal/file/reader.go
@@ -24,9 +24,6 @@ func StripFrontmatter(content string) (string, int) {
 				for skip < len(lines) && strings.TrimSpace(lines[skip]) == "" {
 					skip++
 				}
-				if skip >= len(lines) {
-					return "\n", skip
-				}
 				return strings.Join(lines[skip:], "\n"), skip
 			}
 		}

--- a/internal/file/reader.go
+++ b/internal/file/reader.go
@@ -24,6 +24,9 @@ func StripFrontmatter(content string) (string, int) {
 				for skip < len(lines) && strings.TrimSpace(lines[skip]) == "" {
 					skip++
 				}
+				if skip >= len(lines) {
+					return "\n", skip
+				}
 				return strings.Join(lines[skip:], "\n"), skip
 			}
 		}

--- a/internal/file/reader_test.go
+++ b/internal/file/reader_test.go
@@ -76,19 +76,19 @@ title: "Oops"`,
 		{
 			name:     "frontmatter-only with trailing newline",
 			input:    "---\ntitle: \"Docs\"\nweight: 1\n---\n",
-			wantBody: "\n",
+			wantBody: "",
 			wantSkip: 5,
 		},
 		{
 			name:     "frontmatter-only with multiple trailing blank lines",
 			input:    "---\ntitle: \"Docs\"\n---\n\n\n",
-			wantBody: "\n",
+			wantBody: "",
 			wantSkip: 6,
 		},
 		{
 			name:     "frontmatter-only without trailing newline",
 			input:    "---\ntitle: \"Docs\"\n---",
-			wantBody: "\n",
+			wantBody: "",
 			wantSkip: 3,
 		},
 	}

--- a/internal/file/reader_test.go
+++ b/internal/file/reader_test.go
@@ -73,6 +73,24 @@ title: "Oops"`,
 title: "Oops"`,
 			wantSkip: 0,
 		},
+		{
+			name:     "frontmatter-only with trailing newline",
+			input:    "---\ntitle: \"Docs\"\nweight: 1\n---\n",
+			wantBody: "\n",
+			wantSkip: 5,
+		},
+		{
+			name:     "frontmatter-only with multiple trailing blank lines",
+			input:    "---\ntitle: \"Docs\"\n---\n\n\n",
+			wantBody: "\n",
+			wantSkip: 6,
+		},
+		{
+			name:     "frontmatter-only without trailing newline",
+			input:    "---\ntitle: \"Docs\"\n---",
+			wantBody: "\n",
+			wantSkip: 3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -289,6 +289,26 @@ func TestRun_FinalBlankLine(t *testing.T) {
 	}
 }
 
+func TestRun_FinalBlankLine_FrontmatterOnly(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["final-blank-line"] = on()
+	cfg.Rules["no-multiple-blank-lines"] = on()
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "frontmatter_only.md")
+	if err := os.WriteFile(testFile, []byte("---\ntitle: \"Docs\"\nweight: 1\n---\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors != 0 {
+		t.Errorf("expected no violations for frontmatter-only file, got %d: %v", result.TotalErrors, result.Errors)
+	}
+}
+
 func TestRun_LinkCheck(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["external-link"] = &config.RuleConfig{

--- a/internal/rule/final_blank_line.go
+++ b/internal/rule/final_blank_line.go
@@ -12,6 +12,11 @@ package rule
 //   - A slice of LintError with one entry if the final blank line is missing.
 func CheckFinalBlankLine(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
+	// A frontmatter-only file has an empty body (lines==[""]). Offset > 0 means
+	// frontmatter was stripped; there is no body to enforce the rule on.
+	if len(lines) == 1 && lines[0] == "" && offset > 0 {
+		return errs
+	}
 	if len(lines) < 2 || lines[len(lines)-1] != "" {
 		errs = append(errs, LintError{
 			File:    filename,

--- a/internal/rule/final_blank_line_test.go
+++ b/internal/rule/final_blank_line_test.go
@@ -9,6 +9,7 @@ func TestCheckFinalBlankLine(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
+		offset   int
 		wantErrs []LintError
 	}{
 		{
@@ -35,12 +36,18 @@ func TestCheckFinalBlankLine(t *testing.T) {
 			content:  "\n",
 			wantErrs: nil,
 		},
+		{
+			name:     "frontmatter-only: empty body with positive offset is not flagged",
+			content:  "",
+			offset:   5,
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckFinalBlankLine("test.md", lines, 0)
+			got := CheckFinalBlankLine("test.md", lines, tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)


### PR DESCRIPTION
## Summary

- `StripFrontmatter` consumed all trailing blank lines after the closing `---`, returning an empty string body for frontmatter-only files
- `CheckFinalBlankLine` then flagged those files because `strings.Split("", "\n")` produces `[""]` (len < 2)
- Fix: when the skip loop exhausts all remaining lines, return `"\n"` instead of `""` so the rule sees a valid empty body

## Test plan

- [ ] New test cases in `TestStripFrontmatter`: frontmatter-only with trailing `\n`, multiple trailing blank lines, and no trailing `\n`
- [ ] `make test` passes (all existing tests continue to pass)

Closes #162