### PR TITLE
feat: implement no-hard-tabs rule (MD010)

### DIFF
--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -18,13 +18,12 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] `no-emphasis-as-heading`: Bold/italic must not substitute for headings
 - [x] `no-setext-headings`: Setext-style headings must use ATX style instead
 - [x] `blanks-around-lists`: Lists must be surrounded by blank lines
+- [x] `max-line-length`: Enforce a maximum line length (MD013)
+- [x] `no-hard-tabs`: No hard tab characters in body text (MD010)
 
 ## Rules — Planned
 
 ### Priority 2
-
-- [ ] `max-line-length`: Enforce a maximum line length (MD013)
-- [ ] `no-hard-tabs`: No hard tab characters in body text (MD010)
 - [ ] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
 - [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -24,6 +24,7 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 ## Rules — Planned
 
 ### Priority 2
+
 - [ ] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
 - [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -22,6 +22,9 @@ weight: 2
 | `no-bare-urls`                 | HTTP/HTTPS URLs written as bare text instead of proper Markdown links   | Default **on**                                                                                        |
 | `no-empty-links`               | Links or images with an empty destination (`[]()`, `[](#)`, `[](<>)`)  | Default **on**                                                                                        |
 | `no-emphasis-as-heading`       | Bold/italic text used as a heading substitute instead of ATX headings   | Default **on**. Punctuation-ending spans (`. , ; : ! ? 。 、 ； ： ！ ？`) are excluded              |
+| `blanks-around-lists`          | Lists not surrounded by blank lines                                     | Default **on**                                                                                        |
+| `no-hard-tabs`                 | Hard tab characters (`\t`) outside fenced code blocks and inline code   | Default **on**                                                                                        |
+| `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
 
 ## Execution details

--- a/e2e/config-no-hard-tabs.json
+++ b/e2e/config-no-hard-tabs.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "no-hard-tabs": true
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -323,6 +323,26 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "line exceeds 80 bytes (100)")
 		assertOutputContains(t, output, "1 issues found")
 	})
+
+	t.Run("NoHardTabsValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/no_hard_tabs_valid.md", "--config", "config-no-hard-tabs.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "hard tab character")
+	})
+
+	t.Run("NoHardTabsViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/no_hard_tabs_violation.md", "--config", "config-no-hard-tabs.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/no_hard_tabs_violation.md:")
+		assertOutputContains(t, output, "fixtures/no_hard_tabs_violation.md:3:")
+		assertOutputContains(t, output, "hard tab character found at column 1")
+		assertOutputContains(t, output, "fixtures/no_hard_tabs_violation.md:5:")
+		assertOutputContains(t, output, "hard tab character found at column 4")
+		assertOutputContains(t, output, "fixtures/no_hard_tabs_violation.md:7:")
+		assertOutputContains(t, output, "3 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -450,7 +470,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "emphasis used as heading")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_lists_violation.md:")
 		assertOutputContains(t, output, "list must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 39 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/no_hard_tabs_violation.md:")
+		assertOutputContains(t, output, "hard tab character found")
+		assertOutputContains(t, output, "Checked 41 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
@@ -462,6 +484,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_lists_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_emphasis_as_heading_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/no_hard_tabs_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/no_hard_tabs_valid.md
+++ b/e2e/fixtures/no_hard_tabs_valid.md
@@ -1,0 +1,10 @@
+## Valid: No Hard Tabs
+
+- item one
+  - nested item
+
+Paragraph with spaces only.
+
+```sh
+	code indented with tab is fine
+```

--- a/e2e/fixtures/no_hard_tabs_violation.md
+++ b/e2e/fixtures/no_hard_tabs_violation.md
@@ -1,0 +1,7 @@
+## Hard Tab Violations
+
+	Tab-indented line
+
+key	value
+
+	another tab

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const DefaultConfigJSON = `{
     "no-empty-links": true,
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
+    "no-hard-tabs": true,
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
   },
@@ -219,6 +220,7 @@ func Default() Config {
 			"no-empty-links":          enabledRule(),
 			"no-emphasis-as-heading":  enabledRule(),
 			"blanks-around-lists":     enabledRule(),
+			"no-hard-tabs":            enabledRule(),
 			"max-line-length": {
 				Enabled:  false,
 				Severity: SeverityOff,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -197,6 +197,7 @@ var simpleRules = []struct {
 	{"no-empty-links", rule.CheckNoEmptyLinks},
 	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
+	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.

--- a/internal/rule/no_hard_tabs.go
+++ b/internal/rule/no_hard_tabs.go
@@ -38,12 +38,14 @@ func CheckNoHardTabs(filename string, lines []string, offset int) []LintError {
 			scanned = stripInlineCode(line)
 		}
 
-		for col, ch := range scanned {
+		col := 0
+		for _, ch := range scanned {
+			col++
 			if ch == '\t' {
 				errs = append(errs, LintError{
 					File:    filename,
 					Line:    offset + i + 1,
-					Message: fmt.Sprintf("no-hard-tabs: hard tab character found at column %d", col+1),
+					Message: fmt.Sprintf("no-hard-tabs: hard tab character found at column %d", col),
 				})
 			}
 		}

--- a/internal/rule/no_hard_tabs.go
+++ b/internal/rule/no_hard_tabs.go
@@ -1,0 +1,53 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckNoHardTabs flags hard tab characters (\t) outside fenced code blocks
+// and inline code spans. Each tab is reported as a separate violation.
+func CheckNoHardTabs(filename string, lines []string, offset int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		if !strings.ContainsRune(line, '\t') {
+			continue
+		}
+
+		scanned := line
+		if strings.ContainsRune(line, '`') {
+			scanned = stripInlineCode(line)
+		}
+
+		for col, ch := range scanned {
+			if ch == '\t' {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: fmt.Sprintf("no-hard-tabs: hard tab character found at column %d", col+1),
+				})
+			}
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/no_hard_tabs_test.go
+++ b/internal/rule/no_hard_tabs_test.go
@@ -1,0 +1,120 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckNoHardTabs(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		wantErrs []LintError
+	}{
+		{
+			name:     "valid: no tabs",
+			content:  "- item\n  - nested\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: tab at start of line",
+			content: "\t- item\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 1"},
+			},
+		},
+		{
+			name:    "invalid: tab in paragraph",
+			content: "key\tvalue\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 4"},
+			},
+		},
+		{
+			name:    "invalid: multiple tabs on one line",
+			content: "\tcol1\tcol2\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 1"},
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 6"},
+			},
+		},
+		{
+			name:     "valid: tab inside fenced code block (backtick)",
+			content:  "```\n\tcode\n```\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: tab inside fenced code block (tilde)",
+			content:  "~~~\n\tcode\n~~~\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: tab inside inline code span",
+			content:  "Use `key\tvalue` as example.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: tab inside double-backtick inline code",
+			content:  "Use ``key\tvalue`` as example.\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: tab outside inline code on same line",
+			content: "Run `cmd` then\there.\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 15"},
+			},
+		},
+		{
+			name:    "invalid: tab on second line",
+			content: "# Heading\n\n\tindented\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "no-hard-tabs: hard tab character found at column 1"},
+			},
+		},
+		{
+			name:    "offset shifts line numbers",
+			content: "\titem\n",
+			offset:  5,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 6, Message: "no-hard-tabs: hard tab character found at column 1"},
+			},
+		},
+		{
+			name:     "valid: empty file",
+			content:  "",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: tab before and after fenced code block",
+			content: "\tbefore\n```\n\tcode\n```\n\tafter\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-hard-tabs: hard tab character found at column 1"},
+				{File: "test.md", Line: 5, Message: "no-hard-tabs: hard tab character found at column 1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckNoHardTabs("test.md", lines, tt.offset)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i].File != tt.wantErrs[i].File {
+					t.Errorf("[%d] file: got %q, want %q", i, got[i].File, tt.wantErrs[i].File)
+				}
+				if got[i].Line != tt.wantErrs[i].Line {
+					t.Errorf("[%d] line: got %d, want %d", i, got[i].Line, tt.wantErrs[i].Line)
+				}
+				if got[i].Message != tt.wantErrs[i].Message {
+					t.Errorf("[%d] message: got %q, want %q", i, got[i].Message, tt.wantErrs[i].Message)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `no-hard-tabs` rule (MD010 / remark-lint `no-tabs`)
- Detects hard tab characters (`\t`) outside fenced code blocks and inline code spans
- Each tab on a line is reported as a separate violation with its column number
- Enabled by default

## Changes

- `internal/rule/no_hard_tabs.go` — `CheckNoHardTabs` implementation
- `internal/rule/no_hard_tabs_test.go` — table-driven unit tests (13 cases)
- `internal/config/config.go` — register `no-hard-tabs` in `DefaultConfigJSON` and `Default()`
- `internal/linter/linter.go` — add to `simpleRules`
- `e2e/` — fixture files and test cases
- `docs/content/docs/rules.md` — add `no-hard-tabs`, `blanks-around-lists`, `max-line-length` entries (were missing)

## Test plan

- [x] `make test` passes
- [x] `make test-e2e` passes
- [x] `NoHardTabsValid` — no violations on space-indented content with tab inside fenced code block
- [x] `NoHardTabsViolation` — detects tabs at lines 3, 5, 7 with correct column numbers
- [x] `DirectoryRecursion` — file count updated to 41

Closes #167. Part of #76.