### PR TITLE
refactor(final-blank-line): PR-1 bench coverage + explicit nil return

### DIFF
--- a/internal/rule/final_blank_line.go
+++ b/internal/rule/final_blank_line.go
@@ -11,19 +11,17 @@ package rule
 // Returns:
 //   - A slice of LintError with one entry if the final blank line is missing.
 func CheckFinalBlankLine(filename string, lines []string, offset int) []LintError {
-	var errs []LintError
 	// A frontmatter-only file has an empty body (lines==[""]). Offset > 0 means
 	// frontmatter was stripped; there is no body to enforce the rule on.
 	if len(lines) == 1 && lines[0] == "" && offset > 0 {
-		return errs
+		return nil
 	}
-	if len(lines) < 2 || lines[len(lines)-1] != "" {
-		errs = append(errs, LintError{
-			File:    filename,
-			Line:    len(lines) + offset,
-			Message: "Missing final blank line",
-		})
+	if len(lines) >= 2 && lines[len(lines)-1] == "" {
+		return nil
 	}
-
-	return errs
+	return []LintError{{
+		File:    filename,
+		Line:    len(lines) + offset,
+		Message: "Missing final blank line",
+	}}
 }


### PR DESCRIPTION
## Summary

PR-1 of #146. Covers the \`final-blank-line\` rule in the benchmark.

**Content**: \`generateComplexMarkdown\` already ends with exactly one \`\n\` (fixed in PR-A), so the rule scans fully without producing a violation. No content or \`benchmarkConfig()\` change needed.

**Optimize**: inverted the condition in \`CheckFinalBlankLine\` so the zero-violation fast path returns \`nil\` explicitly, rather than relying on \`var errs\` remaining unappended. No measurable impact (rule is O(1) and does not register in the CPU profile), but the intent is clear at a glance.

## Bench (before → after)

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| \`BenchmarkFullLinting\` before | 11,711,452 | 1,029,398 | 4,355 |
| \`BenchmarkFullLinting\` after | 11,951,568 | 1,032,432 | 4,356 |
| \`BenchmarkFullLinting_ExtraLarge\` after | 189,752,167 | 5,016,564 | 20,431 |

Delta is within noise. \`CheckFinalBlankLine\` does not appear in the top CPU profile nodes — expected for an O(1) check.

**Profile observation** (for future PRs): \`isInCodeBlock\` accounts for 63.72% of CPU time, called per-line from \`CheckNoMultipleBlankLines\` and \`CheckHeadingLevels\`. This is the primary optimization target for PR-2 and PR-7.

## Checklist

- [x] \`TestBenchmarkContentIsViolationFree\` passes
- [x] \`make test-all\` passes
- [x] Before/after bench numbers included above
- [x] Regression is noise-level (no content or activation change)

Part of #146