### PR TITLE
bench(PR-15): max-line-length — firstNonSpaceByte prefilter + short-line fast path

### DIFF
--- a/internal/rule/max_line_length.go
+++ b/internal/rule/max_line_length.go
@@ -35,38 +35,38 @@ func CheckMaxLineLength(filename string, lines []string, offset int, lineLength 
 	fenceMarker := ""
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
-			inBlock = true
-			fenceMarker = marker
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
+		}
+
+		if len(line) <= lineLength {
 			continue
 		}
 
-		if isATXHeading(trimmed) {
+		trimmed := strings.TrimSpace(line)
+		if (first == '#' && isATXHeading(trimmed)) || isBareURLLine(trimmed) {
 			continue
 		}
 
-		if isBareURLLine(trimmed) {
-			continue
-		}
-
-		if len(line) > lineLength {
-			errs = append(errs, LintError{
-				File:    filename,
-				Line:    offset + i + 1,
-				Message: fmt.Sprintf("max-line-length: line exceeds %d bytes (%d)", lineLength, len(line)),
-			})
-		}
+		errs = append(errs, LintError{
+			File:    filename,
+			Line:    offset + i + 1,
+			Message: fmt.Sprintf("max-line-length: line exceeds %d bytes (%d)", lineLength, len(line)),
+		})
 	}
 
 	return errs

--- a/internal/rule/max_line_length_test.go
+++ b/internal/rule/max_line_length_test.go
@@ -47,15 +47,23 @@ func TestCheckMaxLineLength(t *testing.T) {
 		},
 		{
 			name:       "valid: bare http URL line exempt",
-			content:    "http://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/length\n",
+			content:    "http://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/length/extra\n",
 			lineLength: 80,
 			wantErrs:   nil,
 		},
 		{
 			name:       "valid: angle-bracket URL line exempt",
-			content:    "<https://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/>\n",
+			content:    "<https://example.com/very/long/path/that/exceeds/eighty/bytes/in/total/length/xx>\n",
 			lineLength: 80,
 			wantErrs:   nil,
+		},
+		{
+			name:       "invalid: long line starting with backtick but not a fence opener",
+			content:    "`" + strings.Repeat("x", 81) + "\n",
+			lineLength: 80,
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: fmt.Sprintf("max-line-length: line exceeds 80 bytes (%d)", 82)},
+			},
 		},
 		{
 			name:       "valid: long line inside fenced code block",


### PR DESCRIPTION
## Summary

Three changes to `CheckMaxLineLength`:

1. **`firstNonSpaceByte` prefilter for code-block tracking** (same pattern as PR-11–14): avoids `TrimSpace` + `IsClosingFence`/`openingFenceMarker` on lines whose first non-space byte doesn't match the fence character or is not `` ` ``/`~`

2. **Short-line fast path**: move `len(line) <= lineLength` check *before* `TrimSpace` + `isATXHeading` + `isBareURLLine`. Lines within the limit are never violations and need no exemption checks. In the benchmark (`lineLength=120`) every prose line is well under 120 bytes, so `TrimSpace` is now called only for fence-related lines (~1 000 per 1 000-section doc) instead of all ~25 000 lines.

3. **Bug fix**: the original prefilter unconditionally `continue`d for any `` ` ``/`~` line, silently skipping long non-fence lines starting with those characters. Fixed by moving `continue` inside `if marker != ""` so only confirmed fence openers are skipped.

Also updates two existing test URLs whose byte lengths happened to be ≤ `lineLength=80`, causing them to be absorbed by the new fast path and leaving `isBareURLLine`'s `http://` and angle-bracket branches uncovered. URLs extended by a few bytes to keep them > 80 and restore 100% coverage. A regression test for the bug (long backtick-starting non-fence line) was also added.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 2 962 849 ns | 2 868 736 ns | **-3.2% ✅** |
| B/op | 781 897 B | 782 069 B | ≈0% |
| allocs/op | 2 023 | 2 023 | 0% |

Note: CI (AMD EPYC) geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146