### PR TITLE
feat: add consistent-emphasis-style rule (MD049)

### DIFF
--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -44,8 +44,8 @@ func writeHeading(sb *strings.Builder, i int) {
 }
 
 func writeParagraph(sb *strings.Builder) {
-	sb.WriteString("This section contains important information. ")
-	sb.WriteString("Here are some details that you should know about.\n\n")
+	sb.WriteString("This section contains *important* information. ")
+	sb.WriteString("Here are some **key** details that you should know about.\n\n")
 }
 
 func writeList(sb *strings.Builder) {

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -29,7 +29,7 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
 - [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
-- [ ] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
+- [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
 - [ ] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
 
 ### Priority 3

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -27,6 +27,7 @@ weight: 2
 | `no-hard-tabs`                 | Hard tab characters (`\t`) outside fenced code blocks and inline code   | Default **on**                                                                                        |
 | `no-trailing-punctuation`      | Heading text ending with a punctuation character                        | Default **on**. Option: `punctuation` (default `".,;:!"`) — the full set of characters to flag; e.g. set `".,;:!?"` to also flag question headings |
 | `consistent-code-fence`        | Inconsistent fenced code block marker (`` ``` `` vs `~~~`)              | Default **on**. Option: `style` (`consistent` \| `backtick` \| `tilde`, default `consistent`)        |
+| `consistent-emphasis-style`    | Inconsistent emphasis marker (`*text*` vs `_text_`)                     | Default **on**. Option: `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`)   |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |

--- a/e2e/config-consistent-emphasis-style.json
+++ b/e2e/config-consistent-emphasis-style.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "consistent-emphasis-style": { "style": "consistent" }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -282,7 +282,7 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "fixtures/no_emphasis_as_heading_violation.md:3:")
 		assertOutputContains(t, output, "emphasis used as heading, use ATX heading instead: **Section Title**")
 		assertOutputContains(t, output, "fixtures/no_emphasis_as_heading_violation.md:5:")
-		assertOutputContains(t, output, "emphasis used as heading, use ATX heading instead: _Another Heading_")
+		assertOutputContains(t, output, "emphasis used as heading, use ATX heading instead: *Another Heading*")
 		assertOutputContains(t, output, "2 issues found")
 	})
 
@@ -444,6 +444,23 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "expected backtick fence, got tilde fence")
 		assertOutputContains(t, output, "1 issues found")
 	})
+
+	t.Run("ConsistentEmphasisStyleValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/consistent_emphasis_style_valid.md", "--config", "config-consistent-emphasis-style.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "consistent-emphasis-style")
+	})
+
+	t.Run("ConsistentEmphasisStyleViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/consistent_emphasis_style_violation.md", "--config", "config-consistent-emphasis-style.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/consistent_emphasis_style_violation.md:")
+		assertOutputContains(t, output, "fixtures/consistent_emphasis_style_violation.md:5:")
+		assertOutputContains(t, output, "expected asterisk emphasis, got underscore emphasis")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -577,7 +594,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "fenced code block must be preceded by a blank line")
 		assertOutputContains(t, output, "Errors in fixtures/consistent_code_fence_violation.md:")
 		assertOutputContains(t, output, "expected backtick fence, got tilde fence")
-		assertOutputContains(t, output, "Checked 51 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/consistent_emphasis_style_violation.md:")
+		assertOutputContains(t, output, "expected asterisk emphasis, got underscore emphasis")
+		assertOutputContains(t, output, "Checked 53 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
@@ -592,6 +611,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/no_emphasis_as_heading_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/no_hard_tabs_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_fences_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/consistent_emphasis_style_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/consistent_emphasis_style_valid.md
+++ b/e2e/fixtures/consistent_emphasis_style_valid.md
@@ -1,0 +1,9 @@
+## Consistent Emphasis Style
+
+This is *italic* text.
+
+This is **bold** text.
+
+Another *italic* span here.
+
+Use snake_case naming without triggering the rule.

--- a/e2e/fixtures/consistent_emphasis_style_violation.md
+++ b/e2e/fixtures/consistent_emphasis_style_violation.md
@@ -1,0 +1,5 @@
+## Consistent Emphasis Style
+
+This is *italic* text.
+
+This is _also italic_ text.

--- a/e2e/fixtures/no_emphasis_as_heading_violation.md
+++ b/e2e/fixtures/no_emphasis_as_heading_violation.md
@@ -2,6 +2,6 @@
 
 **Section Title**
 
-_Another Heading_
+*Another Heading*
 
 Some valid text here.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ const DefaultConfigJSON = `{
     "no-hard-tabs": true,
     "no-trailing-punctuation": { "punctuation": ".,;:!" },
     "consistent-code-fence": { "style": "consistent" },
+    "consistent-emphasis-style": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
     "link-fragments": { "enabled": false, "slug-algorithm": "github" }
@@ -235,6 +236,11 @@ func Default() Config {
 				Options:  map[string]interface{}{"punctuation": DefaultNoTrailingPunctuation},
 			},
 			"consistent-code-fence": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{"style": "consistent"},
+			},
+			"consistent-emphasis-style": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{"style": "consistent"},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -177,6 +177,17 @@ func (l *Linter) consistentCodeFenceStyle() string {
 	}
 }
 
+// consistentEmphasisStyle returns the configured style for the consistent-emphasis-style rule.
+func (l *Linter) consistentEmphasisStyle() string {
+	style, _ := l.config.RuleOptions("consistent-emphasis-style")["style"].(string)
+	switch style {
+	case "consistent", "asterisk", "underscore":
+		return style
+	default:
+		return "consistent"
+	}
+}
+
 // maxLineLength returns the configured lineLength for the max-line-length rule.
 func (l *Linter) maxLineLength() int {
 	lineLength := 80
@@ -249,6 +260,9 @@ func (l *Linter) collectLineErrors(path string, lines []string, offset int) []ru
 	}
 	if l.config.IsEnabled("consistent-code-fence") {
 		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, lines, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)
+	}
+	if l.config.IsEnabled("consistent-emphasis-style") {
+		errs = append(errs, l.withSeverity(rule.CheckConsistentEmphasisStyle(path, lines, offset, l.consistentEmphasisStyle()), "consistent-emphasis-style")...)
 	}
 	if l.config.IsEnabled("max-line-length") {
 		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -885,3 +885,33 @@ func TestRun_ConsistentCodeFence_NoOptionFallsBackToConsistent(t *testing.T) {
 		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentCodeFenceStyle())
 	}
 }
+
+func TestRun_ConsistentEmphasisStyle_Violation(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-emphasis-style"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "asterisk"},
+	}
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", "This is _italic_ text.\n")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+}
+
+func TestRun_ConsistentEmphasisStyle_NoOptionFallsBackToConsistent(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-emphasis-style"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{},
+	}
+
+	linter := New(cfg)
+	if linter.consistentEmphasisStyle() != "consistent" {
+		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentEmphasisStyle())
+	}
+}

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -1,0 +1,164 @@
+package rule
+
+import (
+	"strings"
+)
+
+// CheckConsistentEmphasisStyle flags emphasis spans that use a different marker
+// than expected. style must be "consistent", "asterisk", or "underscore";
+// any other value falls back to "consistent".
+//
+// In "consistent" mode the first emphasis character found in the document sets
+// the expected style; every subsequent span using a different character is
+// flagged. In "asterisk"/"underscore" mode every span using the wrong character
+// is flagged. Underscores inside words (e.g. snake_case) are not treated as
+// emphasis. Content inside fenced code blocks and inline code spans is ignored.
+func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, style string) []LintError {
+	switch style {
+	case "consistent", "asterisk", "underscore":
+	default:
+		style = "consistent"
+	}
+
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+	var expectedCh byte // 0 until first emphasis seen (consistent mode)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		if !strings.ContainsAny(line, "*_") {
+			continue
+		}
+
+		scanned := line
+		if strings.ContainsRune(scanned, '`') {
+			scanned = stripInlineCode(scanned)
+		}
+
+		for _, ch := range scanEmphasisOpeners(scanned) {
+			if err := checkEmphasisStyle(filename, offset+i+1, ch, style, &expectedCh); err != nil {
+				errs = append(errs, *err)
+			}
+		}
+	}
+
+	return errs
+}
+
+// scanEmphasisOpeners returns the emphasis opener characters ('*' or '_') found
+// in s. Escaped characters and mid-word underscores are skipped.
+func scanEmphasisOpeners(s string) []byte {
+	var result []byte
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+
+		if ch == '\\' {
+			i += 2
+			continue
+		}
+
+		if ch != '*' && ch != '_' {
+			i++
+			continue
+		}
+
+		runLen := 1
+		for i+runLen < len(s) && s[i+runLen] == ch {
+			runLen++
+		}
+
+		// Runs of 3+ are combinations (e.g. ***), not simple emphasis.
+		if runLen > 2 {
+			i += runLen
+			continue
+		}
+
+		afterRun := i + runLen
+
+		// Left-flanking: must be followed by a non-whitespace character.
+		if afterRun >= len(s) || s[afterRun] == ' ' || s[afterRun] == '\t' {
+			i += runLen
+			continue
+		}
+
+		// Underscores flanked by word characters on both sides are mid-word.
+		if ch == '_' {
+			prevIsWord := i > 0 && isEmphWordChar(s[i-1])
+			nextIsWord := isEmphWordChar(s[afterRun])
+			if prevIsWord && nextIsWord {
+				i += runLen
+				continue
+			}
+		}
+
+		result = append(result, ch)
+		i += runLen
+	}
+	return result
+}
+
+// isEmphWordChar reports whether b is a word character for emphasis purposes.
+func isEmphWordChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// checkEmphasisStyle validates ch against the configured style and updates
+// expectedCh in consistent mode. Returns a LintError if the emphasis character
+// does not match, nil otherwise.
+func checkEmphasisStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
+	switch style {
+	case "consistent":
+		if *expectedCh == 0 {
+			*expectedCh = ch
+			return nil
+		}
+		if ch != *expectedCh {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-emphasis-style: expected " + emphCharName(*expectedCh) + " emphasis, got " + emphCharName(ch) + " emphasis",
+			}
+		}
+	case "asterisk":
+		if ch != '*' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis",
+			}
+		}
+	case "underscore":
+		if ch != '_' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis",
+			}
+		}
+	}
+	return nil
+}
+
+func emphCharName(ch byte) string {
+	if ch == '*' {
+		return "asterisk"
+	}
+	return "underscore"
+}

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -57,8 +57,10 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 	return errs
 }
 
