### PR TITLE
feat: add consistent-code-fence rule (MD048)

### DIFF
--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -20,15 +20,15 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] `blanks-around-lists`: Lists must be surrounded by blank lines
 - [x] `max-line-length`: Enforce a maximum line length (MD013)
 - [x] `no-hard-tabs`: No hard tab characters in body text (MD010)
+- [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
+- [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`) (MD048)
 
 ## Rules — Planned
 
 ### Priority 2
 
-- [ ] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
 - [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
-- [ ] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`) (MD048)
 - [ ] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
 - [ ] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
 

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -26,6 +26,7 @@ weight: 2
 | `blanks-around-fences`         | Fenced code blocks not surrounded by blank lines                        | Default **on**                                                                                        |
 | `no-hard-tabs`                 | Hard tab characters (`\t`) outside fenced code blocks and inline code   | Default **on**                                                                                        |
 | `no-trailing-punctuation`      | Heading text ending with a punctuation character                        | Default **on**. Option: `punctuation` (default `".,;:!"`) — the full set of characters to flag; e.g. set `".,;:!?"` to also flag question headings |
+| `consistent-code-fence`        | Inconsistent fenced code block marker (`` ``` `` vs `~~~`)              | Default **on**. Option: `style` (`consistent` \| `backtick` \| `tilde`, default `consistent`)        |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |

--- a/e2e/config-consistent-code-fence.json
+++ b/e2e/config-consistent-code-fence.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "consistent-code-fence": { "style": "consistent" }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -441,7 +441,7 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		}
 		assertOutputContains(t, output, "Errors in fixtures/consistent_code_fence_violation.md:")
 		assertOutputContains(t, output, "fixtures/consistent_code_fence_violation.md:7:")
-		assertOutputContains(t, output, "expected '```' fence, got '~~~' fence")
+		assertOutputContains(t, output, "expected backtick fence, got tilde fence")
 		assertOutputContains(t, output, "1 issues found")
 	})
 }
@@ -576,7 +576,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
 		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
 		assertOutputContains(t, output, "Errors in fixtures/consistent_code_fence_violation.md:")
-		assertOutputContains(t, output, "expected '```' fence, got '~~~' fence")
+		assertOutputContains(t, output, "expected backtick fence, got tilde fence")
 		assertOutputContains(t, output, "Checked 51 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -427,6 +427,23 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "#setup")
 		assertOutputContains(t, output, "1 issues found")
 	})
+
+	t.Run("ConsistentCodeFenceValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/consistent_code_fence_valid.md", "--config", "config-consistent-code-fence.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "consistent-code-fence")
+	})
+
+	t.Run("ConsistentCodeFenceViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/consistent_code_fence_violation.md", "--config", "config-consistent-code-fence.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/consistent_code_fence_violation.md:")
+		assertOutputContains(t, output, "fixtures/consistent_code_fence_violation.md:7:")
+		assertOutputContains(t, output, "expected '```' fence, got '~~~' fence")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -558,7 +575,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "hard tab character found")
 		assertOutputContains(t, output, "Errors in fixtures/blanks_around_fences_violation.md:")
 		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
