### PR TITLE
bench(PR-9): unclosed-code-block — first-byte prefilter in GetCodeBlockLineRanges

### DIFF
--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -32,7 +32,7 @@ func CheckUnclosedCodeBlocks(filename string, lines []string, offset int) []Lint
 // GetCodeBlockLineRanges scans lines and returns the 1-based line ranges of all
 // closed fenced code blocks and the 0-based start lines of any unclosed ones.
 //
-// Optimisation: a byte-level prefilter (firstNonSpaceByte) avoids calling
+// Optimization: a byte-level prefilter (firstNonSpaceByte) avoids calling
 // strings.TrimSpace on the ~95% of lines that cannot be fence openers or
 // closers. Inside a block, only a line whose first non-space byte matches the
 // opening fence character can close the block.

--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -29,6 +29,13 @@ func CheckUnclosedCodeBlocks(filename string, lines []string, offset int) []Lint
 	return errs
 }
 
+// GetCodeBlockLineRanges scans lines and returns the 1-based line ranges of all
+// closed fenced code blocks and the 0-based start lines of any unclosed ones.
+//
+// Optimisation: a byte-level prefilter (firstNonSpaceByte) avoids calling
+// strings.TrimSpace on the ~95% of lines that cannot be fence openers or
+// closers. Inside a block, only a line whose first non-space byte matches the
+// opening fence character can close the block.
 func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
 	inBlock := false
 	var start int
@@ -37,8 +44,14 @@ func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
 	var unclosedStarts []int
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 		if inBlock {
+			// Only a line whose first non-space byte matches the opener's fence
+			// character can close the block; all others are content.
+			if first != fenceMarker[0] {
+				continue
+			}
+			trimmed := strings.TrimSpace(line)
 			if IsClosingFence(trimmed, fenceMarker) {
 				closedRanges = append(closedRanges, [2]int{start + 1, i + 1})
 				inBlock = false
@@ -46,6 +59,11 @@ func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
 			}
 			continue
 		}
+		// Outside a block, only backtick or tilde lines can open a fence.
+		if first != '`' && first != '~' {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
 		marker := openingFenceMarker(trimmed)
 		if marker != "" {
 			start = i

--- a/internal/rule/prefilter.go
+++ b/internal/rule/prefilter.go
@@ -1,0 +1,15 @@
+package rule
+
+// firstNonSpaceByte returns the first non-ASCII-whitespace byte in s, or 0 if
+// s is empty or all ASCII whitespace. Used as a cheap prefilter so that
+// strings.TrimSpace is only called on lines that can plausibly match a
+// rule-relevant pattern (fence opener/closer, ATX heading).
+func firstNonSpaceByte(s string) byte {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
+			return c
+		}
+	}
+	return 0
+}

--- a/internal/rule/single_h1.go
+++ b/internal/rule/single_h1.go
@@ -64,17 +64,3 @@ func CheckSingleH1(filename string, lines []string, offset int) []LintError {
 
 	return errs
 }
-
-// firstNonSpaceByte returns the first non-ASCII-whitespace byte in s, or 0 if
-// s is empty or all ASCII whitespace. Used as a cheap prefilter so that
-// strings.TrimSpace is only called on lines that can plausibly match a
-// rule-relevant pattern (fence opener/closer, ATX heading).
-func firstNonSpaceByte(s string) byte {
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
-			return c
-		}
-	}
-	return 0
-}


### PR DESCRIPTION
Part of #146.

## What changed

Added `firstNonSpaceByte` prefilter to `GetCodeBlockLineRanges` in `internal/rule/code_block.go`. No changes to `cmd/root_bench_test.go` — existing `writeCodeBlock()` already exercises the scan path, and the rule is enabled by default.

## Optimizations

1. **Outside `inBlock`**: skip `strings.TrimSpace` + `openingFenceMarker` on lines whose first non-space byte is neither `` ` `` nor `~` (~95% of lines).
2. **Inside `inBlock`**: skip lines where `firstNonSpaceByte != fenceMarker[0]` — only the same fence character as the opener can close the block.

## Benchmark

End-to-end (`make bench-compare`, Apple M4):

| metric | main | branch | delta |
|---|---|---|---|
| time/op | 3.624 ms | 3.502 ms | **−3.4% (p=0.038)** ✅ |
| B/op | 875.7 Ki | 875.2 Ki | ~ ✅ |
| allocs/op | 2,072 | 2,072 | ~ ✅ |

`GetCodeBlockLineRanges` is called by every rule that does inline code-block tracking, so the prefilter benefit compounds across the linter.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes
- [x] `make bench-compare` — no regression (all ✅)
- [x] `CheckUnclosedCodeBlocks` and `GetCodeBlockLineRanges` at 100% coverage
- [x] References #146