### PR TITLE
bench(PR-13): duplicate-heading — firstNonSpaceByte prefilter + map pre-sizing

### DIFF
--- a/internal/rule/duplicate_headings.go
+++ b/internal/rule/duplicate_headings.go
@@ -21,23 +21,24 @@ import (
 //   - A slice of LintError entries for each detected duplicate heading (excluding the first occurrence).
 func CheckDuplicateHeadings(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
-	seen := map[string]int{}
+	seen := make(map[string]struct{}, len(lines)/10)
 
 	for i, line := range lines {
+		if firstNonSpaceByte(line) != '#' {
+			continue
+		}
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "#") {
-			heading := strings.TrimSpace(strings.TrimLeft(line, "#"))
-			normalized := strings.ToLower(heading)
+		heading := strings.TrimSpace(strings.TrimLeft(line, "#"))
+		normalized := strings.ToLower(heading)
 
-			if _, ok := seen[normalized]; ok {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    i + 1 + offset,
-					Message: fmt.Sprintf("duplicate heading: %q", normalized),
-				})
-			} else {
-				seen[normalized] = i + 1 + offset
-			}
+		if _, ok := seen[normalized]; ok {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    i + 1 + offset,
+				Message: fmt.Sprintf("duplicate heading: %q", normalized),
+			})
+		} else {
+			seen[normalized] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Three changes to `CheckDuplicateHeadings`:

1. **`firstNonSpaceByte` prefilter**: skip `TrimSpace` on lines that do not start with `#` (~92% of lines in a typical document) — avoids ~23 000 `TrimSpace` calls per 1 000-section benchmark document
2. **`map[string]struct{}` instead of `map[string]int`**: the stored integer value was never read back; `struct{}` is a zero-size type and reduces value storage
3. **`make(map[string]struct{}, len(lines)/10)`**: pre-size the `seen` map so it covers the expected heading count (~one heading per 10 lines), eliminating ~10 map-grow resize operations and their backing-array allocations (~113 KB saved per run in the 1 000-section benchmark)

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 249 282 ns | 3 151 642 ns | **-3.0% ✅** |
| B/op | 895 338 B | 782 369 B | **-12.6% ✅** |
| allocs/op | 2 043 | 2 023 | **-1.0% ✅** |

The memory reduction is the headline win: pre-sizing eliminates repeated backing-array allocations during map growth.

Note: local benchmarks on Apple M4 can diverge from CI (AMD EPYC); CI `benchstat` geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146