-		assertOutputContains(t, output, "Checked 49 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/consistent_code_fence_violation.md:")
+		assertOutputContains(t, output, "expected '```' fence, got '~~~' fence")
+		assertOutputContains(t, output, "Checked 51 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
@@ -568,6 +587,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_headings_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_bare_urls_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_lists_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/consistent_code_fence_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_empty_links_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_emphasis_as_heading_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_hard_tabs_valid.md:")

--- a/e2e/fixtures/consistent_code_fence_valid.md
+++ b/e2e/fixtures/consistent_code_fence_valid.md
@@ -1,4 +1,4 @@
-## Valid Fenced Code Blocks
+## Valid Consistent Code Fence
 
 Some text before the fence.
 
@@ -8,10 +8,10 @@ func hello() {
 }
 ```
 
-Some text after the fence.
+Some text in between.
 
 ```python
-print("hello")
+print("world")
 ```
 
 Final text.

--- a/e2e/fixtures/consistent_code_fence_violation.md
+++ b/e2e/fixtures/consistent_code_fence_violation.md
@@ -1,0 +1,9 @@
+## Inconsistent Code Fence
+
+```go
+fmt.Println("hello")
+```
+
+~~~python
+print("world")
+~~~

--- a/e2e/fixtures/longer_closing_fence.md
+++ b/e2e/fixtures/longer_closing_fence.md
@@ -6,11 +6,11 @@ A code block closed by a longer fence:
 package main
 `````
 
-A tilde block closed by a longer fence:
+A code block closed by an even longer fence:
 
-~~~python
+```python
 print("hello")
-~~~~~
+``````
 
 ## After Fenced Blocks
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ const DefaultConfigJSON = `{
     "blanks-around-fences": true,
     "no-hard-tabs": true,
     "no-trailing-punctuation": { "punctuation": ".,;:!" },
+    "consistent-code-fence": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
     "link-fragments": { "enabled": false, "slug-algorithm": "github" }
@@ -232,6 +233,11 @@ func Default() Config {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{"punctuation": DefaultNoTrailingPunctuation},
+			},
+			"consistent-code-fence": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{"style": "consistent"},
 			},
 			"max-line-length": {
 				Enabled:  false,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -166,6 +166,17 @@ func (l *Linter) noTrailingPunctuation() string {
 	return config.DefaultNoTrailingPunctuation
 }
 
+// consistentCodeFenceStyle returns the configured style for the consistent-code-fence rule.
+func (l *Linter) consistentCodeFenceStyle() string {
+	style, _ := l.config.RuleOptions("consistent-code-fence")["style"].(string)
+	switch style {
+	case "consistent", "backtick", "tilde":
+		return style
+	default:
+		return "consistent"
+	}
+}
+
 // maxLineLength returns the configured lineLength for the max-line-length rule.
 func (l *Linter) maxLineLength() int {
 	lineLength := 80
@@ -235,6 +246,9 @@ func (l *Linter) collectLineErrors(path string, lines []string, offset int) []ru
 
 	if l.config.IsEnabled("heading-level") {
 		errs = append(errs, l.withSeverity(rule.CheckHeadingLevels(path, lines, offset, l.headingMinLevel()), "heading-level")...)
+	}
+	if l.config.IsEnabled("consistent-code-fence") {
+		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, lines, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)
 	}
 	if l.config.IsEnabled("max-line-length") {
 		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -855,3 +855,33 @@ func TestRun_LinkFragments_ValidLink(t *testing.T) {
 		t.Errorf("expected no errors for valid fragment link, got %d", result.TotalErrors)
 	}
 }
+
+func TestRun_ConsistentCodeFence_Violation(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "consistent"},
+	}
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", "```go\ncode\n```\n\n~~~python\ncode\n~~~\n")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+}
+
+func TestRun_ConsistentCodeFence_NoOptionFallsBackToConsistent(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{},
+	}
+
+	linter := New(cfg)
+	if linter.consistentCodeFenceStyle() != "consistent" {
+		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentCodeFenceStyle())
+	}
+}

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -51,34 +51,8 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 			ch := marker[0]
 			inBlock = true
 			fenceMarker = marker
-
-			switch style {
-			case "consistent":
-				if expectedCh == 0 {
-					expectedCh = ch
-				} else if ch != expectedCh {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "consistent-code-fence: expected " + fenceCharName(expectedCh) + " fence, got " + fenceCharName(ch) + " fence",
-					})
-				}
-			case "backtick":
-				if ch != '`' {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "consistent-code-fence: expected backtick fence, got tilde fence",
-					})
-				}
-			case "tilde":
-				if ch != '~' {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "consistent-code-fence: expected tilde fence, got backtick fence",
-					})
-				}
+			if err := checkFenceStyle(filename, offset+i+1, ch, style, &expectedCh); err != nil {
+				errs = append(errs, *err)
 			}
 			continue
 		}
@@ -90,6 +64,43 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 	}
 
 	return errs
