### PR TITLE
bench(PR-12): no-bare-urls — firstNonSpaceByte prefilter + defer TrimSpace

### DIFF
--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -243,10 +243,7 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if first != fenceMarker[0] {
-				continue
-			}
-			if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -240,20 +240,25 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 			// Fall through to process the remainder of the line.
 		}
 
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first != fenceMarker[0] {
+				continue
+			}
+			if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
 		}
 
 		if !strings.Contains(line, "http") {
@@ -263,6 +268,7 @@ func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
 			continue
 		}
 
+		trimmed := strings.TrimSpace(line)
 		if isLinkCard(lines, i, trimmed) {
 			continue
 		}


### PR DESCRIPTION
## Summary

Two changes to `CheckNoBareURLs`:

1. **`firstNonSpaceByte` prefilter for code-block tracking** — identical to the pattern used in `GetCodeBlockLineRanges` and `CheckNoEmptyLinks`:
   - Inside a block: skip `TrimSpace` + `IsClosingFence` when `firstNonSpaceByte` does not match the fence character (combined with `&&` to stay within `gocognit` threshold)
   - Outside a block: skip `TrimSpace` + `openingFenceMarker` when `firstNonSpaceByte` is not `` ` `` or `~`

2. **Defer `trimmed := strings.TrimSpace(line)`** to after the `"http"` prefilter — computed only for lines that contain a URL candidate, not for every line.

Together these eliminate ~24 000 unconditional `TrimSpace` calls per 1 000-section document.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 893 538 ns | 3 289 926 ns | **-15.5% ✅** |
| B/op | 895 069 B | 894 206 B | ≈0% |
| allocs/op | 2 043 | 2 043 | 0% |

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes
- [x] `golangci-lint` passes (gocognit ≤ 30)
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146