-// checkEmphasisLine scans s for emphasis openers and appends any style
-// violations to errs. It is allocation-free: no intermediate slice is created.
+// checkEmphasisLine scans s for emphasis spans and appends any style violations
+// to errs. Only valid spans (opener + matching closer) are counted, so closing
+// delimiters followed by punctuation are never double-counted. The function is
+// allocation-free: no intermediate slice is created.
 func checkEmphasisLine(s string, filename string, lineNum int, style string, expectedCh *byte, errs *[]LintError) {
 	i := 0
 	for i < len(s) {
@@ -99,11 +101,41 @@ func checkEmphasisLine(s string, filename string, lineNum int, style string, exp
 			continue
 		}
 
+		// Require a matching closer so that closing delimiters (e.g. the `_`
+		// in `_italic_.`) are never counted as openers.
+		closerPos := findEmphCloser(s, afterRun, ch, runLen)
+		if closerPos == -1 {
+			i += runLen
+			continue
+		}
+
 		if err := checkEmphasisStyle(filename, lineNum, ch, style, expectedCh); err != nil {
 			*errs = append(*errs, *err)
 		}
-		i += runLen
+		i = closerPos + runLen // advance past the entire span
 	}
+}
+
+// findEmphCloser returns the start position of the first right-flanking run of
+// ch with exactly runLen characters at or after start. Returns -1 if not found.
+func findEmphCloser(s string, start int, ch byte, runLen int) int {
+	j := start
+	for j < len(s) {
+		if s[j] != ch {
+			j++
+			continue
+		}
+		closeLen := 1
+		for j+closeLen < len(s) && s[j+closeLen] == ch {
+			closeLen++
+		}
+		// Right-flanking: same length as opener and preceded by non-whitespace.
+		if closeLen == runLen && j > 0 && s[j-1] != ' ' && s[j-1] != '\t' {
+			return j
+		}
+		j += closeLen
+	}
+	return -1
 }
 
 // isEmphLeftFlanking reports whether afterRun is a valid left-flanking position

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -51,20 +51,15 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 			scanned = stripInlineCode(scanned)
 		}
 
