### PR TITLE
fix(external-link): add User-Agent header and allowedStatuses config option

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -178,6 +178,18 @@ func (l *Linter) externalLinkTimeout() int {
 	return timeoutSeconds
 }
 
+// externalLinkAllowedStatuses returns the configured allowedStatuses for the external-link rule.
+func (l *Linter) externalLinkAllowedStatuses() []int {
+	raw, _ := l.config.RuleOptions("external-link")["allowedStatuses"].([]interface{})
+	statuses := make([]int, 0, len(raw))
+	for _, item := range raw {
+		if f, ok := item.(float64); ok {
+			statuses = append(statuses, int(f))
+		}
+	}
+	return statuses
+}
+
 // simpleRules lists rules whose check function takes only (path, lines, offset).
 // Rules that require additional options are handled separately below.
 var simpleRules = []struct {
@@ -233,7 +245,7 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {
-		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.urlCache)
+		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkAllowedStatuses(), l.urlCache)
 		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
 		linksChecked = count
 	}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1,6 +1,9 @@
 package linter
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -734,5 +737,43 @@ func TestRun_DisableComment_NoDisableKeyword_NoOverhead(t *testing.T) {
 
 	if len(errors) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+}
+
+func TestRun_LinkCheckWithAllowedStatuses(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/allowed":
+			w.WriteHeader(http.StatusForbidden) // 403, in allowedStatuses
+		case "/blocked":
+			w.WriteHeader(http.StatusNotFound) // 404, not in allowedStatuses
+		}
+	}))
+	defer ts.Close()
+
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options: map[string]interface{}{
+			"timeoutSeconds":  float64(5),
+			"skipPatterns":    []interface{}{},
+			"allowedStatuses": []interface{}{float64(403)},
+		},
+	}
+
+	linter := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "links.md")
+	content := fmt.Sprintf("[allowed](%s/allowed)\n[blocked](%s/blocked)\n", ts.URL, ts.URL)
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := linter.Run([]string{testFile})
+
+	if result.TotalErrors != 1 {
+		t.Errorf("expected 1 error (404 only), got %d", result.TotalErrors)
 	}
 }

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -128,11 +128,11 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 					err = result.err
 				} else {
 					// Cache contained unexpected type, re-check the URL
-					status, err = checkURL(client, url, retryDelayMs)
+					status, err = checkURL(client, url, retryDelayMs, allowedStatuses)
 					urlCache.Store(url, cacheResult{status: status, err: err})
 				}
 			} else {
-				status, err = checkURL(client, url, retryDelayMs)
+				status, err = checkURL(client, url, retryDelayMs, allowedStatuses)
 				urlCache.Store(url, cacheResult{status: status, err: err})
 			}
 
@@ -155,7 +155,7 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 }
 
 // checkURL performs the URL check with retry logic.
