### PR TITLE
fix(no-bare-urls): skip standalone URL surrounded by blank lines (link card)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -226,6 +226,13 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputNotContains(t, output, "Fenced code block must have a language identifier")
 	})
 
+	t.Run("NoBareURLsLinkCardValid", func(t *testing.T) {
+		// A standalone URL on its own line surrounded by blank lines is a link
+		// card and must not be flagged.
+		output := runTest(t, "fixtures/no_bare_urls_valid.md", "--config", "config-no-bare-urls.json")
+		assertOutputNotContains(t, output, "fixtures/no_bare_urls_valid.md:21:")
+	})
+
 	t.Run("NoBareURLsViolation", func(t *testing.T) {
 		output, err := runTestWithCmd(t, "fixtures/no_bare_urls_violation.md", "--config", "config-no-bare-urls.json")
 		if err == nil {

--- a/e2e/fixtures/no_bare_urls_valid.md
+++ b/e2e/fixtures/no_bare_urls_valid.md
@@ -17,3 +17,5 @@ still inside the second comment
 https://example.com
 ```
 -->
+
+https://example.com

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -198,10 +198,28 @@ func prepareScanned(line string) (string, bool) {
 	return scanned, false
 }
 
+// isLinkCard reports whether line i is a standalone link-card URL: the
+// trimmed line is a single http/https URL with no surrounding prose, preceded
+// and followed by a blank line (or the file boundary). Such lines are
+// intentionally placed by the author to trigger renderer-level link card
+// previews (GitHub, Zenn, etc.) and must not be flagged.
+func isLinkCard(lines []string, i int, trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "http://") && !strings.HasPrefix(trimmed, "https://") {
+		return false
+	}
+	if strings.ContainsAny(trimmed, " \t") {
+		return false
+	}
+	prevBlank := i == 0 || strings.TrimSpace(lines[i-1]) == ""
+	nextBlank := i >= len(lines)-1 || strings.TrimSpace(lines[i+1]) == ""
+	return prevBlank && nextBlank
+}
+
 // CheckNoBareURLs flags HTTP/HTTPS URLs that appear as bare text rather than
 // being wrapped in angle brackets or used inside a Markdown link or image.
 // URLs inside fenced code blocks, inline code spans, HTML comments, and HTML
-// attribute values are ignored.
+// attribute values are ignored. A URL that stands alone on its own line
+// surrounded by blank lines is treated as a link card and not flagged.
 func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
 	inBlock := false
@@ -241,6 +259,10 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 			if strings.Contains(line, "<!--") {
 				_, inComment = stripHTMLComments(line)
 			}
+			continue
+		}
+
+		if isLinkCard(lines, i, trimmed) {
 			continue
 		}
 

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -207,7 +207,8 @@ func isLinkCard(lines []string, i int, trimmed string) bool {
 	if !strings.HasPrefix(trimmed, "http://") && !strings.HasPrefix(trimmed, "https://") {
 		return false
 	}
-	if strings.ContainsAny(trimmed, " \t") {
+	urls := findBareURLs(trimmed)
+	if len(urls) != 1 || trimmed != urls[0] {
 		return false
 	}
 	prevBlank := i == 0 || strings.TrimSpace(lines[i-1]) == ""

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -108,10 +108,38 @@ func TestCheckNoBareURLs(t *testing.T) {
 			},
 		},
 		{
-			name:    "invalid: bare URL on second line",
-			content: "## Section\n\nhttps://example.com\n",
+			name:     "valid: link card — standalone URL after heading with surrounding blank lines",
+			content:  "## Section\n\nhttps://example.com\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link card — URL surrounded by blank lines in prose",
+			content:  "Some text above.\n\nhttps://example.com\n\nSome text below.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link card — URL at start of file followed by blank line",
+			content:  "https://example.com\n\nSome text.\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: link card — URL at end of file preceded by blank line",
+			content:  "Some text.\n\nhttps://example.com\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: two URLs on one line surrounded by blank lines",
+			content: "\nhttps://foo.com https://bar.com\n\n",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 3, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
+				{File: "test.md", Line: 2, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://foo.com"},
+				{File: "test.md", Line: 2, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://bar.com"},
+			},
+		},
+		{
+			name:    "invalid: bare URL not surrounded by blank lines",
+			content: "Above.\nhttps://example.com\nBelow.\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
 			},
 		},
 		{

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -143,6 +143,13 @@ func TestCheckNoBareURLs(t *testing.T) {
 			},
 		},
 		{
+			name:    "invalid: URL with trailing paren surrounded by blank lines is not a link card",
+			content: "\nhttps://example.com)\n\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "no-bare-urls: bare URL found, use angle brackets or a Markdown link: https://example.com"},
+			},
+		},
+		{
 			name:    "offset shifts line numbers",
 			content: "Visit https://example.com today.\n",
 			offset:  4,


### PR DESCRIPTION
## Summary

- Adds `isLinkCard` helper in `CheckNoBareURLs` that skips a bare URL when it stands alone on its own line surrounded by blank lines (or file boundaries)
- A URL that meets this condition is intentionally placed as a link card embed (GitHub, Zenn, etc.) and must not be flagged
- Two URLs on the same line, or a URL with prose on either side, are still flagged as before

## Test plan

- [ ] Unit tests updated: existing `"invalid: bare URL on second line"` corrected to valid (link card); 5 new cases added covering mid-file, start-of-file, end-of-file, two-URLs, and no-blank-lines scenarios
- [ ] E2E fixture `no_bare_urls_valid.md` extended with a standalone link card URL at line 21
- [ ] `NoBareURLsLinkCardValid` e2e test added asserting line 21 is not flagged
- [ ] `make test-all` passes

Closes #173