-		for _, ch := range scanEmphasisOpeners(scanned) {
-			if err := checkEmphasisStyle(filename, offset+i+1, ch, style, &expectedCh); err != nil {
-				errs = append(errs, *err)
-			}
-		}
+		checkEmphasisLine(scanned, filename, offset+i+1, style, &expectedCh, &errs)
 	}
 
 	return errs
 }
 
-// scanEmphasisOpeners returns the emphasis opener characters ('*' or '_') found
-// in s. Escaped characters and mid-word underscores are skipped.
-func scanEmphasisOpeners(s string) []byte {
-	var result []byte
+// checkEmphasisLine scans s for emphasis openers and appends any style
+// violations to errs. It is allocation-free: no intermediate slice is created.
+func checkEmphasisLine(s string, filename string, lineNum int, style string, expectedCh *byte, errs *[]LintError) {
 	i := 0
 	for i < len(s) {
 		ch := s[i]
@@ -93,25 +88,34 @@ func scanEmphasisOpeners(s string) []byte {
 		afterRun := i + runLen
 
 		// Left-flanking: must be followed by a non-whitespace character.
-		if afterRun >= len(s) || s[afterRun] == ' ' || s[afterRun] == '\t' {
+		if !isEmphLeftFlanking(s, afterRun) {
 			i += runLen
 			continue
 		}
 
 		// Underscores flanked by word characters on both sides are mid-word.
-		if ch == '_' {
-			prevIsWord := i > 0 && isEmphWordChar(s[i-1])
-			nextIsWord := isEmphWordChar(s[afterRun])
-			if prevIsWord && nextIsWord {
-				i += runLen
-				continue
-			}
+		if ch == '_' && isEmphMidWord(s, i, afterRun) {
+			i += runLen
+			continue
 		}
 
-		result = append(result, ch)
+		if err := checkEmphasisStyle(filename, lineNum, ch, style, expectedCh); err != nil {
+			*errs = append(*errs, *err)
+		}
 		i += runLen
 	}
-	return result
+}
+
+// isEmphLeftFlanking reports whether afterRun is a valid left-flanking position
+// (followed by a non-whitespace character).
+func isEmphLeftFlanking(s string, afterRun int) bool {
+	return afterRun < len(s) && s[afterRun] != ' ' && s[afterRun] != '\t'
+}
+
+// isEmphMidWord reports whether the delimiter run starting at i is a mid-word
+// underscore (flanked by word characters on both sides).
+func isEmphMidWord(s string, i, afterRun int) bool {
+	return i > 0 && isEmphWordChar(s[i-1]) && isEmphWordChar(s[afterRun])
 }
 
 // isEmphWordChar reports whether b is a word character for emphasis purposes.

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -182,6 +182,14 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			wantErrs: nil,
 		},
 
+		// delimiter followed by whitespace is not an opener
+		{
+			name:     "asterisk followed by space is not an opener",
+			content:  "Use * as a bullet.\n",
+			style:    "underscore",
+			wantErrs: nil,
+		},
+
 		// escaped markers
 		{
 			name:     "escaped asterisk not treated as emphasis",
@@ -226,6 +234,14 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			content:  "This has *no closer.\n",
 			style:    "underscore",
 			wantErrs: nil,
+		},
+		{
+			name:    "wrong-length run skipped, correct closer found",
+			content: "Use *italic**more* text.\n",
+			style:   "underscore",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+			},
 		},
 
 		// offset

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -1,0 +1,244 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckConsistentEmphasisStyle(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		style    string
+		wantErrs []LintError
+	}{
+		// empty / no emphasis
+		{
+			name:     "empty doc",
+			content:  "",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "no emphasis",
+			content:  "# Hello\n\nSome paragraph.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// single emphasis — never flagged in consistent mode
+		{
+			name:     "single asterisk consistent",
+			content:  "This is *italic* text.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "single underscore consistent",
+			content:  "This is _italic_ text.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:    "single underscore asterisk-style violation",
+			content: "This is _italic_ text.\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+		{
+			name:    "single asterisk underscore-style violation",
+			content: "This is *italic* text.\n",
+			style:   "underscore",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+			},
+		},
+
+		// strong emphasis
+		{
+			name:     "strong asterisk consistent no violation",
+			content:  "This is **bold** text.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:    "strong underscore asterisk-style violation",
+			content: "This is __bold__ text.\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// all-asterisk documents
+		{
+			name:     "all asterisk consistent no violation",
+			content:  "This is *italic* text.\n\nThis is **bold** text.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "all asterisk asterisk-style no violation",
+			content:  "This is *italic* text.\n\nThis is **bold** text.\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:    "all asterisk underscore-style two violations",
+			content: "This is *italic* text.\n\nThis is **bold** text.\n",
+			style:   "underscore",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+			},
+		},
+
+		// all-underscore documents
+		{
+			name:     "all underscore consistent no violation",
+			content:  "This is _italic_ text.\n\nThis is __bold__ text.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "all underscore underscore-style no violation",
+			content:  "This is _italic_ text.\n\nThis is __bold__ text.\n",
+			style:    "underscore",
+			wantErrs: nil,
+		},
+		{
+			name:    "all underscore asterisk-style two violations",
+			content: "This is _italic_ text.\n\nThis is __bold__ text.\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// mixed — consistent mode
+		{
+			name:    "asterisk-first consistent: underscore flagged",
+			content: "This is *italic* text.\n\nThis is _also italic_ text.\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+		{
+			name:    "underscore-first consistent: asterisk flagged",
+			content: "This is _italic_ text.\n\nThis is *also italic* text.\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+			},
+		},
+		{
+			name:    "consistent multiple violations",
+			content: "This is *italic* text.\n\nThis is _also italic_ text.\n\nThis is __bold__ text.\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+				{File: "test.md", Line: 5, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// mid-word underscores must not be flagged
+		{
+			name:     "snake_case not treated as emphasis",
+			content:  "Use snake_case naming.\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "multiple underscores in identifier not flagged",
+			content:  "The foo_bar_baz variable.\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:    "leading underscore emphasis not mid-word",
+			content: "_italic_ and snake_case.\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// content inside code block must not be rechecked
+		{
+			name:     "emphasis inside fenced code block not flagged",
+			content:  "```\n_italic_\n```\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "emphasis inside inline code not flagged",
+			content:  "Use `_italic_` syntax.\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+
+		// escaped markers
+		{
+			name:     "escaped asterisk not treated as emphasis",
+			content:  "Use \\*escaped\\* asterisk.\n",
+			style:    "underscore",
+			wantErrs: nil,
+		},
+		{
+			name:     "escaped underscore not treated as emphasis",
+			content:  "Use \\_escaped\\_ underscore.\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+
+		// triple+ runs not treated as emphasis
+		{
+			name:     "triple asterisk run not treated as emphasis opener",
+			content:  "***not emphasis***\n",
+			style:    "underscore",
+			wantErrs: nil,
+		},
+
+		// offset
+		{
+			name:    "offset shifts line numbers",
+			content: "This is *italic* text.\n\nThis is _also italic_ text.\n",
+			offset:  10,
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 13, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// invalid style falls back to consistent
+		{
+			name:    "unknown style falls back to consistent",
+			content: "This is *italic* text.\n\nThis is _also italic_ text.\n",
+			style:   "unknown",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckConsistentEmphasisStyle("test.md", lines, tt.offset, tt.style)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i] != tt.wantErrs[i] {
+					t.Errorf("error[%d]: got %+v, want %+v", i, got[i], tt.wantErrs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -204,6 +204,30 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			wantErrs: nil,
 		},
 
+		// closing delimiter followed by punctuation must not be double-counted
+		{
+			name:    "closing underscore before period not counted as second opener",
+			content: "This is _italic_. More text.\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+		{
+			name:    "closing asterisk before comma not counted as second opener",
+			content: "Use *bold*, not plain.\n",
+			style:   "underscore",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+			},
+		},
+		{
+			name:     "unclosed emphasis not counted",
+			content:  "This has *no closer.\n",
+			style:    "underscore",
+			wantErrs: nil,
+		},
+
 		// offset
 		{
 			name:    "offset shifts line numbers",


### PR DESCRIPTION
## Summary

- Implements `consistent-emphasis-style` (MD049): flags `*text*` vs `_text_` inconsistency across a document
- Three modes: `consistent` (default), `asterisk`, `underscore`
- Mid-word underscores (`snake_case`) are correctly ignored
- Content inside fenced code blocks and inline code spans is skipped
- Allocation-free scanner (`checkEmphasisLine` writes directly to the caller's error slice)

## Benchmark

| metric | baseline (main) | candidate | delta |
|---|---|---|---|
| time/op | 7.555 ms | 7.933 ms | +5.00% ✅ |
| memory/op | 1.654 MiB | 1.654 MiB | +0.03% ✅ |
| allocs/op | 4.510 k | 4.510 k | -0.00% ✅ |

The +5% time delta is the expected one-time shift from activating the new rule scan path. Allocations are zero-regression thanks to the allocation-free `checkEmphasisLine` design.

## Test plan

- [x] Unit tests: `TestCheckConsistentEmphasisStyle` — all 3 styles, mid-word underscore, code block skip, inline code skip, escaped chars, triple-run skip, offset, fallback
- [x] Linter integration: `TestRun_ConsistentEmphasisStyle_Violation`, `TestRun_ConsistentEmphasisStyle_NoOptionFallsBackToConsistent`
- [x] E2E: `ConsistentEmphasisStyleValid`, `ConsistentEmphasisStyleViolation`, `DirectoryRecursion` (53 files)
- [x] Coverage: 100% across all packages
- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make static-lint` (gofmt, golangci-lint) passes

Closes #200. Part of #76.