-func checkURL(client *http.Client, url string, retryDelayMs int) (int, error) {
+func checkURL(client *http.Client, url string, retryDelayMs int, allowedStatuses []int) (int, error) {
 	// maxRetries is the maximum number of retry attempts for failed requests
 	const maxRetries = 2
 	retryDelay := time.Duration(retryDelayMs) * time.Millisecond
@@ -173,6 +173,11 @@ func checkURL(client *http.Client, url string, retryDelayMs int) (int, error) {
 
 		// Success: 2xx or 3xx
 		if err == nil && status < 400 {
+			return status, nil
+		}
+
+		// Allowed statuses (e.g. 429, user-configured): return immediately without retrying
+		if err == nil && isAllowedStatus(status, allowedStatuses) {
 			return status, nil
 		}
 

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -29,7 +29,27 @@ type ExtractedLink struct {
 const (
 	// DefaultRetryDelayMs is the default delay in milliseconds before retrying a failed HTTP request
 	DefaultRetryDelayMs = 1000
+
+	userAgent = "gomarklint/v2 (+https://github.com/shinagawa-web/gomarklint)"
 )
+
+// defaultAllowedStatuses contains status codes never treated as link failures.
+// 429 (Too Many Requests) indicates rate limiting, not a broken link.
+var defaultAllowedStatuses = []int{http.StatusTooManyRequests}
+
+func isAllowedStatus(status int, extra []int) bool {
+	for _, s := range defaultAllowedStatuses {
+		if status == s {
+			return true
+		}
+	}
+	for _, s := range extra {
+		if status == s {
+			return true
+		}
+	}
+	return false
+}
 
 // ExtractExternalLinksWithLineNumbers extracts external links from the given lines.
 // The offset parameter is added to line numbers to account for stripped frontmatter.
@@ -67,7 +87,7 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 // CheckExternalLinks checks external links in the given lines.
 // The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
 // Returns lint errors and the count of unique URLs checked.
-func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, urlCache *sync.Map) ([]LintError, int) {
+func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, allowedStatuses []int, urlCache *sync.Map) ([]LintError, int) {
 	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
 	links := ExtractExternalLinksWithLineNumbers(lines, offset)
 
@@ -116,7 +136,7 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 				urlCache.Store(url, cacheResult{status: status, err: err})
 			}
 
-			if err != nil || status >= 400 {
+			if err != nil || (status >= 400 && !isAllowedStatus(status, allowedStatuses)) {
 				mu.Lock()
 				for _, line := range lns {
 					errs = append(errs, LintError{
@@ -178,6 +198,7 @@ func performCheck(client *http.Client, url string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := client.Do(req)
 	if err == nil {

--- a/internal/rule/external_link_internal_test.go
+++ b/internal/rule/external_link_internal_test.go
@@ -59,7 +59,7 @@ func Test_checkURL(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			status, err := checkURL(ts.Client(), ts.URL, 10)
+			status, err := checkURL(ts.Client(), ts.URL, 10, nil)
 			if tt.expectError && err == nil {
 				t.Errorf("expected error but got none")
 			}

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -42,7 +42,7 @@ func TestCheckExternalLinks_BasicSuccessFailure(t *testing.T) {
 
 	file := "mock.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(results))
@@ -70,7 +70,7 @@ func TestCheckExternalLinks_SkipPattern(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only non-localhost link should be checked), got %d", len(results))
@@ -89,7 +89,7 @@ func TestCheckExternalLinks_IgnoreCodeBlocks(t *testing.T) {
 	skip := []*regexp.Regexp{}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, nil, &sync.Map{})
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (code block link should be ignored), got %d", len(results))
 	}
@@ -119,7 +119,7 @@ Line 8 [link8](%s/fail8)
 
 	skip := []*regexp.Regexp{}
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 5 {
 		t.Fatalf("expected 5 errors, got %d", len(results))
@@ -151,9 +151,9 @@ func TestCheckExternalLinks_Deduplication(t *testing.T) {
 	lines, offset := toLines(markdown)
 
 	// First call - should trigger HTTP request
-	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, urlCache)
+	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
 	// Second call - should use cache
-	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, urlCache)
+	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
 
 	if requestCount != 1 {
 		t.Errorf("expected only 1 HTTP request due to caching, but got %d", requestCount)
@@ -167,7 +167,7 @@ func TestCheckExternalLinks_MultipleOccurrences(t *testing.T) {
 	markdown := fmt.Sprintf("[fail](%s/fail)\n[fail again](%s/fail)", ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	// Should report errors for each occurrence
 	if len(results) != 2 {
@@ -195,7 +195,7 @@ func TestCheckExternalLinks_AllLinksSucceed(t *testing.T) {
 [link3](%s/ok)`, ts.URL, ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors for all successful links, got %d", len(results))
@@ -217,7 +217,7 @@ func TestCheckExternalLinks_HTTPStatusBoundary(t *testing.T) {
 	fileName := "boundary.md"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only 400), got %d", len(results))
@@ -250,7 +250,7 @@ func TestCheckExternalLinks_MultipleSkipPatterns(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only httpstat.us), got %d", len(results))
@@ -275,7 +275,7 @@ func TestCheckExternalLinks_NetworkError(t *testing.T) {
 	unreachableURL := "http://invalid.test.localhost.invalid:9999/path"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error for network failure, got %d", len(results))
@@ -309,7 +309,7 @@ func TestCheckExternalLinks_DifferentHTTPStatusCodes(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)\n[server-error](%s/500)\n[unavailable](%s/503)", statusTs.URL, statusTs.URL, statusTs.URL)
 	fileName := "test.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 errors, got %d", len(results))
@@ -354,7 +354,7 @@ func TestCheckExternalLinks_RetrySuccess(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors due to successful retry, but got %d", len(results))
@@ -376,7 +376,7 @@ func TestCheckExternalLinks_NoRetryFor404(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	// For 404, there should be no retry; it should give up after a single request
 	if requestCount != 1 {
@@ -397,7 +397,7 @@ func TestCheckExternalLinks_ConcurrencyLimit(t *testing.T) {
 	markdown := strings.Join(links, "\n")
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors, got %d", len(results))
@@ -412,14 +412,14 @@ func TestCheckExternalLinks_CacheErrorState(t *testing.T) {
 
 	// First call - should trigger network error
 	lines, offset := toLines(markdown)
-	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, urlCache)
+	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, urlCache)
 
 	if len(results1) != 1 {
 		t.Fatalf("first call: expected 1 error for network failure, got %d", len(results1))
 	}
 
 	// Second call with same cache - should use cached error and report the same error
-	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, urlCache)
+	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, urlCache)
 
 	if len(results2) != 1 {
 		t.Fatalf("second call: expected 1 error from cache, got %d", len(results2))
@@ -446,7 +446,7 @@ func TestCheckExternalLinks_CacheInvalidType(t *testing.T) {
 
 	// Call CheckExternalLinks - should detect invalid cache type and re-check
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, urlCache)
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
 
 	// Should still get error because URL returns 404
 	if len(results) != 1 {
@@ -634,12 +634,68 @@ func TestCheckExternalLinks_GETFallback(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback should succeed), got: %v", results)
 	}
 	if count != 1 {
 		t.Errorf("expected 1 link checked, got %d", count)
+	}
+}
+
+func TestCheckExternalLinks_429NotFlagged(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[rate-limited](%s/429)", ts.URL)
+	lines, offset := toLines(markdown)
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+
+	if len(results) != 0 {
+		t.Errorf("expected no violations for 429 (rate limiting), got %d: %v", len(results), results)
+	}
+}
+
+func TestCheckExternalLinks_AllowedStatuses(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/403":
+			w.WriteHeader(http.StatusForbidden)
+		case "/500":
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	// 403 is in allowedStatuses → no violation; 500 is not → violation
+	markdown := fmt.Sprintf("[forbidden](%s/403)\n[server-error](%s/500)", ts.URL, ts.URL)
+	lines, offset := toLines(markdown)
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, []int{403}, &sync.Map{})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 violation (500 only), got %d: %v", len(results), results)
+	}
+	if !strings.Contains(results[0].Message, "/500") {
+		t.Errorf("expected violation for /500, got: %s", results[0].Message)
+	}
+}
+
+func TestPerformCheck_UserAgentHeader(t *testing.T) {
+	var gotUA string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[link](%s/page)", ts.URL)
+	lines, offset := toLines(markdown)
+	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+
+	if !strings.Contains(gotUA, "gomarklint") {
+		t.Errorf("expected User-Agent to contain 'gomarklint', got %q", gotUA)
 	}
 }


### PR DESCRIPTION
## Summary

- Set `User-Agent: gomarklint/v2 (+https://github.com/shinagawa-web/gomarklint)` on all HTTP requests to avoid false 403s from CDN bot protection (Wikipedia, academic publishers, etc.)
- Add `allowedStatuses` config option to treat specific status codes as non-errors
- 429 (Too Many Requests) is built-in to the default allowed statuses — rate limiting is not a broken link

### Config example

```json
"external-link": {
  "enabled": true,
  "allowedStatuses": [403]
}
```

Closes #155
Closes #174

## Test plan

- [x] `TestPerformCheck_UserAgentHeader` — verifies `gomarklint` UA is sent
- [x] `TestCheckExternalLinks_429NotFlagged` — 429 not reported by default
- [x] `TestCheckExternalLinks_AllowedStatuses` — 403 skipped when in allowedStatuses, 500 still reported
- [x] `TestRun_LinkCheckWithAllowedStatuses` — linter-level integration test
- [x] `make test-all` passes
- [x] `make check-coverage` 100%