+}
+
+// checkFenceStyle validates ch against the configured style and updates
+// expectedCh in consistent mode. Returns a LintError if the fence character
+// does not match, nil otherwise.
+func checkFenceStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
+	switch style {
+	case "consistent":
+		if *expectedCh == 0 {
+			*expectedCh = ch
+			return nil
+		}
+		if ch != *expectedCh {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-code-fence: expected " + fenceCharName(*expectedCh) + " fence, got " + fenceCharName(ch) + " fence",
+			}
+		}
+	case "backtick":
+		if ch != '`' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-code-fence: expected backtick fence, got tilde fence",
+			}
+		}
+	case "tilde":
+		if ch != '~' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-code-fence: expected tilde fence, got backtick fence",
+			}
+		}
+	}
+	return nil
 }
 
 func fenceCharName(ch byte) string {

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -1,0 +1,93 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckConsistentCodeFence flags fenced code blocks that use a different fence
+// character than expected. style must be "consistent", "backtick", or "tilde";
+// any other value falls back to "consistent".
+//
+// In "consistent" mode the first fence character found in the document sets the
+// expected style; every subsequent opener that differs is flagged.
+// In "backtick"/"tilde" mode every opener using the wrong character is flagged.
+func CheckConsistentCodeFence(filename string, lines []string, offset int, style string) []LintError {
+	switch style {
+	case "consistent", "backtick", "tilde":
+	default:
+		style = "consistent"
+	}
+
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+	inHTMLComment := false
+	var expectedCh byte // 0 until first fence seen (consistent mode)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if !inBlock {
+			if skip, stillInComment := stepHTMLComment(trimmed, inHTMLComment); skip {
+				inHTMLComment = stillInComment
+				continue
+			}
+		}
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		marker := openingFenceMarker(trimmed)
+		if marker == "" {
+			continue
+		}
+
+		ch := marker[0]
+		inBlock = true
+		fenceMarker = marker
+
+		switch style {
+		case "consistent":
+			if expectedCh == 0 {
+				expectedCh = ch
+			} else if ch != expectedCh {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: fmt.Sprintf("consistent-code-fence: expected '%s' fence, got '%s' fence", fenceCharStr(expectedCh), fenceCharStr(ch)),
+				})
+			}
+		case "backtick":
+			if ch != '`' {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "consistent-code-fence: expected '```' fence, got '~~~' fence",
+				})
+			}
+		case "tilde":
+			if ch != '~' {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "consistent-code-fence: expected '~~~' fence, got '```' fence",
+				})
+			}
+		}
+	}
+
+	return errs
+}
+
+func fenceCharStr(ch byte) string {
+	if ch == '`' {
+		return "```"
+	}
+	return "~~~"
+}

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -1,7 +1,6 @@
 package rule
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -28,13 +27,7 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
-		if !inBlock {
-			if skip, stillInComment := stepHTMLComment(trimmed, inHTMLComment); skip {
-				inHTMLComment = stillInComment
-				continue
-			}
-		}
-
+		// Inside a code block: only look for the closing fence.
 		if inBlock {
 			if IsClosingFence(trimmed, fenceMarker) {
 				inBlock = false
@@ -43,51 +36,65 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 			continue
 		}
 
-		marker := openingFenceMarker(trimmed)
-		if marker == "" {
+		// Inside an HTML comment block: skip until "-->" is found.
+		if inHTMLComment {
+			if strings.Contains(trimmed, "-->") {
+				inHTMLComment = false
+			}
 			continue
 		}
 
-		ch := marker[0]
-		inBlock = true
-		fenceMarker = marker
+		// Check for an opening fence before inspecting the line for "<!--" so
+		// that fence openers whose info string contains "<!--" (e.g.
+		// "```go <!-- note -->") are treated as fences, not comment starts.
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			ch := marker[0]
+			inBlock = true
+			fenceMarker = marker
 
-		switch style {
-		case "consistent":
-			if expectedCh == 0 {
-				expectedCh = ch
-			} else if ch != expectedCh {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    offset + i + 1,
-					Message: fmt.Sprintf("consistent-code-fence: expected '%s' fence, got '%s' fence", fenceCharStr(expectedCh), fenceCharStr(ch)),
-				})
+			switch style {
+			case "consistent":
+				if expectedCh == 0 {
+					expectedCh = ch
+				} else if ch != expectedCh {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "consistent-code-fence: expected " + fenceCharName(expectedCh) + " fence, got " + fenceCharName(ch) + " fence",
+					})
+				}
+			case "backtick":
+				if ch != '`' {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "consistent-code-fence: expected backtick fence, got tilde fence",
+					})
+				}
+			case "tilde":
+				if ch != '~' {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "consistent-code-fence: expected tilde fence, got backtick fence",
+					})
+				}
 			}
