### PR TITLE
refactor(no-setext-headings): PR-3 hoist regexes to package scope + inline code-block tracking

### DIFF
--- a/internal/rule/setext_headings.go
+++ b/internal/rule/setext_headings.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	settextUnderlineRegex = regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
+	setextUnderlineRegex = regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
 	setextOtherBlockRegex = regexp.MustCompile(`^ {0,3}(?:[*+-]|\d+[.)]|>)\s*`)
 )
 
@@ -52,7 +52,7 @@ func CheckNoSetextHeadings(filename string, lines []string, offset int) []LintEr
 		isCurrentLineEmpty := trimmed == ""
 		isCurrentLineOtherBlock := setextOtherBlockRegex.MatchString(line)
 
-		if !inCodeBlock && settextUnderlineRegex.MatchString(line) &&
+		if !inCodeBlock && setextUnderlineRegex.MatchString(line) &&
 			!isPrevLineEmpty && !isPrevLineOtherBlock && !isInLazyBlockquote {
 			errs = append(errs, LintError{
 				File:    filename,

--- a/internal/rule/setext_headings.go
+++ b/internal/rule/setext_headings.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	setextUnderlineRegex = regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
+	setextUnderlineRegex  = regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
 	setextOtherBlockRegex = regexp.MustCompile(`^ {0,3}(?:[*+-]|\d+[.)]|>)\s*`)
 )
 

--- a/internal/rule/setext_headings.go
+++ b/internal/rule/setext_headings.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+var (
+	settextUnderlineRegex = regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
+	setextOtherBlockRegex = regexp.MustCompile(`^ {0,3}(?:[*+-]|\d+[.)]|>)\s*`)
+)
+
 // CheckNoSetextHeadings ensures that headings of the "setext" style are never
 // used; you should prefer ATX-type headings instead. It is better that one
 // style is consistently used, and ATX headings are better because:
@@ -23,35 +28,39 @@ import (
 //     detected issue.
 func CheckNoSetextHeadings(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
-
-	// According to the CommonMark spec, a setext heading underline is
-	// zero to 3 spaces, followed by any number of either the equals or
-	// dash characters, optionally followed by whitespace.
-	settextUnderlineRegex := regexp.MustCompile(`^ {0,3}(?:=+|-+)\s*$`)
-	// A line is considered empty if it is of either no length or contains
-	// only whitespace.
-	emptyLineRegex := regexp.MustCompile(`^\s*$`)
-	// List markers and blockquote markers
-	otherBlockRegex := regexp.MustCompile(`^ {0,3}(?:[*+-]|\d+[.)]|>)\s*`)
-
-	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
+	inCodeBlock := false
+	var fenceMarker string
 	isPrevLineEmpty := true
 	isPrevLineOtherBlock := false
 	isInLazyBlockquote := false
 
 	for i, line := range lines {
-		isUnderline := settextUnderlineRegex.MatchString(line)
-		isCurrentLineEmpty := emptyLineRegex.MatchString(line)
-		isCurrentLineOtherBlock := otherBlockRegex.MatchString(line)
-		if isUnderline && !isInCodeBlock(i+1, codeBlockRanges) {
-			if !isPrevLineEmpty && !isPrevLineOtherBlock && !isInLazyBlockquote {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    i + 1 + offset,
-					Message: "Setext heading found (prefer ATX style instead)",
-				})
+		trimmed := strings.TrimSpace(line)
+
+		// Maintain code-block state inline to avoid a separate O(n) pass and
+		// the O(k) isInCodeBlock lookup per line.
+		if inCodeBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inCodeBlock = false
+				fenceMarker = ""
 			}
+		} else if marker := openingFenceMarker(trimmed); marker != "" {
+			inCodeBlock = true
+			fenceMarker = marker
 		}
+
+		isCurrentLineEmpty := trimmed == ""
+		isCurrentLineOtherBlock := setextOtherBlockRegex.MatchString(line)
+
+		if !inCodeBlock && settextUnderlineRegex.MatchString(line) &&
+			!isPrevLineEmpty && !isPrevLineOtherBlock && !isInLazyBlockquote {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    i + 1 + offset,
+				Message: "Setext heading found (prefer ATX style instead)",
+			})
+		}
+
 		if isCurrentLineEmpty {
 			isPrevLineEmpty = true
 			isPrevLineOtherBlock = false
@@ -59,7 +68,7 @@ func CheckNoSetextHeadings(filename string, lines []string, offset int) []LintEr
 		} else if isCurrentLineOtherBlock {
 			isPrevLineEmpty = false
 			isPrevLineOtherBlock = true
-			isInLazyBlockquote = strings.HasPrefix(strings.TrimSpace(line), ">")
+			isInLazyBlockquote = strings.HasPrefix(trimmed, ">")
 		} else {
 			isPrevLineEmpty = false
 			isPrevLineOtherBlock = false


### PR DESCRIPTION
## Summary

PR-3 of #146. Covers the \`no-setext-headings\` rule in the benchmark.

**Content**: \`generateComplexMarkdown\` uses only ATX headings (\`##\`, \`###\`), so the rule scans all lines without producing a violation. No content change needed.

**Optimize two bottlenecks**:

1. **Regex recompilation** — three \`regexp.MustCompile\` calls inside the function were re-executed on every \`LintContent\` call. Moved \`settextUnderlineRegex\` and \`setextOtherBlockRegex\` to package-level vars. Replaced \`emptyLineRegex\` with a direct \`trimmed == ""\` comparison (no regex needed).

2. **\`isInCodeBlock\` O(n×k)** — same pattern fixed in PR-2. Replaced \`GetCodeBlockLineRanges\` + per-line \`isInCodeBlock\` with single-pass inline tracking using \`openingFenceMarker\` / \`IsClosingFence\`.

## Bench (Apple M4)

| Benchmark | before | after | delta |
|---|---|---|---|
| \`BenchmarkFullLinting\` | 8,363,132 ns/op | 7,417,943 ns/op | **-11%** |
| \`BenchmarkFullLinting_ExtraLarge\` | 105,721,569 ns/op | 101,431,450 ns/op | **-4%** |
| \`BenchmarkFullLinting\` allocs/op | 4,345 | 4,126 | **-5%** |
| \`BenchmarkFullLinting\` B/op | 1,014,081 | 982,009 | -3% |

## Checklist

- [x] \`TestBenchmarkContentIsViolationFree\` passes
- [x] \`make test-all\` passes
- [x] Before/after bench numbers included above

Part of #146