### PR TITLE
bench(PR-10): empty-alt-text — hoist regex + byte-level prefilter

### DIFF
--- a/internal/rule/empty_alt_text.go
+++ b/internal/rule/empty_alt_text.go
@@ -7,6 +7,7 @@ import (
 
 var emptyAltTextRe = regexp.MustCompile(`!\[\s*\]\([^)]+\)`)
 
+// CheckEmptyAltText reports lint errors for images with empty alt text.
 func CheckEmptyAltText(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/empty_alt_text.go
+++ b/internal/rule/empty_alt_text.go
@@ -2,23 +2,19 @@ package rule
 
 import (
 	"regexp"
+	"strings"
 )
 
-// CheckEmptyAltText checks for image tags with empty alt text (![](...))
-//
-// Parameters:
-//   - filename: the name of the file being checked
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError if any image has empty alt text.
+var emptyAltTextRe = regexp.MustCompile(`!\[\s*\]\([^)]+\)`)
+
 func CheckEmptyAltText(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
-	re := regexp.MustCompile(`!\[\s*\]\([^)]+\)`)
 
 	for i, line := range lines {
-		if re.MatchString(line) {
+		if !strings.Contains(line, "![") {
+			continue
+		}
+		if emptyAltTextRe.MatchString(line) {
 			errs = append(errs, LintError{
 				File:    filename,
 				Line:    i + 1 + offset,


### PR DESCRIPTION
## Summary

- Move `regexp.MustCompile` to package scope — eliminates per-call regex compilation
- Add `strings.Contains(line, "![")` prefilter — skips regex on ~97.5% of lines (non-image lines) in the benchmark document

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 564 030 ns | 3 337 226 ns | **-6.4% ✅** |
| B/op | 895 227 B | 895 239 B | ≈0% |
| allocs/op | 2 072 | 2 043 | **-1.4% ✅** |

The time reduction is real: regex compilation cost eliminated per `LintContent` call, and the prefilter avoids regex engine startup on the vast majority of lines.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146