### PR TITLE
bench(PR-14): no-emphasis-as-heading — two-stage byte prefilter

### DIFF
--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -95,23 +95,29 @@ func CheckNoEmphasisAsHeading(filename string, lines []string, offset int) []Lin
 	fenceMarker := ""
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
-			inBlock = true
-			fenceMarker = marker
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+			}
 			continue
 		}
 
+		if first != '*' && first != '_' {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
 		inner, ok := emphasisContent(trimmed)
 		if !ok {
 			continue

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -59,6 +59,16 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
+			name:     "invalid: backtick-leading non-fence line does not bypass later violation",
+			content:  "`inline code`\n**Heading**\n",
+			wantErrs: []LintError{{File: "test.md", Line: 2, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: **Heading**"}},
+		},
+		{
+			name:     "valid: delimiter-only line too short to be an emphasis span",
+			content:  "**\n",
+			wantErrs: nil,
+		},
+		{
 			name:     "valid: bold with surrounding text",
 			content:  "This is **important** text.\n",
 			wantErrs: nil,


### PR DESCRIPTION
## Summary

Replace the unconditional `strings.TrimSpace` + `emphasisContent` call path with a two-stage byte-level prefilter:

1. **`firstNonSpaceByte` prefilter for code-block tracking** (same pattern as PR-11/12/13):
   - Inside a block: combine `first == fenceMarker[0] && IsClosingFence(...)` with `&&` — avoids `TrimSpace` + `IsClosingFence` when first byte doesn't match
   - Outside a block: skip `TrimSpace` + `openingFenceMarker` for lines not starting with `` ` `` or `~`

2. **Emphasis-candidate prefilter**: `first != '*' && first != '_'` → `continue`. Emphasis spans can only begin with these characters, so ~98% of lines exit here without a `TrimSpace` call.

Combined, `TrimSpace` is now called only for fence-related lines (~1 000 in the 1 000-section benchmark) and `*`/`_` lines (≈ 0 in the benchmark document where lists use `-`).

Also adds two test cases to restore 100% coverage: the new `continue` path for `` ` ``/`~` lines that aren't fence openers, and the `matchDoubleDelim` short-line path that was previously reached via non-`*` lines.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 288 108 ns | 2 997 575 ns | **-8.8% ✅** |
| B/op | 782 755 B | 782 068 B | ≈0% |
| allocs/op | 2 023 | 2 023 | 0% |

Note: CI (AMD EPYC) geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146