### PR TITLE
bench(PR-11): no-empty-links — firstNonSpaceByte prefilter for code-block tracking

### DIFF
--- a/internal/rule/no_empty_links.go
+++ b/internal/rule/no_empty_links.go
@@ -63,21 +63,25 @@ func CheckNoEmptyLinks(filename string, lines []string, offset int) []LintError 
 	fenceMarker := ""
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first != fenceMarker[0] {
+				continue
+			}
+			if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
 		}
 
 		if !strings.Contains(line, "](") {


### PR DESCRIPTION
## Summary

Apply the same byte-level prefilter that `GetCodeBlockLineRanges` uses to the inline code-block tracker inside `CheckNoEmptyLinks`:

- **Inside a block**: skip `TrimSpace` + `IsClosingFence` when `firstNonSpaceByte` does not match the opener's fence character (~97% of in-block lines)
- **Outside a block**: skip `TrimSpace` + `openingFenceMarker` when the line does not start with `` ` `` or `~` (~98% of out-of-block lines)

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 450 371 ns | ~3 356 000 ns | **-2.8% ✅** |
| B/op | 894 453 B | 894 770 B | ≈0% |
| allocs/op | 2 043 | 2 043 | 0% |

Benchmark is noisy locally; CI `benchstat` geomean will be the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146