### PR TITLE
feat(blanks-around-fences): implement MD031 rule (issue #185)

### DIFF
--- a/e2e/config-blanks-around-fences.json
+++ b/e2e/config-blanks-around-fences.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "blanks-around-fences": true
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -314,6 +314,26 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "2 issues found")
 	})
 
+	t.Run("BlanksAroundFencesValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/blanks_around_fences_valid.md", "--config", "config-blanks-around-fences.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "fenced code block must be preceded by a blank line")
+		assertOutputNotContains(t, output, "fenced code block must be followed by a blank line")
+	})
+
+	t.Run("BlanksAroundFencesViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/blanks_around_fences_violation.md", "--config", "config-blanks-around-fences.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
+		assertOutputContains(t, output, "fixtures/blanks_around_fences_violation.md:4:")
+		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
+		assertOutputContains(t, output, "fixtures/blanks_around_fences_violation.md:8:")
+		assertOutputContains(t, output, "fenced code block must be followed by a blank line")
+		assertOutputContains(t, output, "2 issues found")
+	})
+
 	t.Run("MaxLineLengthValid", func(t *testing.T) {
 		output := runTest(t, "fixtures/max_line_length_valid.md", "--config", "config-max-line-length.json")
 		assertOutputContains(t, output, "No issues found")
@@ -479,7 +499,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "list must be preceded by a blank line")
 		assertOutputContains(t, output, "Errors in fixtures/no_hard_tabs_violation.md:")
 		assertOutputContains(t, output, "hard tab character found")
-		assertOutputContains(t, output, "Checked 41 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
+		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
+		assertOutputContains(t, output, "Checked 43 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
@@ -492,6 +514,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_emphasis_as_heading_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_hard_tabs_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_fences_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/blanks_around_fences_valid.md
+++ b/e2e/fixtures/blanks_around_fences_valid.md
@@ -1,0 +1,17 @@
+## Valid Fenced Code Blocks
+
+Some text before the fence.
+
+```go
+func hello() {
+    fmt.Println("hello")
+}
+```
+
+Some text after the fence.
+
+~~~python
+print("hello")
+~~~
+
+Final text.

--- a/e2e/fixtures/blanks_around_fences_violation.md
+++ b/e2e/fixtures/blanks_around_fences_violation.md
@@ -1,0 +1,9 @@
+## Fenced Code Blocks Without Blank Lines
+
+Some text before the fence.
+```go
+func hello() {
+    fmt.Println("hello")
+}
+```
+Some text after the fence.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const DefaultConfigJSON = `{
     "no-empty-links": true,
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
+    "blanks-around-fences": true,
     "no-hard-tabs": true,
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
@@ -220,6 +221,7 @@ func Default() Config {
 			"no-empty-links":          enabledRule(),
 			"no-emphasis-as-heading":  enabledRule(),
 			"blanks-around-lists":     enabledRule(),
+			"blanks-around-fences":    enabledRule(),
 			"no-hard-tabs":            enabledRule(),
 			"max-line-length": {
 				Enabled:  false,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -209,6 +209,7 @@ var simpleRules = []struct {
 	{"no-empty-links", rule.CheckNoEmptyLinks},
 	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
+	{"blanks-around-fences", rule.CheckBlanksAroundFences},
 	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -16,20 +16,15 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 		trimmed := strings.TrimSpace(line)
 		isBlank := trimmed == ""
 
-		// Track HTML comment blocks (<!-- ... -->).
-		// Fences inside comments are not real fenced code blocks.
-		if !inHTMLComment {
-			if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
-				inHTMLComment = true
+		// HTML comment tracking only applies outside fenced code blocks;
+		// `<!--`-like content inside a fenced block is just code and must not
+		// interfere with detecting the closing fence.
+		if !inBlock {
+			if skip, stillInComment := stepHTMLComment(trimmed, inHTMLComment); skip {
+				inHTMLComment = stillInComment
 				prevBlank = false
 				continue
 			}
-		} else {
-			if strings.Contains(trimmed, "-->") {
-				inHTMLComment = false
-			}
-			prevBlank = false
-			continue
 		}
 
 		if inBlock {
@@ -68,4 +63,20 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 	}
 
 	return errs
+}
+
+// stepHTMLComment advances the HTML-comment state machine for one line.
+// It returns (skip, inComment) where skip indicates the caller should
+// `continue` past this line, and inComment is the updated state.
+func stepHTMLComment(trimmed string, inComment bool) (bool, bool) {
+	if inComment {
+		if strings.Contains(trimmed, "-->") {
+			return true, false
+		}
+		return true, true
+	}
+	if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
+		return true, true
+	}
+	return false, false
 }

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -1,0 +1,71 @@
+package rule
+
+import "strings"
+
+// CheckBlanksAroundFences flags fenced code blocks that are not preceded or
+// followed by a blank line. Fences at the start or end of the file are exempt
+// from the respective check. Fences inside HTML comment blocks are ignored.
+func CheckBlanksAroundFences(filename string, lines []string, offset int) []LintError {
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+	inHTMLComment := false
+	prevBlank := true
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		isBlank := trimmed == ""
+
+		// Track HTML comment blocks (<!-- ... -->).
+		// Fences inside comments are not real fenced code blocks.
+		if !inHTMLComment {
+			if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
+				inHTMLComment = true
+				prevBlank = false
+				continue
+			}
+		} else {
+			if strings.Contains(trimmed, "-->") {
+				inHTMLComment = false
+			}
+			prevBlank = false
+			continue
+		}
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+				// closing fence: check the next line
+				if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) != "" {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "blanks-around-fences: fenced code block must be followed by a blank line",
+					})
+				}
+			}
+			prevBlank = false
+			continue
+		}
+
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			// opening fence: check the previous line
+			if i > 0 && !prevBlank {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
+				})
+			}
+			prevBlank = false
+			continue
+		}
+
+		prevBlank = isBlank
+	}
+
+	return errs
+}

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -1,0 +1,124 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckBlanksAroundFences(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		wantErrs []LintError
+	}{
+		{
+			name:     "valid: blank lines around fence",
+			content:  "Some text\n\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fence at start of file needs no preceding blank",
+			content:  "```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fence at end of file needs no following blank",
+			content:  "Some text\n\n```go\ncode\n```",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fence is the only content",
+			content:  "```go\ncode\n```",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: tilde fence with blank lines",
+			content:  "Some text\n\n~~~go\ncode\n~~~\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: no blank line before opening fence",
+			content: "Some text\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+			},
+		},
+		{
+			name:    "invalid: no blank line after closing fence",
+			content: "Some text\n\n```go\ncode\n```\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "blanks-around-fences: fenced code block must be followed by a blank line"},
+			},
+		},
+		{
+			name:    "invalid: missing blank before and after",
+			content: "Some text\n```go\ncode\n```\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+				{File: "test.md", Line: 4, Message: "blanks-around-fences: fenced code block must be followed by a blank line"},
+			},
+		},
+		{
+			name:    "invalid: tilde fence missing blank before",
+			content: "Some text\n~~~go\ncode\n~~~\n\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+			},
+		},
+		{
+			name:    "invalid: multiple fences with violations",
+			content: "text\n```\nfoo\n```\ntext\n```\nbar\n```\nend\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+				{File: "test.md", Line: 4, Message: "blanks-around-fences: fenced code block must be followed by a blank line"},
+				{File: "test.md", Line: 6, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+				{File: "test.md", Line: 8, Message: "blanks-around-fences: fenced code block must be followed by a blank line"},
+			},
+		},
+		{
+			name:    "offset shifts line numbers",
+			content: "Some text\n```go\ncode\n```\n\nMore text\n",
+			offset:  5,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 7, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+			},
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: longer fence marker",
+			content:  "Some text\n\n````go\ncode\n````\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fence inside HTML comment block is ignored",
+			content:  "Some text\n<!--\n```go\ncode\n```\n-->\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: fence after HTML comment block requires blank line",
+			content:  "<!--\ncomment\n-->\n\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckBlanksAroundFences("test.md", lines, tt.offset)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i] != tt.wantErrs[i] {
+					t.Errorf("error[%d]: got %+v, want %+v", i, got[i], tt.wantErrs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -104,6 +104,18 @@ func TestCheckBlanksAroundFences(t *testing.T) {
 			content:  "<!--\ncomment\n-->\n\n```go\ncode\n```\n\nMore text\n",
 			wantErrs: nil,
 		},
+		{
+			name:    "invalid: code block containing <!-- still detects missing trailing blank",
+			content: "text\n\n```\n<!--\n```\ntext\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "blanks-around-fences: fenced code block must be followed by a blank line"},
+			},
+		},
+		{
+			name:     "valid: code block containing balanced <!-- and --> closes correctly",
+			content:  "text\n\n```\n<!--\n-->\n```\n\ntext\n",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Implements `blanks-around-fences` (MD031) rule: fenced code blocks must be preceded and followed by a blank line
- Fences at the start/end of the file are exempt from the respective check
- Fences inside HTML comment blocks (`<!-- ... -->`) are ignored to avoid false positives

## Changes

- `internal/rule/blanks_around_fences.go` — rule implementation using `openingFenceMarker` / `IsClosingFence` utilities
- `internal/rule/blanks_around_fences_test.go` — 16 table-driven test cases (100% coverage)
- `internal/config/config.go` — register rule as enabled by default
- `internal/linter/linter.go` — wire rule into `simpleRules` slice
- `e2e/fixtures/blanks_around_fences_valid.md` — valid fixture
- `e2e/fixtures/blanks_around_fences_violation.md` — violation fixture (2 violations)
- `e2e/config-blanks-around-fences.json` — opt-in config for e2e tests
- `e2e/e2e_test.go` — `BlanksAroundFencesValid` and `BlanksAroundFencesViolation` test cases

Closes #185

## Test plan

- [x] `make check-coverage` — 100%
- [x] `make test-e2e` — all pass
- [x] `make static-lint` — 0 issues
- [x] Benchmark comparison — no regression