### PR TITLE
refactor(blanks-around-lists): PR-5 eliminate TrimSpace look-ahead/look-behind

### DIFF
--- a/internal/rule/blanks_around_lists.go
+++ b/internal/rule/blanks_around_lists.go
@@ -54,7 +54,8 @@ func CheckBlanksAroundLists(filename string, lines []string, offset int) []LintE
 	fenceMarker := ""
 	// prevBlank and prevWasListItem replace the TrimSpace look-behind on
 	// lines[i-1] for every list item encountered.
-	// prevBlank is initialized to true so the first line is exempt.
+	// prevBlank starts as true to model the pre-file boundary as blank; the
+	// first-line exemption is enforced by the i > 0 guard below.
 	prevBlank := true
 	prevWasListItem := false
 	prevLineNum := 0 // 1-indexed line number of the previous list item

--- a/internal/rule/blanks_around_lists.go
+++ b/internal/rule/blanks_around_lists.go
@@ -52,46 +52,62 @@ func CheckBlanksAroundLists(filename string, lines []string, offset int) []LintE
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""
+	// prevBlank and prevWasListItem replace the TrimSpace look-behind on
+	// lines[i-1] for every list item encountered.
+	// prevBlank is initialized to true so the first line is exempt.
+	prevBlank := true
+	prevWasListItem := false
+	prevLineNum := 0 // 1-indexed line number of the previous list item
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
+		isBlank := trimmed == ""
+		isList := isListItem(line)
+
+		// Check "end of block" before fence branches so a list item immediately
+		// followed by a fence opener is still flagged (lesson from PR-4).
+		if prevWasListItem && !isBlank && !isList {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + prevLineNum + 1,
+				Message: "blanks-around-lists: list must be followed by a blank line",
+			})
+		}
 
 		if inBlock {
 			if IsClosingFence(trimmed, fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
+			prevBlank = false
+			prevWasListItem = false
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
+		if marker := openingFenceMarker(trimmed); marker != "" {
 			inBlock = true
 			fenceMarker = marker
+			prevBlank = false
+			prevWasListItem = false
 			continue
 		}
 
-		if !isListItem(line) {
-			continue
+		if isList {
+			// Check "start of block": first item of a block not preceded by blank.
+			if i > 0 && !prevBlank && !prevWasListItem {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "blanks-around-lists: list must be preceded by a blank line",
+				})
+			}
+			prevWasListItem = true
+			prevLineNum = i + 1
+		} else {
+			prevWasListItem = false
 		}
 
-		// Check "start of block": previous line is non-blank and not a list item.
-		if i > 0 && strings.TrimSpace(lines[i-1]) != "" && !isListItem(lines[i-1]) {
-			errs = append(errs, LintError{
-				File:    filename,
-				Line:    offset + i + 1,
-				Message: "blanks-around-lists: list must be preceded by a blank line",
-			})
-		}
-
-		// Check "end of block": next line is non-blank and not a list item.
-		if i < len(lines)-1 && strings.TrimSpace(lines[i+1]) != "" && !isListItem(lines[i+1]) {
-			errs = append(errs, LintError{
-				File:    filename,
-				Line:    offset + i + 2,
-				Message: "blanks-around-lists: list must be followed by a blank line",
-			})
-		}
+		prevBlank = isBlank
 	}
 
 	return errs

--- a/internal/rule/blanks_around_lists_test.go
+++ b/internal/rule/blanks_around_lists_test.go
@@ -110,6 +110,20 @@ func TestCheckBlanksAroundLists(t *testing.T) {
 			},
 		},
 		{
+			name:    "invalid: list immediately followed by fenced code block opener",
+			content: "- item 1\n- item 2\n```go\nfmt.Println()\n```\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "blanks-around-lists: list must be followed by a blank line"},
+			},
+		},
+		{
+			name:    "invalid: list immediately followed by tilde fence opener",
+			content: "- item 1\n- item 2\n~~~go\nfmt.Println()\n~~~\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "blanks-around-lists: list must be followed by a blank line"},
+			},
+		},
+		{
 			name:    "offset shifts line numbers",
 			content: "Some text\n- item 1\nMore text\n",
 			offset:  5,


### PR DESCRIPTION
## Summary

PR-5 of #146. Covers the \`blanks-around-lists\` rule in the benchmark.

**Content**: \`generateComplexMarkdown\` already surrounds every list with blank lines, so the rule scans all list items without producing a violation. No content change needed.

**Optimize**: same approach as PR-4. Replaced \`TrimSpace(lines[i-1])\` look-behind and \`TrimSpace(lines[i+1])\` look-ahead with state variables:

- \`prevBlank\` / \`prevWasListItem\` — eliminate the look-behind \`TrimSpace\` call
- Deferred "end of block" check on the next iteration — eliminates the look-ahead \`TrimSpace\` call

The deferred check is placed **before** the fence branches (lesson from PR-4 Copilot review) so a list item immediately followed by a fence opener is still flagged correctly.

## Bench (Apple M4)

| Benchmark | before | after | delta |
|---|---|---|---|
| \`BenchmarkFullLinting\` | 7,309,379 ns/op | 7,517,496 ns/op | noise |
| \`BenchmarkFullLinting_ExtraLarge\` | 100,540,592 ns/op | 97,499,979 ns/op | **-3%** |

## Checklist

- [x] \`TestBenchmarkContentIsViolationFree\` passes
- [x] \`make test-all\` passes
- [x] \`make static-lint\` passes
- [x] Before/after bench numbers included above

Part of #146