### PR TITLE
feat(link-fragments): implement link-fragments rule (MD051 equivalent)

### DIFF
--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -37,7 +37,6 @@ func benchmarkConfig() config.Config {
 func writeIntro(sb *strings.Builder) {
 	sb.WriteString("# Main Title\n\n")
 	sb.WriteString("This is the introduction to the document.\n\n")
-	sb.WriteString("See [Main Title](#main-title) for this section.\n\n")
 }
 
 func writeHeading(sb *strings.Builder, i int) {
@@ -77,7 +76,7 @@ func writeImage(sb *strings.Builder, i int) {
 
 func writeSubsection(sb *strings.Builder, i int) {
 	fmt.Fprintf(sb, "### Subsection %d.1\n\n", i)
-	fmt.Fprintf(sb, "See [Section %d](#section-%d) for the parent section.\n\n", i, i)
+	sb.WriteString("More detailed information goes here.\n\n")
 }
 
 // generateComplexMarkdown generates a realistic markdown file with mixed content.

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -26,12 +26,18 @@ func benchmarkConfig() config.Config {
 		Severity: config.SeverityError,
 		Options:  map[string]interface{}{"lineLength": float64(120)},
 	}
+	cfg.Rules["link-fragments"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"slug-algorithm": "github"},
+	}
 	return cfg
 }
 
 func writeIntro(sb *strings.Builder) {
 	sb.WriteString("# Main Title\n\n")
 	sb.WriteString("This is the introduction to the document.\n\n")
+	sb.WriteString("See [Main Title](#main-title) for this section.\n\n")
 }
 
 func writeHeading(sb *strings.Builder, i int) {
@@ -71,7 +77,7 @@ func writeImage(sb *strings.Builder, i int) {
 
 func writeSubsection(sb *strings.Builder, i int) {
 	fmt.Fprintf(sb, "### Subsection %d.1\n\n", i)
-	sb.WriteString("More detailed information goes here.\n\n")
+	fmt.Fprintf(sb, "See [Section %d](#section-%d) for the parent section.\n\n", i, i)
 }
 
 // generateComplexMarkdown generates a realistic markdown file with mixed content.

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -50,8 +50,8 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 | `vitepress` | VitePress |
 | `docusaurus` | Docusaurus |
 | `gatsby` | Gatsby (`gatsby-remark-autolink-headers`) |
-| `astro` | Astro / Starlight |
-| `starlight` | Starlight (alias for `astro`) |
+| `astro` | Astro |
+| `starlight` | Starlight |
 | `nuxt-content` | Nuxt Content |
 | `pandoc` | Pandoc (`auto_identifiers`) |
 | `pandoc-gfm` | Pandoc (`gfm_auto_identifiers`) |
@@ -63,10 +63,41 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 | `gitea` | Gitea |
 | `forgejo` | Forgejo |
 | `sphinx` | Sphinx |
-| `eleventy` | Eleventy (`@sindresorhus/slugify`, approximate) |
+| `eleventy` | Eleventy |
 | `azure-devops` | Azure DevOps Wiki |
 | `myst` | MyST Parser |
 | `custom` | Parameterized engine — see below |
+
+#### Preset reference
+
+Detailed slug behavior for each preset:
+
+| Value | lowercase | preserve-unicode | space-replacement | strip-chars | collapse-separators | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `github` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `github-slugger`; consecutive spaces → consecutive hyphens |
+| `gitlab` | ✓ | ✓ | `-` | `[^\p{L}\p{N}_-]` | ✓ | goldmark slugify; collapses consecutive separators unlike GitHub |
+| `zenn` | ✓ | ✓ | `-` | preserves all non-space chars | — | `markdown-it-anchor` default; anchors are percent-encoded in HTML |
+| `qiita` | ✓ | ✓ | `-` | `[^\p{Word}\- ]` | — | `downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-")`; consecutive hyphens preserved |
+| `hugo` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `autoHeadingIDType: github` (default); equivalent to `github-slugger` |
+| `vitepress` | ✓ | partial | `-` | NFKD, strip combining chars, then punctuation→`-` | ✓ | Accented Latin normalized to ASCII (é→e); CJK preserved |
+| `docusaurus` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `github-slugger` directly |
+| `gatsby` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gatsby-remark-autolink-headers` uses `github-slugger` |
+| `astro` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Documented as GitHub-compatible in Astro official docs |
+| `starlight` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Starlight (Astro-based); same algorithm as `astro` |
+| `nuxt-content` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `rehype-slug` (github-slugger wrapper) |
+| `pandoc` | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | `auto_identifiers` extension; strips non-ASCII |
+| `pandoc-gfm` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gfm_auto_identifiers` extension; equivalent to GitHub |
+| `quarto` | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | Uses `auto_identifiers` extension by default; same as `pandoc` |
+| `kramdown` | ✓ | — | `-` | `[^a-zA-Z0-9 -]` | ✓ | `header_ids` extension default |
+| `mkdocs` | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode |
+| `docfx` | — | — | `-` | `[^a-zA-Z0-9-_.]` | ✓ | Markdig AutoIdentifiers; does **not** lowercase |
+| `mdbook` | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
+| `gitea` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; `user-content-` prefix added in rendered HTML (not in fragment) |
+| `forgejo` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
+| `sphinx` | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings fall back to `id1`, `id2`, etc. |
+| `eleventy` | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |
+| `azure-devops` | ✓ | ✓ | `-` | non-RFC-3986-unreserved chars percent-encoded | — | Unicode Zs category → `-`; non-ASCII preserved as percent-encoded |
+| `myst` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | MyST-Parser (Python/Sphinx); documented as GitHub-compatible |
 
 ### Custom algorithm
 

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -60,7 +60,7 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 | `mkdocs` | MkDocs | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode |
 | `docfx` | DocFX | — | — | `-` | `[^a-zA-Z0-9-_.]` | ✓ | Markdig AutoIdentifiers; does **not** lowercase |
 | `mdbook` | mdBook | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
-| `gitea` | Gitea | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; `user-content-` prefix added in rendered HTML (not in fragment) |
+| `gitea` | Gitea | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; `user-content-` prefix is part of the fragment (e.g. `#user-content-hello`) |
 | `forgejo` | Forgejo | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
 | `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings fall back to `id1`, `id2`, etc. |
 | `eleventy` | Eleventy | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -28,6 +28,73 @@ weight: 2
 | `no-trailing-punctuation`      | Heading text ending with a punctuation character                        | Default **on**. Option: `punctuation` (default `".,;:!"`) — the full set of characters to flag; e.g. set `".,;:!?"` to also flag question headings |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
+| `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
+
+## link-fragments
+
+`link-fragments` validates that every internal fragment link in a document resolves to an actual heading slug. It supports multiple slug algorithms to match the platform where the Markdown is published.
+
+### slug-algorithm
+
+Set `slug-algorithm` to the name of the platform you are writing for. Each platform is an independent named value — you do not need to know which underlying algorithm it maps to.
+
+**Supported platforms:**
+
+| Value | Platform |
+| --- | --- |
+| `github` | GitHub (default) |
+| `gitlab` | GitLab |
+| `zenn` | Zenn |
+| `qiita` | Qiita |
+| `hugo` | Hugo |
+| `vitepress` | VitePress |
+| `docusaurus` | Docusaurus |
+| `gatsby` | Gatsby (`gatsby-remark-autolink-headers`) |
+| `astro` | Astro / Starlight |
+| `starlight` | Starlight (alias for `astro`) |
+| `nuxt-content` | Nuxt Content |
+| `pandoc` | Pandoc (`auto_identifiers`) |
+| `pandoc-gfm` | Pandoc (`gfm_auto_identifiers`) |
+| `quarto` | Quarto |
+| `kramdown` | kramdown |
+| `mkdocs` | MkDocs |
+| `docfx` | DocFX |
+| `mdbook` | mdBook |
+| `gitea` | Gitea |
+| `forgejo` | Forgejo |
+| `sphinx` | Sphinx |
+| `eleventy` | Eleventy (`@sindresorhus/slugify`, approximate) |
+| `azure-devops` | Azure DevOps Wiki |
+| `myst` | MyST Parser |
+| `custom` | Parameterized engine — see below |
+
+### Custom algorithm
+
+Use `slug-algorithm: "custom"` with `slug-params` for platforms not covered by the built-in presets:
+
+```json
+"link-fragments": {
+  "enabled": true,
+  "slug-algorithm": "custom",
+  "slug-params": {
+    "lowercase": true,
+    "preserve-unicode": true,
+    "space-replacement": "-",
+    "strip-chars": "[^\\w\\- ]",
+    "collapse-separators": true
+  }
+}
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `lowercase` | bool | Lowercase the heading before processing (default `true`) |
+| `preserve-unicode` | bool | Keep non-ASCII characters in the slug (default `true`) |
+| `space-replacement` | string | Character to replace spaces — `"-"` or `"_"` (default `"-"`) |
+| `strip-chars` | string | Regex matching characters to remove after space replacement |
+| `collapse-separators` | bool | Collapse consecutive separators and trim leading/trailing (default `false`) |
+
+> **Note:** `strip-chars` uses Go's `regexp` syntax. `\w` matches ASCII `[0-9A-Za-z_]` only. To match Unicode word characters use `\p{L}`, `\p{N}`, etc.
 
 ## Execution details
 

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -40,64 +40,33 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 
 **Supported platforms:**
 
-| Value | Platform |
-| --- | --- |
-| `github` | GitHub (default) |
-| `gitlab` | GitLab |
-| `zenn` | Zenn |
-| `qiita` | Qiita |
-| `hugo` | Hugo |
-| `vitepress` | VitePress |
-| `docusaurus` | Docusaurus |
-| `gatsby` | Gatsby (`gatsby-remark-autolink-headers`) |
-| `astro` | Astro |
-| `starlight` | Starlight |
-| `nuxt-content` | Nuxt Content |
-| `pandoc` | Pandoc (`auto_identifiers`) |
-| `pandoc-gfm` | Pandoc (`gfm_auto_identifiers`) |
-| `quarto` | Quarto |
-| `kramdown` | kramdown |
-| `mkdocs` | MkDocs |
-| `docfx` | DocFX |
-| `mdbook` | mdBook |
-| `gitea` | Gitea |
-| `forgejo` | Forgejo |
-| `sphinx` | Sphinx |
-| `eleventy` | Eleventy |
-| `azure-devops` | Azure DevOps Wiki |
-| `myst` | MyST Parser |
-| `custom` | Parameterized engine — see below |
-
-#### Preset reference
-
-Detailed slug behavior for each preset:
-
-| Value | lowercase | preserve-unicode | space-replacement | strip-chars | collapse-separators | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| `github` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `github-slugger`; consecutive spaces → consecutive hyphens |
-| `gitlab` | ✓ | ✓ | `-` | `[^\p{L}\p{N}_-]` | ✓ | goldmark slugify; collapses consecutive separators unlike GitHub |
-| `zenn` | ✓ | ✓ | `-` | preserves all non-space chars | — | `markdown-it-anchor` default; anchors are percent-encoded in HTML |
-| `qiita` | ✓ | ✓ | `-` | `[^\p{Word}\- ]` | — | `downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-")`; consecutive hyphens preserved |
-| `hugo` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `autoHeadingIDType: github` (default); equivalent to `github-slugger` |
-| `vitepress` | ✓ | partial | `-` | NFKD, strip combining chars, then punctuation→`-` | ✓ | Accented Latin normalized to ASCII (é→e); CJK preserved |
-| `docusaurus` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `github-slugger` directly |
-| `gatsby` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gatsby-remark-autolink-headers` uses `github-slugger` |
-| `astro` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Documented as GitHub-compatible in Astro official docs |
-| `starlight` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Starlight (Astro-based); same algorithm as `astro` |
-| `nuxt-content` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `rehype-slug` (github-slugger wrapper) |
-| `pandoc` | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | `auto_identifiers` extension; strips non-ASCII |
-| `pandoc-gfm` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gfm_auto_identifiers` extension; equivalent to GitHub |
-| `quarto` | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | Uses `auto_identifiers` extension by default; same as `pandoc` |
-| `kramdown` | ✓ | — | `-` | `[^a-zA-Z0-9 -]` | ✓ | `header_ids` extension default |
-| `mkdocs` | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode |
-| `docfx` | — | — | `-` | `[^a-zA-Z0-9-_.]` | ✓ | Markdig AutoIdentifiers; does **not** lowercase |
-| `mdbook` | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
-| `gitea` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; `user-content-` prefix added in rendered HTML (not in fragment) |
-| `forgejo` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
-| `sphinx` | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings fall back to `id1`, `id2`, etc. |
-| `eleventy` | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |
-| `azure-devops` | ✓ | ✓ | `-` | non-RFC-3986-unreserved chars percent-encoded | — | Unicode Zs category → `-`; non-ASCII preserved as percent-encoded |
-| `myst` | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | MyST-Parser (Python/Sphinx); documented as GitHub-compatible |
+| Value | Platform | lowercase | preserve-unicode | space-replacement | strip-chars | collapse-separators | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `github` | GitHub (default) | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `github-slugger`; consecutive spaces → consecutive hyphens |
+| `gitlab` | GitLab | ✓ | ✓ | `-` | `[^\p{L}\p{N}_-]` | ✓ | goldmark slugify; collapses consecutive separators unlike GitHub |
+| `zenn` | Zenn | ✓ | ✓ | `-` | preserves all non-space chars | — | `markdown-it-anchor` default; anchors are percent-encoded in HTML |
+| `qiita` | Qiita | ✓ | ✓ | `-` | `[^\p{Word}\- ]` | — | `downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-")`; consecutive hyphens preserved |
+| `hugo` | Hugo | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `autoHeadingIDType: github` (default); equivalent to `github-slugger` |
+| `vitepress` | VitePress | ✓ | partial | `-` | NFKD, strip combining chars, then punctuation→`-` | ✓ | Accented Latin normalized to ASCII (é→e); CJK preserved |
+| `docusaurus` | Docusaurus | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `github-slugger` directly |
+| `gatsby` | Gatsby | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gatsby-remark-autolink-headers` uses `github-slugger` |
+| `astro` | Astro | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Documented as GitHub-compatible in Astro official docs |
+| `starlight` | Starlight | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Starlight (Astro-based); same algorithm as `astro` |
+| `nuxt-content` | Nuxt Content | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `rehype-slug` (github-slugger wrapper) |
+| `pandoc` | Pandoc (`auto_identifiers`) | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | `auto_identifiers` extension; strips non-ASCII |
+| `pandoc-gfm` | Pandoc (`gfm_auto_identifiers`) | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gfm_auto_identifiers` extension; equivalent to GitHub |
+| `quarto` | Quarto | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | Uses `auto_identifiers` extension by default; same as `pandoc` |
+| `kramdown` | kramdown | ✓ | — | `-` | `[^a-zA-Z0-9 -]` | ✓ | `header_ids` extension default |
+| `mkdocs` | MkDocs | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode |
+| `docfx` | DocFX | — | — | `-` | `[^a-zA-Z0-9-_.]` | ✓ | Markdig AutoIdentifiers; does **not** lowercase |
+| `mdbook` | mdBook | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
+| `gitea` | Gitea | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; `user-content-` prefix added in rendered HTML (not in fragment) |
+| `forgejo` | Forgejo | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
+| `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings fall back to `id1`, `id2`, etc. |
+| `eleventy` | Eleventy | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |
+| `azure-devops` | Azure DevOps Wiki | ✓ | ✓ | `-` | non-RFC-3986-unreserved chars percent-encoded | — | Unicode Zs category → `-`; non-ASCII preserved as percent-encoded |
+| `myst` | MyST Parser | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | MyST-Parser (Python/Sphinx); documented as GitHub-compatible |
+| `custom` | — | — | — | — | — | — | Parameterized engine — see below |
 
 ### Custom algorithm
 

--- a/e2e/config-link-fragments-custom.json
+++ b/e2e/config-link-fragments-custom.json
@@ -1,0 +1,20 @@
+{
+  "default": false,
+  "rules": {
+    "link-fragments": {
+      "enabled": true,
+      "severity": "error",
+      "slug-algorithm": "custom",
+      "slug-params": {
+        "lowercase": true,
+        "preserve-unicode": true,
+        "space-replacement": "-",
+        "strip-chars": "[^\\w\\- ]",
+        "collapse-separators": true
+      }
+    }
+  },
+  "include": ["fixtures"],
+  "ignore": [],
+  "output": "text"
+}

--- a/e2e/config-link-fragments.json
+++ b/e2e/config-link-fragments.json
@@ -1,0 +1,9 @@
+{
+  "default": false,
+  "rules": {
+    "link-fragments": { "enabled": true, "severity": "error", "slug-algorithm": "github" }
+  },
+  "include": ["fixtures"],
+  "ignore": [],
+  "output": "text"
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -558,7 +558,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "hard tab character found")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
 		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 45 file(s)")
+		assertOutputContains(t, output, "Checked 47 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -391,6 +391,24 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, `heading ends with "!"`)
 		assertOutputContains(t, output, "3 issues found")
 	})
+
+	t.Run("LinkFragmentsValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/link_fragments_valid.md", "--config", "config-link-fragments.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "link-fragments")
+	})
+
+	t.Run("LinkFragmentsViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/link_fragments_violation.md", "--config", "config-link-fragments.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/link_fragments_violation.md:")
+		assertOutputContains(t, output, "fixtures/link_fragments_violation.md:3:")
+		assertOutputContains(t, output, "link-fragments")
+		assertOutputContains(t, output, "#setup")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -409,6 +409,24 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "#setup")
 		assertOutputContains(t, output, "1 issues found")
 	})
+
+	t.Run("LinkFragmentsCustomValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/link_fragments_custom_valid.md", "--config", "config-link-fragments-custom.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "link-fragments")
+	})
+
+	t.Run("LinkFragmentsCustomViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/link_fragments_custom_violation.md", "--config", "config-link-fragments-custom.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/link_fragments_custom_violation.md:")
+		assertOutputContains(t, output, "fixtures/link_fragments_custom_violation.md:3:")
+		assertOutputContains(t, output, "link-fragments")
+		assertOutputContains(t, output, "#setup")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -558,7 +558,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "hard tab character found")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
 		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 47 file(s)")
+		assertOutputContains(t, output, "Checked 49 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")

--- a/e2e/fixtures/link_fragments_custom_valid.md
+++ b/e2e/fixtures/link_fragments_custom_valid.md
@@ -1,0 +1,17 @@
+## Introduction
+
+Some introductory text.
+
+## Getting Started
+
+See [Introduction](#introduction) for background.
+
+Also see [Getting Started](#getting-started) for this section.
+
+### Installation
+
+A subsection about installation.
+
+See [Getting Started](#getting-started) for the parent section.
+
+[ref-getting-started]: #getting-started

--- a/e2e/fixtures/link_fragments_custom_violation.md
+++ b/e2e/fixtures/link_fragments_custom_violation.md
@@ -1,0 +1,7 @@
+## Introduction
+
+See [Setup](#setup) for details.
+
+## Getting Started
+
+Some text.

--- a/e2e/fixtures/link_fragments_valid.md
+++ b/e2e/fixtures/link_fragments_valid.md
@@ -1,0 +1,21 @@
+## Introduction
+
+Some introductory text.
+
+## Getting Started
+
+See [Introduction](#introduction) for background.
+
+Also see [Getting Started](#getting-started) for this section.
+
+### Installation
+
+A subsection about installation.
+
+See [Getting Started](#getting-started) for the parent section.
+
+## References
+
+Check [References](#references) for more links.
+
+[ref-getting-started]: #getting-started

--- a/e2e/fixtures/link_fragments_violation.md
+++ b/e2e/fixtures/link_fragments_violation.md
@@ -1,0 +1,7 @@
+## Introduction
+
+See [Setup](#setup) for details.
+
+## Getting Started
+
+Some text.

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/text v0.21.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shinagawa-web/gomarklint/v2
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
@@ -10,4 +10,5 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/text v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,5 +21,9 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,8 @@ const DefaultConfigJSON = `{
     "no-hard-tabs": true,
     "no-trailing-punctuation": { "punctuation": ".,;:!" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
+    "link-fragments": { "enabled": false, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],
@@ -246,6 +247,11 @@ func Default() Config {
 				Enabled:  false,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "skipPatterns": []interface{}{}},
+			},
+			"link-fragments": {
+				Enabled:  false,
+				Severity: SeverityOff,
+				Options:  map[string]interface{}{"slug-algorithm": "github"},
 			},
 		},
 		Include:      []string{"README.md", "testdata"},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -242,6 +242,9 @@ func (l *Linter) collectLineErrors(path string, lines []string, offset int) []ru
 	if l.config.IsEnabled("no-trailing-punctuation") {
 		errs = append(errs, l.withSeverity(rule.CheckNoTrailingPunctuation(path, lines, offset, l.noTrailingPunctuation()), "no-trailing-punctuation")...)
 	}
+	if l.config.IsEnabled("link-fragments") {
+		errs = append(errs, l.withSeverity(rule.CheckLinkFragments(path, lines, offset, l.config.RuleOptions("link-fragments")), "link-fragments")...)
+	}
 	return errs
 }
 

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -807,3 +807,51 @@ func TestRun_NoTrailingPunctuation_NoOptionFallsBackToDefault(t *testing.T) {
 		t.Errorf("expected default punctuation %q, got %q", config.DefaultNoTrailingPunctuation, linter.noTrailingPunctuation())
 	}
 }
+
+func TestRun_LinkFragments_DetectsViolation(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["link-fragments"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"slug-algorithm": "github"},
+	}
+
+	lint := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.md")
+	content := "## Introduction\n\nSee [Setup](#setup) for details.\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := lint.Run([]string{testFile})
+
+	if result.TotalErrors == 0 {
+		t.Error("expected error for broken fragment link")
+	}
+}
+
+func TestRun_LinkFragments_ValidLink(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["link-fragments"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"slug-algorithm": "github"},
+	}
+
+	lint := New(cfg)
+
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.md")
+	content := "## Introduction\n\nSee [Introduction](#introduction) for details.\n"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	result := lint.Run([]string{testFile})
+
+	if result.TotalErrors != 0 {
+		t.Errorf("expected no errors for valid fragment link, got %d", result.TotalErrors)
+	}
+}

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -1,0 +1,170 @@
+package rule
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// extractHeadingText extracts the plain text from an ATX heading line (e.g. ## Heading).
+// Returns the trimmed heading text and its level (1–6).
+// Returns "", 0 for lines that are not valid ATX headings.
+func extractHeadingText(line string) (string, int) {
+	if len(line) == 0 || line[0] != '#' {
+		return "", 0
+	}
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level > 6 {
+		return "", 0
+	}
+	rest := line[level:]
+	if rest == "" {
+		return "", level
+	}
+	if rest[0] != ' ' {
+		return "", 0
+	}
+	return strings.TrimSpace(rest[1:]), level
+}
+
+// reFragmentLink matches inline fragment links: [text](#fragment)
+// Capture group 1 is the fragment without the leading #.
+var reFragmentLink = regexp.MustCompile(`\[[^\]]*\]\(#([^)]+)\)`)
+
+// reRefLinkUsage matches reference-style link usage: [text][label]
+// Capture group 1 is the reference label.
+var reRefLinkUsage = regexp.MustCompile(`\[[^\]]*\]\[([^\]]+)\]`)
+
+// reRefDef matches reference link definitions that target a fragment: [label]: #fragment
+// Capture group 1 is the label; group 2 is the fragment without the leading #.
+var reRefDef = regexp.MustCompile(`^\s*\[([^\]]+)\]:\s+#(\S+)`)
+
+// collectRefDefs returns a map from normalized reference label to fragment string (without #)
+// for all reference link definitions in lines that target a fragment destination.
+func collectRefDefs(lines []string) map[string]string {
+	defs := make(map[string]string)
+	for _, line := range lines {
+		m := reRefDef.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		label := strings.ToLower(strings.TrimSpace(m[1]))
+		fragment := strings.TrimSpace(m[2])
+		defs[label] = fragment
+	}
+	return defs
+}
+
+// collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings
+// in lines. Headings inside fenced code blocks are excluded.
+// Duplicate headings produce suffixed slugs (-1, -2, …) following GitHub convention.
+func collectHeadingSlugs(lines []string, algorithm string) map[string]struct{} {
+	var headings []string
+
+	inBlock := false
+	fenceMarker := ""
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		text, level := extractHeadingText(trimmed)
+		if level == 0 {
+			continue
+		}
+		headings = append(headings, text)
+	}
+
+	return buildSlugSet(headings, algorithm)
+}
+
+// CheckLinkFragments validates that every internal fragment link in the document
+// resolves to an actual heading slug. Both inline links ([text](#frag)) and
+// reference links ([text][ref] + [ref]: #frag) are checked. Content inside fenced
+// code blocks and inline code spans is skipped.
+//
+// Supported options:
+//   - "slug-algorithm": string — one of github, gitlab, zenn, pandoc, pandoc-gfm,
+//     kramdown, mkdocs, docfx, hugo (default: "github")
+func CheckLinkFragments(filename string, lines []string, offset int, options map[string]interface{}) []LintError {
+	algorithm := "github"
+	if v, ok := options["slug-algorithm"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			algorithm = s
+		}
+	}
+
+	slugs := collectHeadingSlugs(lines, algorithm)
+	refDefs := collectRefDefs(lines)
+
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		scanned := line
+		if strings.ContainsRune(scanned, '`') {
+			scanned = stripInlineCode(scanned)
+		}
+
+		lineNum := offset + i + 1
+
+		for _, m := range reFragmentLink.FindAllStringSubmatch(scanned, -1) {
+			fragment := m[1]
+			if _, ok := slugs[fragment]; !ok {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    lineNum,
+					Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
+				})
+			}
+		}
+
+		for _, m := range reRefLinkUsage.FindAllStringSubmatch(scanned, -1) {
+			label := strings.ToLower(strings.TrimSpace(m[1]))
+			fragment, ok := refDefs[label]
+			if !ok {
+				continue
+			}
+			if _, found := slugs[fragment]; !found {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    lineNum,
+					Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
+				})
+			}
+		}
+	}
+
+	return errs
+}

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -24,7 +24,7 @@ func extractHeadingText(line string) (string, int) {
 	if rest == "" {
 		return "", level
 	}
-	if rest[0] != ' ' {
+	if rest[0] != ' ' && rest[0] != '\t' {
 		return "", 0
 	}
 	return strings.TrimSpace(rest[1:]), level
@@ -42,11 +42,32 @@ var reRefLinkUsage = regexp.MustCompile(`\[[^\]]*\]\[([^\]]+)\]`)
 // Capture group 1 is the label; group 2 is the fragment without the leading #.
 var reRefDef = regexp.MustCompile(`^\s*\[([^\]]+)\]:\s+#(\S+)`)
 
+// reStripInlineImages matches inline images: ![alt](url)
+// Used to remove image syntax before fragment link detection to avoid false positives
+// from image fragments like ![alt](#fig-1).
+var reStripInlineImages = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
+
 // collectRefDefs returns a map from normalized reference label to fragment string (without #)
 // for all reference link definitions in lines that target a fragment destination.
+// Definitions inside fenced code blocks are excluded.
 func collectRefDefs(lines []string) map[string]string {
 	defs := make(map[string]string)
+	inBlock := false
+	fenceMarker := ""
 	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
 		// Reference definitions must start with optional whitespace then '['.
 		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "[") {
 			continue
@@ -95,6 +116,19 @@ func collectHeadingSlugs(lines []string, slugger func(string) string) map[string
 	}
 
 	return buildSlugSet(headings, slugger)
+}
+
+// hasAnyFragmentSyntax is a cheap pre-filter that reports whether lines contain
+// any text that could be a fragment link or fragment definition, without
+// allocating any state. Checks for "(#" (inline fragment links) and
+// "]: #" (reference definition pointing at a fragment).
+func hasAnyFragmentSyntax(lines []string) bool {
+	for _, line := range lines {
+		if strings.Contains(line, "(#") || strings.Contains(line, "]: #") {
+			return true
+		}
+	}
+	return false
 }
 
 // hasAnyFragmentLinks reports whether lines contain at least one potential
@@ -172,6 +206,9 @@ func checkRefFragments(filename string, lineNum int, scanned string, slugs map[s
 //     preserve-unicode (bool), space-replacement (string), strip-chars (regex string),
 //     collapse-separators (bool)
 func CheckLinkFragments(filename string, lines []string, offset int, options map[string]interface{}) []LintError {
+	if !hasAnyFragmentSyntax(lines) {
+		return nil
+	}
 	refDefs := collectRefDefs(lines)
 	if !hasAnyFragmentLinks(lines, refDefs) {
 		return nil
@@ -207,6 +244,9 @@ func CheckLinkFragments(filename string, lines []string, offset int, options map
 		}
 
 		scanned := line
+		if strings.ContainsRune(scanned, '!') {
+			scanned = reStripInlineImages.ReplaceAllString(scanned, "")
+		}
 		if strings.ContainsRune(scanned, '`') {
 			scanned = stripInlineCode(scanned)
 		}

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -65,7 +65,7 @@ func collectRefDefs(lines []string) map[string]string {
 // collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings
 // in lines. Headings inside fenced code blocks are excluded.
 // Duplicate headings produce suffixed slugs (-1, -2, …) following GitHub convention.
-func collectHeadingSlugs(lines []string, algorithm string) map[string]struct{} {
+func collectHeadingSlugs(lines []string, slugger func(string) string) map[string]struct{} {
 	var headings []string
 
 	inBlock := false
@@ -94,7 +94,7 @@ func collectHeadingSlugs(lines []string, algorithm string) map[string]struct{} {
 		headings = append(headings, text)
 	}
 
-	return buildSlugSet(headings, algorithm)
+	return buildSlugSet(headings, slugger)
 }
 
 // hasAnyFragmentLinks reports whether lines contain at least one potential
@@ -164,14 +164,20 @@ func checkRefFragments(filename string, lineNum int, scanned string, slugs map[s
 // code blocks and inline code spans is skipped.
 //
 // Supported options:
-//   - "slug-algorithm": string — one of github, gitlab, zenn, pandoc, pandoc-gfm,
-//     kramdown, mkdocs, docfx, hugo (default: "github")
+//   - "slug-algorithm": string — preset name (github, gitlab, zenn, pandoc, pandoc-gfm,
+//     kramdown, mkdocs, docfx, hugo, qiita, mdbook, vitepress, gitea, forgejo, sphinx,
+//     eleventy, azure-devops, myst, docusaurus, gatsby, astro, starlight, nuxt-content,
+//     quarto) or "custom" (default: "github")
+//   - "slug-params": map — used only when slug-algorithm is "custom"; keys: lowercase (bool),
+//     preserve-unicode (bool), space-replacement (string), strip-chars (regex string),
+//     collapse-separators (bool)
 func CheckLinkFragments(filename string, lines []string, offset int, options map[string]interface{}) []LintError {
 	refDefs := collectRefDefs(lines)
 	if !hasAnyFragmentLinks(lines, refDefs) {
 		return nil
 	}
-	slugs := collectHeadingSlugs(lines, parseSlugAlgorithm(options))
+	algorithm := parseSlugAlgorithm(options)
+	slugs := collectHeadingSlugs(lines, makeSlugger(algorithm, options))
 
 	var errs []LintError
 	inBlock := false

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -47,6 +47,10 @@ var reRefDef = regexp.MustCompile(`^\s*\[([^\]]+)\]:\s+#(\S+)`)
 func collectRefDefs(lines []string) map[string]string {
 	defs := make(map[string]string)
 	for _, line := range lines {
+		// Reference definitions must start with optional whitespace then '['.
+		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "[") {
+			continue
+		}
 		m := reRefDef.FindStringSubmatch(line)
 		if m == nil {
 			continue
@@ -93,6 +97,67 @@ func collectHeadingSlugs(lines []string, algorithm string) map[string]struct{} {
 	return buildSlugSet(headings, algorithm)
 }
 
+// hasAnyFragmentLinks reports whether lines contain at least one potential
+// fragment link. The check is intentionally coarse (no code-block awareness)
+// to stay O(n) with a single pass and minimal overhead.
+func hasAnyFragmentLinks(lines []string, refDefs map[string]string) bool {
+	for _, line := range lines {
+		if strings.Contains(line, "(#") {
+			return true
+		}
+		if len(refDefs) > 0 && strings.Contains(line, "][") {
+			return true
+		}
+	}
+	return false
+}
+
+// parseSlugAlgorithm extracts the slug-algorithm option, defaulting to "github".
+func parseSlugAlgorithm(options map[string]interface{}) string {
+	if v, ok := options["slug-algorithm"]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+	return "github"
+}
+
+// checkInlineFragments checks inline fragment links ([text](#frag)) on one line.
+func checkInlineFragments(filename string, lineNum int, scanned string, slugs map[string]struct{}) []LintError {
+	var errs []LintError
+	for _, m := range reFragmentLink.FindAllStringSubmatch(scanned, -1) {
+		fragment := m[1]
+		if _, ok := slugs[fragment]; !ok {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    lineNum,
+				Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
+			})
+		}
+	}
+	return errs
+}
+
+// checkRefFragments checks reference-style fragment links ([text][ref] with [ref]: #frag) on one line.
+func checkRefFragments(filename string, lineNum int, scanned string, slugs map[string]struct{}, refDefs map[string]string) []LintError {
+	var errs []LintError
+	for _, m := range reRefLinkUsage.FindAllStringSubmatch(scanned, -1) {
+		label := strings.ToLower(strings.TrimSpace(m[1]))
+		fragment, ok := refDefs[label]
+		if !ok {
+			continue
+		}
+		if _, found := slugs[fragment]; !found {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    lineNum,
+				Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
+			})
+		}
+	}
+	return errs
+}
+
 // CheckLinkFragments validates that every internal fragment link in the document
 // resolves to an actual heading slug. Both inline links ([text](#frag)) and
 // reference links ([text][ref] + [ref]: #frag) are checked. Content inside fenced
@@ -102,15 +167,11 @@ func collectHeadingSlugs(lines []string, algorithm string) map[string]struct{} {
 //   - "slug-algorithm": string — one of github, gitlab, zenn, pandoc, pandoc-gfm,
 //     kramdown, mkdocs, docfx, hugo (default: "github")
 func CheckLinkFragments(filename string, lines []string, offset int, options map[string]interface{}) []LintError {
-	algorithm := "github"
-	if v, ok := options["slug-algorithm"]; ok {
-		if s, ok := v.(string); ok && s != "" {
-			algorithm = s
-		}
-	}
-
-	slugs := collectHeadingSlugs(lines, algorithm)
 	refDefs := collectRefDefs(lines)
+	if !hasAnyFragmentLinks(lines, refDefs) {
+		return nil
+	}
+	slugs := collectHeadingSlugs(lines, parseSlugAlgorithm(options))
 
 	var errs []LintError
 	inBlock := false
@@ -132,37 +193,24 @@ func CheckLinkFragments(filename string, lines []string, offset int, options map
 			continue
 		}
 
+		// Fast path: skip lines with no potential fragment links.
+		hasInlineLink := strings.Contains(line, "(#")
+		hasRefLink := len(refDefs) > 0 && strings.Contains(line, "][")
+		if !hasInlineLink && !hasRefLink {
+			continue
+		}
+
 		scanned := line
 		if strings.ContainsRune(scanned, '`') {
 			scanned = stripInlineCode(scanned)
 		}
 
 		lineNum := offset + i + 1
-
-		for _, m := range reFragmentLink.FindAllStringSubmatch(scanned, -1) {
-			fragment := m[1]
-			if _, ok := slugs[fragment]; !ok {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    lineNum,
-					Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
-				})
-			}
+		if hasInlineLink {
+			errs = append(errs, checkInlineFragments(filename, lineNum, scanned, slugs)...)
 		}
-
-		for _, m := range reRefLinkUsage.FindAllStringSubmatch(scanned, -1) {
-			label := strings.ToLower(strings.TrimSpace(m[1]))
-			fragment, ok := refDefs[label]
-			if !ok {
-				continue
-			}
-			if _, found := slugs[fragment]; !found {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    lineNum,
-					Message: fmt.Sprintf("link-fragments: fragment #%s not found in this document", fragment),
-				})
-			}
+		if hasRefLink {
+			errs = append(errs, checkRefFragments(filename, lineNum, scanned, slugs, refDefs)...)
 		}
 	}
 

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -461,40 +461,54 @@ func makeSlugger(algorithm string, options map[string]interface{}) func(string) 
 	}
 }
 
+// slugRegistry maps each supported platform name to its slug function.
+// Each platform is listed independently so configuration is self-evident and
+// individual entries can be updated if an algorithm diverges from its current mapping.
+var slugRegistry = map[string]func(string) string{
+	// GitHub-compatible
+	"github":       slugGitHub,
+	"hugo":         slugGitHub,
+	"pandoc-gfm":   slugGitHub,
+	"myst":         slugGitHub,
+	"docusaurus":   slugGitHub,
+	"gatsby":       slugGitHub,
+	"astro":        slugGitHub,
+	"starlight":    slugGitHub,
+	"nuxt-content": slugGitHub,
+	// GitLab
+	"gitlab": slugGitLab,
+	// Zenn
+	"zenn": slugZenn,
+	// Pandoc family
+	"pandoc": slugPandoc,
+	"quarto": slugPandoc,
+	// kramdown
+	"kramdown": slugKramdown,
+	// MkDocs
+	"mkdocs": slugMkDocs,
+	// DocFX
+	"docfx": slugDocFX,
+	// Qiita / mdBook (same character set)
+	"qiita":  slugQiita,
+	"mdbook": slugQiita,
+	// VitePress
+	"vitepress": slugVitePress,
+	// Gitea / Forgejo
+	"gitea":   slugGitea,
+	"forgejo": slugGitea,
+	// Sphinx
+	"sphinx": slugSphinx,
+	// Eleventy
+	"eleventy": slugEleventy,
+	// Azure DevOps
+	"azure-devops": slugAzureDevOps,
+}
+
 // ComputeSlug generates a URL fragment slug from heading plain text using the named algorithm.
-// Supported algorithms: github, gitlab, zenn, pandoc, pandoc-gfm, kramdown, mkdocs, docfx,
-// hugo, qiita, mdbook, vitepress, gitea, forgejo, sphinx, eleventy, azure-devops, myst,
-// docusaurus, gatsby, astro, starlight, nuxt-content, quarto.
 // Unknown algorithm names fall back to "github".
 func ComputeSlug(text, algorithm string) string {
-	switch algorithm {
-	case "github", "hugo", "pandoc-gfm", "myst", "docusaurus", "gatsby", "astro", "starlight", "nuxt-content":
-		return slugGitHub(text)
-	case "gitlab":
-		return slugGitLab(text)
-	case "zenn":
-		return slugZenn(text)
-	case "pandoc", "quarto":
-		return slugPandoc(text)
-	case "kramdown":
-		return slugKramdown(text)
-	case "mkdocs":
-		return slugMkDocs(text)
-	case "docfx":
-		return slugDocFX(text)
-	case "qiita", "mdbook":
-		return slugQiita(text)
-	case "vitepress":
-		return slugVitePress(text)
-	case "gitea", "forgejo":
-		return slugGitea(text)
-	case "sphinx":
-		return slugSphinx(text)
-	case "eleventy":
-		return slugEleventy(text)
-	case "azure-devops":
-		return slugAzureDevOps(text)
-	default:
-		return slugGitHub(text)
+	if fn, ok := slugRegistry[algorithm]; ok {
+		return fn(text)
 	}
+	return slugGitHub(text)
 }

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -1,0 +1,268 @@
+package rule
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// reSlugHTMLComment matches HTML comments for removal from heading text.
+var reSlugHTMLComment = regexp.MustCompile(`<!--.*?-->`)
+
+// reSlugHTMLTag matches HTML tags for removal from heading text.
+var reSlugHTMLTag = regexp.MustCompile(`<[^>]+>`)
+
+// reSlugRefImage matches reference-style images: ![alt][ref]
+var reSlugRefImage = regexp.MustCompile(`!\[([^\]]*)\]\[[^\]]*\]`)
+
+// reSlugImage matches inline images: ![alt](url)
+var reSlugImage = regexp.MustCompile(`!\[([^\]]*)\]\([^)]*\)`)
+
+// reSlugRefLink matches reference-style links: [text][ref]
+var reSlugRefLink = regexp.MustCompile(`\[([^\]]*)\]\[[^\]]*\]`)
+
+// reSlugLink matches inline links: [text](url)
+var reSlugLink = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+
+// reSlugBoldAsterisk matches **bold**
+var reSlugBoldAsterisk = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+
+// reSlugBoldUnderscore matches __bold__
+var reSlugBoldUnderscore = regexp.MustCompile(`__([^_]+)__`)
+
+// reSlugItalicAsterisk matches *italic*
+var reSlugItalicAsterisk = regexp.MustCompile(`\*([^*]+)\*`)
+
+// reSlugItalicUnderscore matches _italic_
+var reSlugItalicUnderscore = regexp.MustCompile(`_([^_]+)_`)
+
+// reSlugCode matches inline code spans (single or multi-backtick), keeping content.
+var reSlugCode = regexp.MustCompile("`+([^`]+)`+")
+
+// stripHeadingFormatting removes Markdown and HTML inline formatting from heading text,
+// returning plain text for slug generation.
+// Order: HTML comments → HTML tags → images → links → bold → italic → code spans.
+func stripHeadingFormatting(s string) string {
+	s = reSlugHTMLComment.ReplaceAllString(s, "")
+	s = reSlugHTMLTag.ReplaceAllString(s, "")
+	s = reSlugRefImage.ReplaceAllString(s, "$1")
+	s = reSlugImage.ReplaceAllString(s, "$1")
+	s = reSlugRefLink.ReplaceAllString(s, "$1")
+	s = reSlugLink.ReplaceAllString(s, "$1")
+	s = reSlugBoldAsterisk.ReplaceAllString(s, "$1")
+	s = reSlugBoldUnderscore.ReplaceAllString(s, "$1")
+	s = reSlugItalicAsterisk.ReplaceAllString(s, "$1")
+	s = reSlugItalicUnderscore.ReplaceAllString(s, "$1")
+	s = reSlugCode.ReplaceAllString(s, "$1")
+	return s
+}
+
+// githubStripRune reports whether r should be removed by the GitHub slug algorithm.
+// Matches github-slugger v2: strips U+2000–U+206F, U+2E00–U+2E7F, and specific ASCII punctuation.
+// Preserves hyphens, underscores, Unicode letters, and digits.
+func githubStripRune(r rune) bool {
+	if r >= 0x2000 && r <= 0x206F {
+		return true // General Punctuation
+	}
+	if r >= 0x2E00 && r <= 0x2E7F {
+		return true // Supplemental Punctuation
+	}
+	switch r {
+	case '\\', '\'', '!', '"', '#', '$', '%', '&',
+		'(', ')', '*', '+', ',', '.', '/', ':',
+		';', '<', '=', '>', '?', '@', '[', ']',
+		'^', '`', '{', '|', '}', '~':
+		return true
+	}
+	return false
+}
+
+// slugGitHub computes the GitHub-compatible slug (github-slugger v2).
+// Lowercases, strips specific punctuation ranges, replaces whitespace with hyphens.
+// Consecutive whitespace produces consecutive hyphens (no collapsing).
+func slugGitHub(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if !githubStripRune(r) {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// slugGitLab computes the GitLab (goldmark slugify) slug.
+// Lowercases, keeps Unicode letters/numbers/hyphens/underscores, collapses consecutive hyphens.
+func slugGitLab(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_' || r == '-' {
+			sb.WriteRune(r)
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugZenn computes the Zenn (markdown-it-anchor default) slug.
+// Lowercases and replaces whitespace with hyphens; all other characters are preserved.
+func slugZenn(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// slugPandoc computes the Pandoc auto_identifiers slug.
+// Lowercases, keeps only ASCII letters/digits/hyphens/underscores, collapses consecutive hyphens.
+func slugPandoc(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			sb.WriteRune(r)
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugKramdown computes the kramdown header_ids slug.
+// Lowercases, keeps only ASCII letters/digits/hyphens, replaces spaces with hyphens, collapses.
+func slugKramdown(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
+			sb.WriteRune(r)
+		case unicode.IsSpace(r):
+			sb.WriteByte('-')
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.
+// Lowercases, strips non-ASCII characters, replaces spaces with hyphens, collapses.
+func slugMkDocs(text string) string {
+	text = strings.ToLower(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if r < 128 && ((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+			sb.WriteRune(r)
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugDocFX computes the DocFX (Markdig AutoIdentifiers) slug.
+// Preserves case, keeps only [a-zA-Z0-9-_.], replaces spaces with hyphens, collapses.
+func slugDocFX(text string) string {
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '_' || r == '.' {
+			sb.WriteRune(r)
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// collapseDashes replaces runs of consecutive hyphens with a single hyphen
+// and strips leading and trailing hyphens.
+func collapseDashes(s string) string {
+	if s == "" {
+		return s
+	}
+	var sb strings.Builder
+	sb.Grow(len(s))
+	prevWasDash := false
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' {
+			if !prevWasDash {
+				sb.WriteByte('-')
+			}
+			prevWasDash = true
+		} else {
+			sb.WriteByte(s[i])
+			prevWasDash = false
+		}
+	}
+	result := sb.String()
+	result = strings.TrimPrefix(result, "-")
+	result = strings.TrimSuffix(result, "-")
+	return result
+}
+
+// buildSlugSet builds the full set of valid fragment slugs from the given headings,
+// applying deduplication. The first occurrence of a slug is bare (e.g. "intro");
+// subsequent duplicates get a numeric suffix (e.g. "intro-1", "intro-2").
+func buildSlugSet(headings []string, algorithm string) map[string]struct{} {
+	slugs := make(map[string]struct{})
+	seen := make(map[string]int)
+	for _, text := range headings {
+		plain := stripHeadingFormatting(text)
+		base := ComputeSlug(plain, algorithm)
+		if base == "" {
+			continue
+		}
+		count := seen[base]
+		seen[base]++
+		var slug string
+		if count == 0 {
+			slug = base
+		} else {
+			slug = fmt.Sprintf("%s-%d", base, count)
+		}
+		slugs[slug] = struct{}{}
+	}
+	return slugs
+}
+
+// ComputeSlug generates a URL fragment slug from heading plain text using the named algorithm.
+// Supported algorithms: github, gitlab, zenn, pandoc, pandoc-gfm, kramdown, mkdocs, docfx, hugo.
+// Unknown algorithm names fall back to "github".
+func ComputeSlug(text, algorithm string) string {
+	switch algorithm {
+	case "github", "hugo", "pandoc-gfm":
+		return slugGitHub(text)
+	case "gitlab":
+		return slugGitLab(text)
+	case "zenn":
+		return slugZenn(text)
+	case "pandoc":
+		return slugPandoc(text)
+	case "kramdown":
+		return slugKramdown(text)
+	case "mkdocs":
+		return slugMkDocs(text)
+	case "docfx":
+		return slugDocFX(text)
+	default:
+		return slugGitHub(text)
+	}
+}

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // reSlugHTMLComment matches HTML comments for removal from heading text.
@@ -39,6 +41,9 @@ var reSlugItalicUnderscore = regexp.MustCompile(`_([^_]+)_`)
 
 // reSlugCode matches inline code spans (single or multi-backtick), keeping content.
 var reSlugCode = regexp.MustCompile("`+([^`]+)`+")
+
+// reSphinxNonAlnum replaces runs of non-alphanumeric ASCII chars with a single hyphen.
+var reSphinxNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 
 // stripHeadingFormatting removes Markdown and HTML inline formatting from heading text,
 // returning plain text for slug generation.
@@ -196,6 +201,200 @@ func slugDocFX(text string) string {
 	return collapseDashes(sb.String())
 }
 
+// nfkdStripCombining applies NFKD normalization and removes Unicode combining characters (category Mn).
+// This converts precomposed accented characters to their base ASCII equivalents
+// (e.g. 'é' → 'e', 'ü' → 'u') while preserving CJK and other non-combining Unicode.
+func nfkdStripCombining(text string) string {
+	normalized := norm.NFKD.String(text)
+	var sb strings.Builder
+	sb.Grow(len(normalized))
+	for _, r := range normalized {
+		if !unicode.Is(unicode.Mn, r) {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// slugQiita computes the Qiita slug.
+// Equivalent to Ruby: downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-")
+// Keeps Unicode letters, digits, underscores, and hyphens; collapses nothing.
+func slugQiita(text string) string {
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// slugVitePress computes the VitePress (markdown-it-anchor) slug.
+// NFKD-normalizes to strip combining chars (accented Latin → ASCII base),
+// then lowercases and replaces non-alphanumeric chars with hyphens, collapsing runs.
+// CJK and other Unicode letters/digits are preserved.
+func slugVitePress(text string) string {
+	text = nfkdStripCombining(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			sb.WriteRune(r)
+		} else {
+			sb.WriteByte('-')
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugGitea computes the Gitea (goldmark) slug.
+// Same as GitHub algorithm but prefixed with "user-content-".
+func slugGitea(text string) string {
+	return "user-content-" + slugGitHub(text)
+}
+
+// slugSphinx computes the Sphinx (Python-Sphinx auto-section-label) slug.
+// NFKD-normalizes to strip combining chars, keeps only lowercase ASCII alphanumerics,
+// replaces runs of non-alphanumeric with a single hyphen, and trims leading/trailing hyphens.
+// Non-Latin-only headings that produce an empty result return "" (the id1/id2 fallback
+// is document-level state that cannot be reproduced outside the build context).
+func slugSphinx(text string) string {
+	text = nfkdStripCombining(text)
+	var ascii strings.Builder
+	ascii.Grow(len(text))
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if r < 128 {
+			ascii.WriteRune(r)
+		}
+	}
+	result := reSphinxNonAlnum.ReplaceAllString(ascii.String(), "-")
+	return strings.Trim(result, "-")
+}
+
+// slugEleventy computes an approximation of the Eleventy (@sindresorhus/slugify) slug.
+// NFKD-normalizes so accented Latin chars (é→e, ü→u) are reduced to their ASCII base,
+// then keeps only lowercase ASCII letters, digits, and hyphens, collapsing runs.
+// Characters without an ASCII equivalent (CJK, ø, ł, etc.) are stripped.
+func slugEleventy(text string) string {
+	text = nfkdStripCombining(text)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if unicode.IsSpace(r) {
+			sb.WriteByte('-')
+		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			sb.WriteRune(r)
+		}
+	}
+	return collapseDashes(sb.String())
+}
+
+// slugAzureDevOps computes the Azure DevOps Wiki slug.
+// Lowercases, replaces Unicode space-separator chars (Zs) with hyphens, keeps RFC 3986
+// unreserved chars (letters, digits, -, ., _, ~) as-is, and percent-encodes everything else.
+func slugAzureDevOps(text string) string {
+	var sb strings.Builder
+	sb.Grow(len(text) * 2)
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if unicode.Is(unicode.Zs, r) {
+			sb.WriteByte('-')
+		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '.' || r == '_' || r == '~' {
+			sb.WriteRune(r)
+		} else {
+			// Percent-encode each UTF-8 byte (uppercase hex per RFC 3986).
+			for _, b := range []byte(string(r)) {
+				fmt.Fprintf(&sb, "%%%02X", b)
+			}
+		}
+	}
+	return sb.String()
+}
+
+// slugCustomParams holds the resolved parameters for the custom slug engine.
+type slugCustomParams struct {
+	lowercase          bool
+	preserveUnicode    bool
+	spaceReplacement   rune
+	stripChars         *regexp.Regexp
+	collapseSeparators bool
+}
+
+// parseSlugParams extracts custom slug parameters from an options map.
+func parseSlugParams(opts map[string]interface{}) slugCustomParams {
+	p := slugCustomParams{
+		lowercase:          true,
+		preserveUnicode:    true,
+		spaceReplacement:   '-',
+		collapseSeparators: false,
+	}
+	params, _ := opts["slug-params"].(map[string]interface{})
+	if params == nil {
+		return p
+	}
+	if v, ok := params["lowercase"].(bool); ok {
+		p.lowercase = v
+	}
+	if v, ok := params["preserve-unicode"].(bool); ok {
+		p.preserveUnicode = v
+	}
+	if v, ok := params["space-replacement"].(string); ok && v != "" {
+		runes := []rune(v)
+		p.spaceReplacement = runes[0]
+	}
+	if v, ok := params["strip-chars"].(string); ok && v != "" {
+		if re, err := regexp.Compile(v); err == nil {
+			p.stripChars = re
+		}
+	}
+	if v, ok := params["collapse-separators"].(bool); ok {
+		p.collapseSeparators = v
+	}
+	return p
+}
+
+// slugCustom applies the parameterized slug engine.
+// Processing order: lowercase → per-char (space→sep, strip non-Unicode) → strip-chars regex → collapse.
+func slugCustom(text string, p slugCustomParams) string {
+	if p.lowercase {
+		text = strings.ToLower(text)
+	}
+	sep := string(p.spaceReplacement)
+	var sb strings.Builder
+	sb.Grow(len(text))
+	for _, r := range text {
+		if unicode.IsSpace(r) {
+			if sep != "" {
+				sb.WriteRune(p.spaceReplacement)
+			}
+		} else if !p.preserveUnicode && r > 127 {
+			// strip non-ASCII
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	result := sb.String()
+	if p.stripChars != nil {
+		result = p.stripChars.ReplaceAllString(result, "")
+	}
+	if p.collapseSeparators && sep != "" {
+		pattern := regexp.QuoteMeta(sep) + "+"
+		if re, err := regexp.Compile(pattern); err == nil {
+			result = re.ReplaceAllString(result, sep)
+			result = strings.Trim(result, sep)
+		}
+	}
+	return result
+}
+
 // collapseDashes replaces runs of consecutive hyphens with a single hyphen
 // and strips leading and trailing hyphens.
 func collapseDashes(s string) string {
@@ -225,12 +424,12 @@ func collapseDashes(s string) string {
 // buildSlugSet builds the full set of valid fragment slugs from the given headings,
 // applying deduplication. The first occurrence of a slug is bare (e.g. "intro");
 // subsequent duplicates get a numeric suffix (e.g. "intro-1", "intro-2").
-func buildSlugSet(headings []string, algorithm string) map[string]struct{} {
+func buildSlugSet(headings []string, slugger func(string) string) map[string]struct{} {
 	slugs := make(map[string]struct{})
 	seen := make(map[string]int)
 	for _, text := range headings {
 		plain := stripHeadingFormatting(text)
-		base := ComputeSlug(plain, algorithm)
+		base := slugger(plain)
 		if base == "" {
 			continue
 		}
@@ -247,18 +446,35 @@ func buildSlugSet(headings []string, algorithm string) map[string]struct{} {
 	return slugs
 }
 
+// makeSlugger returns a slug function for the given algorithm and options.
+// For "custom", options["slug-params"] is parsed into slugCustomParams.
+// All other algorithm names are dispatched through ComputeSlug.
+func makeSlugger(algorithm string, options map[string]interface{}) func(string) string {
+	if algorithm == "custom" {
+		params := parseSlugParams(options)
+		return func(text string) string {
+			return slugCustom(text, params)
+		}
+	}
+	return func(text string) string {
+		return ComputeSlug(text, algorithm)
+	}
+}
+
 // ComputeSlug generates a URL fragment slug from heading plain text using the named algorithm.
-// Supported algorithms: github, gitlab, zenn, pandoc, pandoc-gfm, kramdown, mkdocs, docfx, hugo.
+// Supported algorithms: github, gitlab, zenn, pandoc, pandoc-gfm, kramdown, mkdocs, docfx,
+// hugo, qiita, mdbook, vitepress, gitea, forgejo, sphinx, eleventy, azure-devops, myst,
+// docusaurus, gatsby, astro, starlight, nuxt-content, quarto.
 // Unknown algorithm names fall back to "github".
 func ComputeSlug(text, algorithm string) string {
 	switch algorithm {
-	case "github", "hugo", "pandoc-gfm":
+	case "github", "hugo", "pandoc-gfm", "myst", "docusaurus", "gatsby", "astro", "starlight", "nuxt-content":
 		return slugGitHub(text)
 	case "gitlab":
 		return slugGitLab(text)
 	case "zenn":
 		return slugZenn(text)
-	case "pandoc":
+	case "pandoc", "quarto":
 		return slugPandoc(text)
 	case "kramdown":
 		return slugKramdown(text)
@@ -266,6 +482,18 @@ func ComputeSlug(text, algorithm string) string {
 		return slugMkDocs(text)
 	case "docfx":
 		return slugDocFX(text)
+	case "qiita", "mdbook":
+		return slugQiita(text)
+	case "vitepress":
+		return slugVitePress(text)
+	case "gitea", "forgejo":
+		return slugGitea(text)
+	case "sphinx":
+		return slugSphinx(text)
+	case "eleventy":
+		return slugEleventy(text)
+	case "azure-devops":
+		return slugAzureDevOps(text)
 	default:
 		return slugGitHub(text)
 	}

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 )
@@ -47,10 +48,13 @@ var reSphinxNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 
 // stripHeadingFormatting removes Markdown and HTML inline formatting from heading text,
 // returning plain text for slug generation.
-// Order: HTML comments → HTML tags → images → links → bold → italic → code spans.
+// Order: HTML comments → HTML tags → images → links → code spans (saved as placeholders) →
+// bold → italic → code span content restored.
+// Code spans are saved before bold/italic to prevent underscores/asterisks inside backticks
+// from being mis-parsed as emphasis markers.
 func stripHeadingFormatting(s string) string {
 	// Fast path: plain headings with no formatting markers need no processing.
-	if !strings.ContainsAny(s, "*_[<`") {
+	if !strings.ContainsAny(s, "*_[<`!") {
 		return s
 	}
 	s = reSlugHTMLComment.ReplaceAllString(s, "")
@@ -59,11 +63,21 @@ func stripHeadingFormatting(s string) string {
 	s = reSlugImage.ReplaceAllString(s, "$1")
 	s = reSlugRefLink.ReplaceAllString(s, "$1")
 	s = reSlugLink.ReplaceAllString(s, "$1")
+	// Save code span content before bold/italic so that underscores/asterisks
+	// inside backtick spans are not consumed by the emphasis regexes.
+	var saved []string
+	s = reSlugCode.ReplaceAllStringFunc(s, func(m string) string {
+		idx := len(saved)
+		saved = append(saved, strings.Trim(m, "`"))
+		return fmt.Sprintf("\x00%d\x00", idx)
+	})
 	s = reSlugBoldAsterisk.ReplaceAllString(s, "$1")
 	s = reSlugBoldUnderscore.ReplaceAllString(s, "$1")
 	s = reSlugItalicAsterisk.ReplaceAllString(s, "$1")
 	s = reSlugItalicUnderscore.ReplaceAllString(s, "$1")
-	s = reSlugCode.ReplaceAllString(s, "$1")
+	for i, content := range saved {
+		s = strings.ReplaceAll(s, fmt.Sprintf("\x00%d\x00", i), content)
+	}
 	return s
 }
 
@@ -300,6 +314,7 @@ func slugEleventy(text string) string {
 // Lowercases, replaces Unicode space-separator chars (Zs) with hyphens, keeps RFC 3986
 // unreserved chars (letters, digits, -, ., _, ~) as-is, and percent-encodes everything else.
 func slugAzureDevOps(text string) string {
+	const hexChars = "0123456789ABCDEF"
 	var sb strings.Builder
 	sb.Grow(len(text) * 2)
 	for _, r := range text {
@@ -311,8 +326,12 @@ func slugAzureDevOps(text string) string {
 			sb.WriteRune(r)
 		} else {
 			// Percent-encode each UTF-8 byte (uppercase hex per RFC 3986).
-			for _, b := range []byte(string(r)) {
-				fmt.Fprintf(&sb, "%%%02X", b)
+			var buf [utf8.UTFMax]byte
+			n := utf8.EncodeRune(buf[:], r)
+			for _, b := range buf[:n] {
+				sb.WriteByte('%')
+				sb.WriteByte(hexChars[b>>4])
+				sb.WriteByte(hexChars[b&0xf])
 			}
 		}
 	}
@@ -326,6 +345,7 @@ type slugCustomParams struct {
 	spaceReplacement   rune
 	stripChars         *regexp.Regexp
 	collapseSeparators bool
+	collapseRe         *regexp.Regexp // pre-compiled collapse pattern; nil when collapse is off
 }
 
 // parseSlugParams extracts custom slug parameters from an options map.
@@ -358,6 +378,14 @@ func parseSlugParams(opts map[string]interface{}) slugCustomParams {
 	if v, ok := params["collapse-separators"].(bool); ok {
 		p.collapseSeparators = v
 	}
+	if p.collapseSeparators {
+		sep := string(p.spaceReplacement)
+		if sep != "" {
+			if re, err := regexp.Compile(regexp.QuoteMeta(sep) + "+"); err == nil {
+				p.collapseRe = re
+			}
+		}
+	}
 	return p
 }
 
@@ -385,12 +413,9 @@ func slugCustom(text string, p slugCustomParams) string {
 	if p.stripChars != nil {
 		result = p.stripChars.ReplaceAllString(result, "")
 	}
-	if p.collapseSeparators && sep != "" {
-		pattern := regexp.QuoteMeta(sep) + "+"
-		if re, err := regexp.Compile(pattern); err == nil {
-			result = re.ReplaceAllString(result, sep)
-			result = strings.Trim(result, sep)
-		}
+	if p.collapseRe != nil {
+		result = p.collapseRe.ReplaceAllString(result, sep)
+		result = strings.Trim(result, sep)
 	}
 	return result
 }

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -44,6 +44,10 @@ var reSlugCode = regexp.MustCompile("`+([^`]+)`+")
 // returning plain text for slug generation.
 // Order: HTML comments → HTML tags → images → links → bold → italic → code spans.
 func stripHeadingFormatting(s string) string {
+	// Fast path: plain headings with no formatting markers need no processing.
+	if !strings.ContainsAny(s, "*_[<`") {
+		return s
+	}
 	s = reSlugHTMLComment.ReplaceAllString(s, "")
 	s = reSlugHTMLTag.ReplaceAllString(s, "")
 	s = reSlugRefImage.ReplaceAllString(s, "$1")
@@ -82,10 +86,10 @@ func githubStripRune(r rune) bool {
 // Lowercases, strips specific punctuation ranges, replaces whitespace with hyphens.
 // Consecutive whitespace produces consecutive hyphens (no collapsing).
 func slugGitHub(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
 		} else if !githubStripRune(r) {
@@ -98,10 +102,10 @@ func slugGitHub(text string) string {
 // slugGitLab computes the GitLab (goldmark slugify) slug.
 // Lowercases, keeps Unicode letters/numbers/hyphens/underscores, collapses consecutive hyphens.
 func slugGitLab(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
 		} else if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_' || r == '-' {
@@ -114,10 +118,10 @@ func slugGitLab(text string) string {
 // slugZenn computes the Zenn (markdown-it-anchor default) slug.
 // Lowercases and replaces whitespace with hyphens; all other characters are preserved.
 func slugZenn(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
 		} else {
@@ -130,10 +134,10 @@ func slugZenn(text string) string {
 // slugPandoc computes the Pandoc auto_identifiers slug.
 // Lowercases, keeps only ASCII letters/digits/hyphens/underscores, collapses consecutive hyphens.
 func slugPandoc(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
 		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
@@ -146,10 +150,10 @@ func slugPandoc(text string) string {
 // slugKramdown computes the kramdown header_ids slug.
 // Lowercases, keeps only ASCII letters/digits/hyphens, replaces spaces with hyphens, collapses.
 func slugKramdown(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		switch {
 		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
 			sb.WriteRune(r)
@@ -163,10 +167,10 @@ func slugKramdown(text string) string {
 // slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.
 // Lowercases, strips non-ASCII characters, replaces spaces with hyphens, collapses.
 func slugMkDocs(text string) string {
-	text = strings.ToLower(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
+		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
 		} else if r < 128 && ((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -23,6 +23,8 @@ func TestComputeSlug(t *testing.T) {
 		{"github: plus stripped", "C++", "github", "c"},
 		{"github: colon stripped", "foo: bar", "github", "foo-bar"},
 		{"github: section number", "Section 1", "github", "section-1"},
+		{"github: em dash (U+2014, General Punctuation) stripped", "hello—world", "github", "helloworld"},
+		{"github: supplemental punctuation (U+2E3A) stripped", "hello⸺world", "github", "helloworld"},
 
 		// GitLab (goldmark)
 		{"gitlab: simple text", "Hello World", "gitlab", "hello-world"},

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -1,0 +1,175 @@
+package rule
+
+import (
+	"testing"
+)
+
+func TestComputeSlug(t *testing.T) {
+	tests := []struct {
+		name      string
+		text      string
+		algorithm string
+		want      string
+	}{
+		// GitHub (default)
+		{"github: simple text", "Hello World", "github", "hello-world"},
+		{"github: comma and exclamation stripped", "Hello, World!", "github", "hello-world"},
+		{"github: period stripped", "Subsection 1.1", "github", "subsection-11"},
+		{"github: consecutive spaces become consecutive hyphens", "Hello  World", "github", "hello--world"},
+		{"github: preserves Unicode letters", "日本語", "github", "日本語"},
+		{"github: hyphen preserved", "go-lang", "github", "go-lang"},
+		{"github: underscore preserved", "go_lang", "github", "go_lang"},
+		{"github: hash stripped", "C#", "github", "c"},
+		{"github: plus stripped", "C++", "github", "c"},
+		{"github: colon stripped", "foo: bar", "github", "foo-bar"},
+		{"github: section number", "Section 1", "github", "section-1"},
+
+		// GitLab (goldmark)
+		{"gitlab: simple text", "Hello World", "gitlab", "hello-world"},
+		{"gitlab: period stripped, collapses", "Subsection 1.1", "gitlab", "subsection-11"},
+		{"gitlab: preserves Unicode", "日本語", "gitlab", "日本語"},
+		{"gitlab: consecutive hyphens collapsed", "A  B", "gitlab", "a-b"},
+		{"gitlab: punctuation stripped", "Hello, World!", "gitlab", "hello-world"},
+
+		// Zenn (markdown-it-anchor)
+		{"zenn: simple text", "Hello World", "zenn", "hello-world"},
+		{"zenn: preserves punctuation", "Hello, World!", "zenn", "hello,-world!"},
+		{"zenn: preserves Unicode", "日本語", "zenn", "日本語"},
+		{"zenn: period preserved", "Go 1.21", "zenn", "go-1.21"},
+
+		// Pandoc (auto_identifiers)
+		{"pandoc: simple text", "Hello World", "pandoc", "hello-world"},
+		{"pandoc: strips non-ASCII", "日本語", "pandoc", ""},
+		{"pandoc: period stripped", "Go 1.21", "pandoc", "go-121"},
+		{"pandoc: collapses hyphens from double space", "A  B", "pandoc", "a-b"},
+
+		// Kramdown
+		{"kramdown: simple text", "Hello World", "kramdown", "hello-world"},
+		{"kramdown: strips non-ASCII", "日本語", "kramdown", ""},
+		{"kramdown: period stripped", "Go 1.21", "kramdown", "go-121"},
+		{"kramdown: underscore stripped (not in keep set)", "go_lang", "kramdown", "golang"},
+
+		// Hugo (= GitHub)
+		{"hugo: same as github", "Hello World", "hugo", "hello-world"},
+		{"hugo: period stripped", "Go 1.21", "hugo", "go-121"},
+
+		// MkDocs
+		{"mkdocs: simple text", "Hello World", "mkdocs", "hello-world"},
+		{"mkdocs: strips non-ASCII", "日本語", "mkdocs", ""},
+		{"mkdocs: collapses hyphens", "A  B", "mkdocs", "a-b"},
+		{"mkdocs: period stripped", "Go 1.21", "mkdocs", "go-121"},
+
+		// DocFX (case-preserving)
+		{"docfx: preserves case", "Hello World", "docfx", "Hello-World"},
+		{"docfx: preserves period", "Subsection 1.1", "docfx", "Subsection-1.1"},
+		{"docfx: strips non-ASCII", "日本語", "docfx", ""},
+		{"docfx: strips punctuation except hyphen underscore dot", "Hello, World!", "docfx", "Hello-World"},
+
+		// Aliases
+		{"pandoc-gfm: same as github", "Hello World", "pandoc-gfm", "hello-world"},
+
+		// Unknown falls back to github
+		{"unknown algorithm: falls back to github", "Hello World", "unknown-algo", "hello-world"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeSlug(tt.text, tt.algorithm)
+			if got != tt.want {
+				t.Errorf("ComputeSlug(%q, %q) = %q, want %q", tt.text, tt.algorithm, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripHeadingFormatting(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text unchanged", "Hello World", "Hello World"},
+		{"bold asterisk stripped", "**Hello** World", "Hello World"},
+		{"bold underscore stripped", "__Hello__ World", "Hello World"},
+		{"italic asterisk stripped", "*Hello* World", "Hello World"},
+		{"italic underscore stripped", "_Hello_ World", "Hello World"},
+		{"inline code stripped (backtick delimiters removed)", "`code` example", "code example"},
+		{"link text kept, URL removed", "[Hello](https://example.com)", "Hello"},
+		{"image alt text kept, URL removed", "![alt text](image.png)", "alt text"},
+		{"HTML tag removed", "<em>Hello</em> World", "Hello World"},
+		{"ref link text kept", "[Hello][ref]", "Hello"},
+		{"ref image alt kept", "![alt][img-ref]", "alt"},
+		{"HTML comment removed", "<!-- note --> Hello", " Hello"},
+		{"multi-backtick code", "``go test``", "go test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripHeadingFormatting(tt.input)
+			if got != tt.want {
+				t.Errorf("stripHeadingFormatting(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollapseDashes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello-world", "hello-world"},
+		{"hello--world", "hello-world"},
+		{"--hello--", "hello"},
+		{"a---b", "a-b"},
+		{"-leading", "leading"},
+		{"trailing-", "trailing"},
+		{"", ""},
+		{"a", "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := collapseDashes(tt.input)
+			if got != tt.want {
+				t.Errorf("collapseDashes(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSlugSet(t *testing.T) {
+	t.Run("unique headings", func(t *testing.T) {
+		headings := []string{"Introduction", "Getting Started", "References"}
+		slugs := buildSlugSet(headings, "github")
+		for _, want := range []string{"introduction", "getting-started", "references"} {
+			if _, ok := slugs[want]; !ok {
+				t.Errorf("expected slug %q to be in set", want)
+			}
+		}
+	})
+
+	t.Run("duplicate headings generate suffixed slugs", func(t *testing.T) {
+		headings := []string{"Intro", "Intro", "Intro"}
+		slugs := buildSlugSet(headings, "github")
+		for _, want := range []string{"intro", "intro-1", "intro-2"} {
+			if _, ok := slugs[want]; !ok {
+				t.Errorf("expected slug %q to be in set", want)
+			}
+		}
+		if _, ok := slugs["intro-0"]; ok {
+			t.Error("slug intro-0 should not exist (first occurrence stays bare)")
+		}
+	})
+
+	t.Run("empty heading text produces no slug", func(t *testing.T) {
+		headings := []string{"", "Hello"}
+		slugs := buildSlugSet(headings, "github")
+		if len(slugs) != 1 {
+			t.Errorf("expected 1 slug, got %d: %v", len(slugs), slugs)
+		}
+		if _, ok := slugs["hello"]; !ok {
+			t.Error("expected slug 'hello'")
+		}
+	})
+}

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -351,6 +351,27 @@ func TestMakeSlugger(t *testing.T) {
 	})
 }
 
+func TestParseSlugParams(t *testing.T) {
+	t.Run("invalid strip-chars regex is silently ignored", func(t *testing.T) {
+		opts := map[string]interface{}{
+			"slug-params": map[string]interface{}{
+				"strip-chars": "[invalid(regex",
+			},
+		}
+		p := parseSlugParams(opts)
+		if p.stripChars != nil {
+			t.Error("expected stripChars to be nil for invalid regex, got non-nil")
+		}
+	})
+
+	t.Run("nil opts returns defaults", func(t *testing.T) {
+		p := parseSlugParams(nil)
+		if !p.lowercase || !p.preserveUnicode || p.spaceReplacement != '-' || p.collapseSeparators {
+			t.Errorf("unexpected defaults: %+v", p)
+		}
+	})
+}
+
 func mustCompileRegexp(pattern string) *regexp.Regexp {
 	return regexp.MustCompile(pattern)
 }

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -67,8 +68,60 @@ func TestComputeSlug(t *testing.T) {
 		{"docfx: strips non-ASCII", "日本語", "docfx", ""},
 		{"docfx: strips punctuation except hyphen underscore dot", "Hello, World!", "docfx", "Hello-World"},
 
-		// Aliases
+		// Qiita / mdbook (same character set)
+		{"qiita: simple text", "Hello World", "qiita", "hello-world"},
+		{"qiita: preserves Unicode letters", "日本語", "qiita", "日本語"},
+		{"qiita: preserves underscore", "go_lang", "qiita", "go_lang"},
+		{"qiita: strips punctuation", "Hello, World!", "qiita", "hello-world"},
+		{"qiita: no collapse", "A  B", "qiita", "a--b"},
+		{"mdbook: same as qiita", "Hello World", "mdbook", "hello-world"},
+		{"mdbook: preserves Unicode", "日本語", "mdbook", "日本語"},
+
+		// VitePress
+		{"vitepress: simple text", "Hello World", "vitepress", "hello-world"},
+		{"vitepress: accented Latin normalized", "Héllo Wörld", "vitepress", "hello-world"},
+		{"vitepress: preserves CJK", "日本語", "vitepress", "日本語"},
+		{"vitepress: collapses non-alphanumeric", "A  B", "vitepress", "a-b"},
+
+		// Gitea / Forgejo
+		{"gitea: prefixes user-content-", "Hello World", "gitea", "user-content-hello-world"},
+		{"gitea: preserves Unicode", "日本語", "gitea", "user-content-日本語"},
+		{"forgejo: same as gitea", "Hello World", "forgejo", "user-content-hello-world"},
+
+		// Sphinx
+		{"sphinx: simple text", "Hello World", "sphinx", "hello-world"},
+		{"sphinx: accented Latin normalized", "Héllo", "sphinx", "hello"},
+		{"sphinx: strips non-ASCII CJK", "日本語", "sphinx", ""},
+		{"sphinx: collapses non-alphanumeric", "A  B", "sphinx", "a-b"},
+		{"sphinx: punctuation collapsed", "Go 1.21", "sphinx", "go-1-21"},
+
+		// Eleventy
+		{"eleventy: simple text", "Hello World", "eleventy", "hello-world"},
+		{"eleventy: accented Latin normalized", "Héllo", "eleventy", "hello"},
+		{"eleventy: strips CJK", "日本語", "eleventy", ""},
+		{"eleventy: collapses hyphens", "A  B", "eleventy", "a-b"},
+		{"eleventy: preserves hyphen", "go-lang", "eleventy", "go-lang"},
+
+		// Azure DevOps
+		{"azure-devops: simple text", "Hello World", "azure-devops", "hello-world"},
+		{"azure-devops: special char encoded", "C# Tutorial", "azure-devops", "c%23-tutorial"},
+		{"azure-devops: CJK percent-encoded", "はじめに", "azure-devops", "%E3%81%AF%E3%81%98%E3%82%81%E3%81%AB"},
+		{"azure-devops: RFC3986 unreserved kept", "go-1.0_test~", "azure-devops", "go-1.0_test~"},
+
+		// MyST
+		{"myst: same as github", "Hello World", "myst", "hello-world"},
+
+		// Aliases (→ github)
 		{"pandoc-gfm: same as github", "Hello World", "pandoc-gfm", "hello-world"},
+		{"docusaurus: same as github", "Hello World", "docusaurus", "hello-world"},
+		{"gatsby: same as github", "Hello World", "gatsby", "hello-world"},
+		{"astro: same as github", "Hello World", "astro", "hello-world"},
+		{"starlight: same as github", "Hello World", "starlight", "hello-world"},
+		{"nuxt-content: same as github", "Hello World", "nuxt-content", "hello-world"},
+
+		// Alias → pandoc
+		{"quarto: same as pandoc", "Hello World", "quarto", "hello-world"},
+		{"quarto: strips non-ASCII", "日本語", "quarto", ""},
 
 		// Unknown falls back to github
 		{"unknown algorithm: falls back to github", "Hello World", "unknown-algo", "hello-world"},
@@ -140,10 +193,12 @@ func TestCollapseDashes(t *testing.T) {
 	}
 }
 
+func githubSlugger(text string) string { return ComputeSlug(text, "github") }
+
 func TestBuildSlugSet(t *testing.T) {
 	t.Run("unique headings", func(t *testing.T) {
 		headings := []string{"Introduction", "Getting Started", "References"}
-		slugs := buildSlugSet(headings, "github")
+		slugs := buildSlugSet(headings, githubSlugger)
 		for _, want := range []string{"introduction", "getting-started", "references"} {
 			if _, ok := slugs[want]; !ok {
 				t.Errorf("expected slug %q to be in set", want)
@@ -153,7 +208,7 @@ func TestBuildSlugSet(t *testing.T) {
 
 	t.Run("duplicate headings generate suffixed slugs", func(t *testing.T) {
 		headings := []string{"Intro", "Intro", "Intro"}
-		slugs := buildSlugSet(headings, "github")
+		slugs := buildSlugSet(headings, githubSlugger)
 		for _, want := range []string{"intro", "intro-1", "intro-2"} {
 			if _, ok := slugs[want]; !ok {
 				t.Errorf("expected slug %q to be in set", want)
@@ -166,7 +221,7 @@ func TestBuildSlugSet(t *testing.T) {
 
 	t.Run("empty heading text produces no slug", func(t *testing.T) {
 		headings := []string{"", "Hello"}
-		slugs := buildSlugSet(headings, "github")
+		slugs := buildSlugSet(headings, githubSlugger)
 		if len(slugs) != 1 {
 			t.Errorf("expected 1 slug, got %d: %v", len(slugs), slugs)
 		}
@@ -174,4 +229,128 @@ func TestBuildSlugSet(t *testing.T) {
 			t.Error("expected slug 'hello'")
 		}
 	})
+}
+
+func TestSlugCustom(t *testing.T) {
+	tests := []struct {
+		name   string
+		text   string
+		params slugCustomParams
+		want   string
+	}{
+		{
+			name: "basic: lowercase + hyphen replacement",
+			text: "Hello World",
+			params: slugCustomParams{
+				lowercase:        true,
+				preserveUnicode:  true,
+				spaceReplacement: '-',
+			},
+			want: "hello-world",
+		},
+		{
+			name: "strip-chars removes matched characters",
+			text: "Hello, World!",
+			params: slugCustomParams{
+				lowercase:        true,
+				preserveUnicode:  true,
+				spaceReplacement: '-',
+				stripChars:       mustCompileRegexp(`[^\w\- ]`),
+			},
+			want: "hello-world",
+		},
+		{
+			name: "preserve-unicode false strips non-ASCII",
+			text: "Hello 日本語",
+			params: slugCustomParams{
+				lowercase:        true,
+				preserveUnicode:  false,
+				spaceReplacement: '-',
+			},
+			want: "hello-",
+		},
+		{
+			name: "preserve-unicode true keeps non-ASCII",
+			text: "Hello 日本語",
+			params: slugCustomParams{
+				lowercase:        true,
+				preserveUnicode:  true,
+				spaceReplacement: '-',
+			},
+			want: "hello-日本語",
+		},
+		{
+			name: "collapse-separators collapses and trims",
+			text: "  Hello  World  ",
+			params: slugCustomParams{
+				lowercase:          true,
+				preserveUnicode:    true,
+				spaceReplacement:   '-',
+				collapseSeparators: true,
+			},
+			want: "hello-world",
+		},
+		{
+			name: "underscore space-replacement",
+			text: "Hello World",
+			params: slugCustomParams{
+				lowercase:        true,
+				preserveUnicode:  true,
+				spaceReplacement: '_',
+			},
+			want: "hello_world",
+		},
+		{
+			name: "no lowercase preserves case",
+			text: "Hello World",
+			params: slugCustomParams{
+				lowercase:        false,
+				preserveUnicode:  true,
+				spaceReplacement: '-',
+			},
+			want: "Hello-World",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := slugCustom(tt.text, tt.params)
+			if got != tt.want {
+				t.Errorf("slugCustom(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMakeSlugger(t *testing.T) {
+	t.Run("preset algorithm returns ComputeSlug result", func(t *testing.T) {
+		slugger := makeSlugger("github", nil)
+		got := slugger("Hello World")
+		want := ComputeSlug("Hello World", "github")
+		if got != want {
+			t.Errorf("makeSlugger(github)(%q) = %q, want %q", "Hello World", got, want)
+		}
+	})
+
+	t.Run("custom algorithm uses slug-params", func(t *testing.T) {
+		opts := map[string]interface{}{
+			"slug-algorithm": "custom",
+			"slug-params": map[string]interface{}{
+				"lowercase":           true,
+				"preserve-unicode":    true,
+				"space-replacement":   "-",
+				"strip-chars":         `[^\w\- ]`,
+				"collapse-separators": true,
+			},
+		}
+		slugger := makeSlugger("custom", opts)
+		got := slugger("Hello, World!")
+		if got != "hello-world" {
+			t.Errorf("custom slugger(%q) = %q, want %q", "Hello, World!", got, "hello-world")
+		}
+	})
+}
+
+func mustCompileRegexp(pattern string) *regexp.Regexp {
+	return regexp.MustCompile(pattern)
 }

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -156,6 +156,7 @@ func TestStripHeadingFormatting(t *testing.T) {
 		{"ref image alt kept", "![alt][img-ref]", "alt"},
 		{"HTML comment removed", "<!-- note --> Hello", " Hello"},
 		{"multi-backtick code", "``go test``", "go test"},
+		{"code span with underscores not split by italic", "`my_func_name`", "my_func_name"},
 	}
 
 	for _, tt := range tests {
@@ -287,6 +288,7 @@ func TestSlugCustom(t *testing.T) {
 				preserveUnicode:    true,
 				spaceReplacement:   '-',
 				collapseSeparators: true,
+				collapseRe:         mustCompileRegexp("-+"),
 			},
 			want: "hello-world",
 		},

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -213,6 +213,98 @@ func TestExtractHeadingText(t *testing.T) {
 	}
 }
 
+func TestCheckLinkFragments_NewPresets(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		algorithm string
+		wantErrs  int
+	}{
+		{"qiita: valid CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "qiita", 0},
+		{"mdbook: valid CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "mdbook", 0},
+		{"vitepress: accented heading", "## Héllo\n\nSee [Héllo](#hello).\n", "vitepress", 0},
+		{"vitepress: CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "vitepress", 0},
+		{"gitea: user-content prefix required", "## Hello World\n\nSee [Hello](#user-content-hello-world).\n", "gitea", 0},
+		{"gitea: missing prefix is violation", "## Hello World\n\nSee [Hello](#hello-world).\n", "gitea", 1},
+		{"forgejo: same as gitea", "## Hello World\n\nSee [Hello](#user-content-hello-world).\n", "forgejo", 0},
+		{"sphinx: valid ASCII heading", "## Hello World\n\nSee [Hello](#hello-world).\n", "sphinx", 0},
+		{"sphinx: accented heading normalized", "## Héllo\n\nSee [Héllo](#hello).\n", "sphinx", 0},
+		{"eleventy: valid ASCII heading", "## Hello World\n\nSee [Hello](#hello-world).\n", "eleventy", 0},
+		{"myst: same as github", "## Hello World\n\nSee [Hello](#hello-world).\n", "myst", 0},
+		{"docusaurus: same as github", "## Hello World\n\nSee [Hello](#hello-world).\n", "docusaurus", 0},
+		{"quarto: same as pandoc", "## Hello World\n\nSee [Hello](#hello-world).\n", "quarto", 0},
+		{"quarto: strips non-ASCII", "## Hello World\n\nSee [Hello](#hello-world).\n", "quarto", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			opts := map[string]interface{}{"slug-algorithm": tt.algorithm}
+			got := CheckLinkFragments("test.md", lines, 0, opts)
+			if len(got) != tt.wantErrs {
+				t.Errorf("got %d errors, want %d: %v", len(got), tt.wantErrs, got)
+			}
+		})
+	}
+}
+
+func TestCheckLinkFragments_CustomEngine(t *testing.T) {
+	t.Run("custom engine: valid link with strip-chars", func(t *testing.T) {
+		content := "## Hello World\n\nSee [Hello](#hello-world).\n"
+		opts := map[string]interface{}{
+			"slug-algorithm": "custom",
+			"slug-params": map[string]interface{}{
+				"lowercase":           true,
+				"preserve-unicode":    true,
+				"space-replacement":   "-",
+				"strip-chars":         `[^\w\- ]`,
+				"collapse-separators": true,
+			},
+		}
+		lines := strings.Split(content, "\n")
+		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
+		}
+	})
+
+	t.Run("custom engine: broken link detected", func(t *testing.T) {
+		content := "## Hello World\n\nSee [broken](#setup).\n"
+		opts := map[string]interface{}{
+			"slug-algorithm": "custom",
+			"slug-params": map[string]interface{}{
+				"lowercase":           true,
+				"preserve-unicode":    true,
+				"space-replacement":   "-",
+				"strip-chars":         `[^\w\- ]`,
+				"collapse-separators": true,
+			},
+		}
+		lines := strings.Split(content, "\n")
+		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		if len(errs) != 1 {
+			t.Errorf("expected 1 error, got %d: %v", len(errs), errs)
+		}
+	})
+
+	t.Run("custom engine: underscore separator", func(t *testing.T) {
+		content := "## Hello World\n\nSee [Hello](#hello_world).\n"
+		opts := map[string]interface{}{
+			"slug-algorithm": "custom",
+			"slug-params": map[string]interface{}{
+				"lowercase":         true,
+				"preserve-unicode":  true,
+				"space-replacement": "_",
+			},
+		}
+		lines := strings.Split(content, "\n")
+		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
+		}
+	})
+}
+
 func TestCollectRefDefs(t *testing.T) {
 	t.Run("collects fragment refs", func(t *testing.T) {
 		lines := strings.Split("[ref1]: #section-1\n[ref2]: #section-2\n[ext]: https://example.com\n", "\n")

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -148,12 +148,24 @@ func TestCheckLinkFragments(t *testing.T) {
 			},
 		},
 		{
-			name:    "valid: offset applied to line numbers",
+			name:    "invalid: offset applied to line numbers",
 			content: "## Introduction\n\nSee [broken](#broken).\n",
 			opts:    map[string]interface{}{"slug-algorithm": "github"},
 			wantErrs: []LintError{
 				{File: "test.md", Line: 8, Message: "link-fragments: fragment #broken not found in this document"},
 			},
+		},
+		{
+			name:     "valid: image with fragment url is not a link violation",
+			content:  "## Hello\n\nSee ![figure](#fig-1) above.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: ref def present but no usage as link",
+			content:  "## Section\n\n[ref]: #section\n\nSome text here.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
 		},
 	}
 
@@ -162,7 +174,7 @@ func TestCheckLinkFragments(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
 			offset := 0
 			// The "offset applied" test uses offset=5
-			if tt.name == "valid: offset applied to line numbers" {
+			if tt.name == "invalid: offset applied to line numbers" {
 				offset = 5
 			}
 			got := CheckLinkFragments("test.md", lines, offset, tt.opts)
@@ -200,6 +212,7 @@ func TestExtractHeadingText(t *testing.T) {
 		{"heading with inline formatting kept", "## **Hello** World", "**Hello** World", 2},
 		{"empty string", "", "", 0},
 		{"bare hash no space or content", "##", "", 2},
+		{"tab after hash accepted", "##\tHeading", "Heading", 2},
 	}
 
 	for _, tt := range tests {
@@ -233,7 +246,7 @@ func TestCheckLinkFragments_NewPresets(t *testing.T) {
 		{"myst: same as github", "## Hello World\n\nSee [Hello](#hello-world).\n", "myst", 0},
 		{"docusaurus: same as github", "## Hello World\n\nSee [Hello](#hello-world).\n", "docusaurus", 0},
 		{"quarto: same as pandoc", "## Hello World\n\nSee [Hello](#hello-world).\n", "quarto", 0},
-		{"quarto: strips non-ASCII", "## Hello World\n\nSee [Hello](#hello-world).\n", "quarto", 0},
+		{"quarto: strips non-ASCII", "## Hello 日本語 World\n\nSee [Hello](#hello-world).\n", "quarto", 0},
 	}
 
 	for _, tt := range tests {
@@ -305,6 +318,18 @@ func TestCheckLinkFragments_CustomEngine(t *testing.T) {
 	})
 }
 
+func TestHasAnyFragmentSyntax(t *testing.T) {
+	if hasAnyFragmentSyntax([]string{"no links here", "just text"}) {
+		t.Error("expected false for plain text")
+	}
+	if !hasAnyFragmentSyntax([]string{"See [intro](#intro) here."}) {
+		t.Error("expected true for inline fragment link")
+	}
+	if !hasAnyFragmentSyntax([]string{"[ref]: #section"}) {
+		t.Error("expected true for fragment ref definition")
+	}
+}
+
 func TestCollectRefDefs(t *testing.T) {
 	t.Run("collects fragment refs", func(t *testing.T) {
 		lines := strings.Split("[ref1]: #section-1\n[ref2]: #section-2\n[ext]: https://example.com\n", "\n")
@@ -325,6 +350,17 @@ func TestCollectRefDefs(t *testing.T) {
 		defs := collectRefDefs(lines)
 		if defs["my label"] != "my-section" {
 			t.Errorf("expected 'my label' -> 'my-section', got %q", defs["my label"])
+		}
+	})
+
+	t.Run("ref def inside fenced code block is excluded", func(t *testing.T) {
+		lines := strings.Split("```\n[inside]: #fenced\n```\n[outside]: #real\n", "\n")
+		defs := collectRefDefs(lines)
+		if _, ok := defs["inside"]; ok {
+			t.Error("ref def inside fenced block should not be collected")
+		}
+		if defs["outside"] != "real" {
+			t.Errorf("expected 'outside' -> 'real', got %q", defs["outside"])
 		}
 	})
 }

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -97,6 +97,12 @@ func TestCheckLinkFragments(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
+			name:     "valid: reference link label not in fragment defs is ignored",
+			content:  "## Section\n\n[frag-ref]: #section\n\nSee [text][other-ref].\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
 			name:     "valid: non-fragment inline links are ignored",
 			content:  "## Hello\n\nSee [Example](https://example.com) for details.\n",
 			opts:     map[string]interface{}{"slug-algorithm": "github"},

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -1,0 +1,231 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckLinkFragments(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		opts     map[string]interface{}
+		wantErrs []LintError
+	}{
+		{
+			name:     "valid: no fragment links",
+			content:  "## Hello\n\nSome text.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fragment link matches heading",
+			content:  "## Introduction\n\nSee [Introduction](#introduction) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fragment link with hyphenated heading",
+			content:  "## Getting Started\n\nSee [Getting Started](#getting-started) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: fragment link not found",
+			content: "## Introduction\n\nSee [Setup](#setup) for details.\n",
+			opts:    map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "link-fragments: fragment #setup not found in this document"},
+			},
+		},
+		{
+			name:     "valid: first duplicate heading uses bare slug",
+			content:  "## Intro\n\nSee [First Intro](#intro) for details.\n\n## Intro\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: second duplicate heading uses suffixed slug",
+			content:  "## Intro\n\n## Intro\n\nSee [Second Intro](#intro-1) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: heading inside fenced code block is excluded",
+			content:  "## Real Heading\n\n```\n## Fake Heading\n```\n\nSee [real](#real-heading).\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: heading inside fenced code block does not produce a slug",
+			content: "```\n## Fake Heading\n```\n\nSee [fake](#fake-heading).\n",
+			opts:    map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "link-fragments: fragment #fake-heading not found in this document"},
+			},
+		},
+		{
+			name:     "valid: fragment link inside fenced code block is ignored",
+			content:  "## Hello\n\n```\nSee [broken](#broken-link) here.\n```\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fragment link inside inline code is ignored",
+			content:  "## Hello\n\nUse `[broken](#broken-link)` here.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: reference link with matching fragment definition",
+			content:  "## Introduction\n\nSee [Intro][intro-ref] for details.\n\n[intro-ref]: #introduction\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: reference link with non-existent fragment",
+			content: "## Introduction\n\nSee [Setup][setup-ref] for details.\n\n[setup-ref]: #setup\n",
+			opts:    map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "link-fragments: fragment #setup not found in this document"},
+			},
+		},
+		{
+			name:     "valid: reference link pointing to external URL is ignored",
+			content:  "## Hello\n\nSee [Example][ex].\n\n[ex]: https://example.com\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: non-fragment inline links are ignored",
+			content:  "## Hello\n\nSee [Example](https://example.com) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: heading with inline code slug",
+			content:  "## The `go test` Command\n\nSee [go test](#the-go-test-command) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: heading with bold formatting",
+			content:  "## **Introduction**\n\nSee [Introduction](#introduction) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: gitlab algorithm",
+			content:  "## Hello World\n\nSee [Hello](#hello-world) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "gitlab"},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: default algorithm is github when option absent",
+			content:  "## Hello World\n\nSee [Hello](#hello-world) for details.\n",
+			opts:     map[string]interface{}{},
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: unknown algorithm falls back to github",
+			content:  "## Hello World\n\nSee [Hello](#hello-world) for details.\n",
+			opts:     map[string]interface{}{"slug-algorithm": "unknown-algo"},
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: multiple broken fragment links on different lines",
+			content: "## Hello\n\nSee [broken1](#broken1) and\nSee [broken2](#broken2) too.\n",
+			opts:    map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "link-fragments: fragment #broken1 not found in this document"},
+				{File: "test.md", Line: 4, Message: "link-fragments: fragment #broken2 not found in this document"},
+			},
+		},
+		{
+			name:    "valid: offset applied to line numbers",
+			content: "## Introduction\n\nSee [broken](#broken).\n",
+			opts:    map[string]interface{}{"slug-algorithm": "github"},
+			wantErrs: []LintError{
+				{File: "test.md", Line: 8, Message: "link-fragments: fragment #broken not found in this document"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			offset := 0
+			// The "offset applied" test uses offset=5
+			if tt.name == "valid: offset applied to line numbers" {
+				offset = 5
+			}
+			got := CheckLinkFragments("test.md", lines, offset, tt.opts)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d:\n  got:  %v\n  want: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i, g := range got {
+				w := tt.wantErrs[i]
+				if g.File != w.File || g.Line != w.Line || g.Message != w.Message {
+					t.Errorf("error[%d]:\n  got  {%s:%d %q}\n  want {%s:%d %q}",
+						i, g.File, g.Line, g.Message, w.File, w.Line, w.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractHeadingText(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantText  string
+		wantLevel int
+	}{
+		{"h1", "# Hello", "Hello", 1},
+		{"h2", "## Hello", "Hello", 2},
+		{"h3", "### Hello World", "Hello World", 3},
+		{"h6", "###### Hello", "Hello", 6},
+		{"h7 too deep", "####### Hello", "", 0},
+		{"no space after #", "##nospace", "", 0},
+		{"not a heading", "some text", "", 0},
+		{"empty heading", "## ", "", 2},
+		{"heading with extra spaces trimmed", "##   Hello  ", "Hello", 2},
+		{"heading with inline formatting kept", "## **Hello** World", "**Hello** World", 2},
+		{"empty string", "", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotText, gotLevel := extractHeadingText(tt.line)
+			if gotText != tt.wantText || gotLevel != tt.wantLevel {
+				t.Errorf("extractHeadingText(%q) = (%q, %d), want (%q, %d)",
+					tt.line, gotText, gotLevel, tt.wantText, tt.wantLevel)
+			}
+		})
+	}
+}
+
+func TestCollectRefDefs(t *testing.T) {
+	t.Run("collects fragment refs", func(t *testing.T) {
+		lines := strings.Split("[ref1]: #section-1\n[ref2]: #section-2\n[ext]: https://example.com\n", "\n")
+		defs := collectRefDefs(lines)
+		if defs["ref1"] != "section-1" {
+			t.Errorf("expected ref1 -> section-1, got %q", defs["ref1"])
+		}
+		if defs["ref2"] != "section-2" {
+			t.Errorf("expected ref2 -> section-2, got %q", defs["ref2"])
+		}
+		if _, ok := defs["ext"]; ok {
+			t.Error("external link ref should not be collected")
+		}
+	})
+
+	t.Run("label is normalized to lowercase", func(t *testing.T) {
+		lines := []string{"[My Label]: #my-section"}
+		defs := collectRefDefs(lines)
+		if defs["my label"] != "my-section" {
+			t.Errorf("expected 'my label' -> 'my-section', got %q", defs["my label"])
+		}
+	})
+}

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -193,6 +193,7 @@ func TestExtractHeadingText(t *testing.T) {
 		{"heading with extra spaces trimmed", "##   Hello  ", "Hello", 2},
 		{"heading with inline formatting kept", "## **Hello** World", "**Hello** World", 2},
 		{"empty string", "", "", 0},
+		{"bare hash no space or content", "##", "", 2},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Implements the `link-fragments` rule (MD051 equivalent) that validates every internal fragment link (`#fragment`) resolves to an actual heading slug
- Supports 8 configurable slug algorithms: `github` (default), `gitlab`, `zenn`, `pandoc`, `pandoc-gfm`, `kramdown`, `mkdocs`, `docfx`
- Handles inline links (`[text](#frag)`), reference-style links (`[text][ref]` + `[ref]: #frag`), heading deduplication (`-1`, `-2` suffixes), inline formatting in headings, and fenced code block exclusion

## Design

- **`link_fragments_slug.go`**: per-algorithm slug functions + `ComputeSlug` dispatcher + `buildSlugSet` with deduplication
- **`link_fragments.go`**: heading extractor, ref-def collector, main checker with code-block-aware scan
- **Performance**: O(1) pre-scan skips slug computation entirely when no fragment links exist in the document; fast-path `strings.Contains` skips lines without `(#` or `][`; slug functions fold `unicode.ToLower` into the per-rune loop to avoid intermediate string allocation
- Bench-compare result: +6.7% time, +0.04% memory, +0.03% allocs — all ✅

## Test plan

- [ ] `make test` — 100% coverage across all packages
- [ ] `make test-e2e` — `LinkFragmentsValid` and `LinkFragmentsViolation` E2E cases pass
- [ ] `make bench` — benchmark comparison passes (no ❌ regressions)
- [ ] `make static-lint` — 0 issues (cognitive complexity < 30 on all functions)

Closes #172