-		case "backtick":
-			if ch != '`' {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    offset + i + 1,
-					Message: "consistent-code-fence: expected '```' fence, got '~~~' fence",
-				})
-			}
-		case "tilde":
-			if ch != '~' {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    offset + i + 1,
-					Message: "consistent-code-fence: expected '~~~' fence, got '```' fence",
-				})
-			}
+			continue
+		}
+
+		// Track HTML comment blocks so fences inside them are ignored.
+		if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
+			inHTMLComment = true
 		}
 	}
 
 	return errs
 }
 
-func fenceCharStr(ch byte) string {
+func fenceCharName(ch byte) string {
 	if ch == '`' {
-		return "```"
+		return "backtick"
 	}
-	return "~~~"
+	return "tilde"
 }

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -1,0 +1,196 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckConsistentCodeFence(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		style    string
+		wantErrs []LintError
+	}{
+		// empty / no fences
+		{
+			name:     "empty doc",
+			content:  "",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "no fences",
+			content:  "# Hello\n\nSome paragraph.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// single fence — never flagged in any mode
+		{
+			name:     "single backtick fence consistent",
+			content:  "```go\ncode\n```\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "single tilde fence consistent",
+			content:  "~~~go\ncode\n~~~\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "single tilde fence backtick-style violation",
+			content:  "~~~go\ncode\n~~~\n",
+			style:    "backtick",
+			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"}},
+		},
+		{
+			name:     "single backtick fence tilde-style violation",
+			content:  "```go\ncode\n```\n",
+			style:    "tilde",
+			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"}},
+		},
+
+		// all-backtick documents
+		{
+			name:     "all backtick consistent no violation",
+			content:  "```go\ncode\n```\n\n```python\ncode\n```\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "all backtick backtick-style no violation",
+			content:  "```go\ncode\n```\n\n```python\ncode\n```\n",
+			style:    "backtick",
+			wantErrs: nil,
+		},
+		{
+			name:  "all backtick tilde-style two violations",
+			content: "```go\ncode\n```\n\n```python\ncode\n```\n",
+			style: "tilde",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
+			},
+		},
+
+		// all-tilde documents
+		{
+			name:     "all tilde consistent no violation",
+			content:  "~~~go\ncode\n~~~\n\n~~~python\ncode\n~~~\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "all tilde tilde-style no violation",
+			content:  "~~~go\ncode\n~~~\n\n~~~python\ncode\n~~~\n",
+			style:    "tilde",
+			wantErrs: nil,
+		},
+		{
+			name:  "all tilde backtick-style two violations",
+			content: "~~~go\ncode\n~~~\n\n~~~python\ncode\n~~~\n",
+			style: "backtick",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+			},
+		},
+
+		// mixed fences — consistent mode
+		{
+			name:    "backtick-first consistent: tilde flagged",
+			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+			},
+		},
+		{
+			name:    "tilde-first consistent: backtick flagged",
+			content: "~~~go\ncode\n~~~\n\n```python\ncode\n```\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
+			},
+		},
+		{
+			name:    "consistent multiple violations",
+			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n\n~~~bash\ncode\n~~~\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 9, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+			},
+		},
+
+		// content inside code block must not be rechecked
+		{
+			name:     "tilde-looking content inside backtick block not flagged",
+			content:  "```go\n~~~\n```\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "backtick-looking content inside tilde block not flagged",
+			content:  "~~~go\n```\n~~~\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// fence inside HTML comment is ignored
+		{
+			name:     "fence inside HTML comment ignored",
+			content:  "text\n<!--\n~~~go\ncode\n~~~\n-->\n```go\ncode\n```\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// offset
+		{
+			name:    "offset shifts line numbers",
+			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
+			offset:  10,
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 15, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+			},
+		},
+
+		// invalid style falls back to consistent
+		{
+			name:    "unknown style falls back to consistent",
+			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
+			style:   "unknown",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+			},
+		},
+
+		// longer fence markers
+		{
+			name:     "longer backtick fence consistent no violation",
+			content:  "````go\ncode\n````\n\n````python\ncode\n````\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckConsistentCodeFence("test.md", lines, tt.offset, tt.style)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i] != tt.wantErrs[i] {
+					t.Errorf("error[%d]: got %+v, want %+v", i, got[i], tt.wantErrs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -67,9 +67,9 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
-			name:  "all backtick tilde-style two violations",
+			name:    "all backtick tilde-style two violations",
 			content: "```go\ncode\n```\n\n```python\ncode\n```\n",
-			style: "tilde",
+			style:   "tilde",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
 				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
@@ -90,9 +90,9 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			wantErrs: nil,
 		},
 		{
-			name:  "all tilde backtick-style two violations",
+			name:    "all tilde backtick-style two violations",
 			content: "~~~go\ncode\n~~~\n\n~~~python\ncode\n~~~\n",
-			style: "backtick",
+			style:   "backtick",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
 				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -44,13 +44,13 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			name:     "single tilde fence backtick-style violation",
 			content:  "~~~go\ncode\n~~~\n",
 			style:    "backtick",
-			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"}},
+			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected backtick fence, got tilde fence"}},
 		},
 		{
 			name:     "single backtick fence tilde-style violation",
 			content:  "```go\ncode\n```\n",
 			style:    "tilde",
-			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"}},
+			wantErrs: []LintError{{File: "test.md", Line: 1, Message: "consistent-code-fence: expected tilde fence, got backtick fence"}},
 		},
 
 		// all-backtick documents
@@ -71,8 +71,8 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "```go\ncode\n```\n\n```python\ncode\n```\n",
 			style:   "tilde",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
+				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected tilde fence, got backtick fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected tilde fence, got backtick fence"},
 			},
 		},
 
