### PR TITLE
refactor(no-multiple-blank-lines): PR-2 replace isInCodeBlock O(n×k) with inline tracking

### DIFF
--- a/internal/rule/no_multiple_blank_lines.go
+++ b/internal/rule/no_multiple_blank_lines.go
@@ -20,13 +20,28 @@ import (
 // Returns:
 //   - A slice of LintError with entries for each occurrence of multiple consecutive blank lines.
 func CheckNoMultipleBlankLines(filename string, lines []string, offset int) []LintError {
-	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
-
 	var errs []LintError
-
 	consecutiveBlankCount := 0
+	inCodeBlock := false
+	var fenceMarker string
+
 	for i, line := range lines {
-		if !isInCodeBlock(i+1, codeBlockRanges) && strings.TrimSpace(line) == "" {
+		trimmed := strings.TrimSpace(line)
+		if inCodeBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inCodeBlock = false
+				fenceMarker = ""
+			}
+			consecutiveBlankCount = 0
+			continue
+		}
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inCodeBlock = true
+			fenceMarker = marker
+			consecutiveBlankCount = 0
+			continue
+		}
+		if trimmed == "" {
 			consecutiveBlankCount++
 			if consecutiveBlankCount > 1 {
 				errs = append(errs, LintError{


### PR DESCRIPTION
## Summary

PR-2 of #146. Covers the \`no-multiple-blank-lines\` rule in the benchmark.

**Content**: \`generateComplexMarkdown\` already separates every block with exactly one blank line, so the rule scans all lines without producing a violation. No content change needed.

**Optimize**: the previous implementation made two passes over the lines:
1. \`GetCodeBlockLineRanges\` — an extra O(n) scan to build a range list
2. Main loop — \`isInCodeBlock\` O(k) linear range search on every line

With 500 code blocks in a 1000-section document this made the hot loop O(n×k), which showed up as **63.72% of total CPU** in the PR-1 profile.

Replaced with single-pass inline tracking using the existing \`openingFenceMarker\` / \`IsClosingFence\` helpers — O(1) state per line, one pass total.

## Bench (Apple M4)

| Benchmark | before | after | delta |
|---|---|---|---|
| \`BenchmarkFullLinting\` | 11,758,057 ns/op | 8,360,673 ns/op | **-29%** |
| \`BenchmarkFullLinting_ExtraLarge\` | 188,437,847 ns/op | 107,301,809 ns/op | **-43%** |
| \`BenchmarkFullLinting\` B/op | 1,031,264 | 1,012,738 | -2% |
| \`BenchmarkFullLinting_ExtraLarge\` B/op | 4,991,576 | 4,890,118 | -2% |

Regression is a real optimization win, not content/activation noise.

## Checklist

- [x] \`TestBenchmarkContentIsViolationFree\` passes
- [x] \`make test-all\` passes
- [x] Before/after bench numbers included above

Part of #146