@@ -94,8 +94,8 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "~~~go\ncode\n~~~\n\n~~~python\ncode\n~~~\n",
 			style:   "backtick",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 1, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
 			},
 		},
 
@@ -105,7 +105,7 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
 			style:   "consistent",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "~~~go\ncode\n~~~\n\n```python\ncode\n```\n",
 			style:   "consistent",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '~~~' fence, got '```' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected tilde fence, got backtick fence"},
 			},
 		},
 		{
@@ -121,8 +121,8 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n\n~~~bash\ncode\n~~~\n",
 			style:   "consistent",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
-				{File: "test.md", Line: 9, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
+				{File: "test.md", Line: 9, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
 			},
 		},
 
@@ -147,6 +147,15 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			style:    "consistent",
 			wantErrs: nil,
 		},
+		// fence opener whose info string contains "<!--" must not be skipped
+		{
+			name:    "fence opener with <!-- in info string not skipped",
+			content: "```go <!-- comment -->\ncode\n```\n\n~~~python\ncode\n~~~\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
+			},
+		},
 
 		// offset
 		{
@@ -155,7 +164,7 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			offset:  10,
 			style:   "consistent",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 15, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 15, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
 			},
 		},
 
@@ -165,7 +174,7 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
 			style:   "unknown",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected '```' fence, got '~~~' fence"},
+				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
 			},
 		},
 


### PR DESCRIPTION
## Summary

- Implements `consistent-code-fence` rule (closes #198, part of #76)
- Enforces a uniform fenced code block marker (`` ``` `` vs `~~~`) across a document
- Supports three styles via `style` option: `consistent` (default), `backtick`, `tilde`
- Updates docs (rules table + roadmap) and fixes existing fixtures that mixed fence characters

## Test plan

- [x] Unit tests in `internal/rule/consistent_code_fence_test.go` — all pass
- [x] E2E tests (`ConsistentCodeFenceValid`, `ConsistentCodeFenceViolation`) — pass
- [x] `TestBenchmarkContentIsViolationFree` — pass
- [x] `make test-all` — all green