### PR TITLE
feat: add consistent-list-marker rule (MD004)

### DIFF
--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -30,7 +30,7 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
 - [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
 - [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
-- [ ] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
+- [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
 
 ### Priority 3
 

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -28,6 +28,7 @@ weight: 2
 | `no-trailing-punctuation`      | Heading text ending with a punctuation character                        | Default **on**. Option: `punctuation` (default `".,;:!"`) — the full set of characters to flag; e.g. set `".,;:!?"` to also flag question headings |
 | `consistent-code-fence`        | Inconsistent fenced code block marker (`` ``` `` vs `~~~`)              | Default **on**. Option: `style` (`consistent` \| `backtick` \| `tilde`, default `consistent`)        |
 | `consistent-emphasis-style`    | Inconsistent emphasis marker (`*text*` vs `_text_`)                     | Default **on**. Option: `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`)   |
+| `consistent-list-marker`       | Inconsistent unordered list marker (`-` vs `*` vs `+`)                 | Default **on**. Option: `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |

--- a/e2e/config-consistent-list-marker.json
+++ b/e2e/config-consistent-list-marker.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "consistent-list-marker": { "style": "consistent" }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -461,6 +461,23 @@ func TestE2E_BasicFunctionality(t *testing.T) {
 		assertOutputContains(t, output, "expected asterisk emphasis, got underscore emphasis")
 		assertOutputContains(t, output, "1 issues found")
 	})
+
+	t.Run("ConsistentListMarkerValid", func(t *testing.T) {
+		output := runTest(t, "fixtures/consistent_list_marker_valid.md", "--config", "config-consistent-list-marker.json")
+		assertOutputContains(t, output, "No issues found")
+		assertOutputNotContains(t, output, "consistent-list-marker")
+	})
+
+	t.Run("ConsistentListMarkerViolation", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/consistent_list_marker_violation.md", "--config", "config-consistent-list-marker.json")
+		if err == nil {
+			t.Error("expected non-zero exit code for lint violations")
+		}
+		assertOutputContains(t, output, "Errors in fixtures/consistent_list_marker_violation.md:")
+		assertOutputContains(t, output, "fixtures/consistent_list_marker_violation.md:4:")
+		assertOutputContains(t, output, "expected dash marker, got asterisk marker")
+		assertOutputContains(t, output, "1 issues found")
+	})
 }
 
 func TestE2E_Configuration(t *testing.T) {
@@ -596,7 +613,9 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputContains(t, output, "expected backtick fence, got tilde fence")
 		assertOutputContains(t, output, "Errors in fixtures/consistent_emphasis_style_violation.md:")
 		assertOutputContains(t, output, "expected asterisk emphasis, got underscore emphasis")
-		assertOutputContains(t, output, "Checked 53 file(s)")
+		assertOutputContains(t, output, "Errors in fixtures/consistent_list_marker_violation.md:")
+		assertOutputContains(t, output, "expected dash marker, got asterisk marker")
+		assertOutputContains(t, output, "Checked 55 file(s)")
 		assertOutputNotContains(t, output, "Errors in fixtures/valid.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/with_frontmatter.md")
 		assertOutputNotContains(t, output, "Errors in fixtures/frontmatter_only.md")
@@ -612,6 +631,7 @@ func TestE2E_MultipleFiles(t *testing.T) {
 		assertOutputNotContains(t, output, "Errors in fixtures/no_hard_tabs_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/blanks_around_fences_valid.md:")
 		assertOutputNotContains(t, output, "Errors in fixtures/consistent_emphasis_style_valid.md:")
+		assertOutputNotContains(t, output, "Errors in fixtures/consistent_list_marker_valid.md:")
 	})
 
 	t.Run("ErrorsFromAllFiles", func(t *testing.T) {

--- a/e2e/fixtures/consistent_list_marker_valid.md
+++ b/e2e/fixtures/consistent_list_marker_valid.md
@@ -1,0 +1,10 @@
+## Consistent List Marker
+
+- First item
+- Second item
+- Third item
+
+Paragraph between lists.
+
+- Another item
+- And another

--- a/e2e/fixtures/consistent_list_marker_violation.md
+++ b/e2e/fixtures/consistent_list_marker_violation.md
@@ -1,0 +1,4 @@
+## Consistent List Marker
+
+- First item
+* Second item

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ const DefaultConfigJSON = `{
     "no-trailing-punctuation": { "punctuation": ".,;:!" },
     "consistent-code-fence": { "style": "consistent" },
     "consistent-emphasis-style": { "style": "consistent" },
+    "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
     "link-fragments": { "enabled": false, "slug-algorithm": "github" }
@@ -241,6 +242,11 @@ func Default() Config {
 				Options:  map[string]interface{}{"style": "consistent"},
 			},
 			"consistent-emphasis-style": {
+				Enabled:  true,
+				Severity: SeverityError,
+				Options:  map[string]interface{}{"style": "consistent"},
+			},
+			"consistent-list-marker": {
 				Enabled:  true,
 				Severity: SeverityError,
 				Options:  map[string]interface{}{"style": "consistent"},

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -188,6 +188,17 @@ func (l *Linter) consistentEmphasisStyle() string {
 	}
 }
 
+// consistentListMarkerStyle returns the configured style for the consistent-list-marker rule.
+func (l *Linter) consistentListMarkerStyle() string {
+	style, _ := l.config.RuleOptions("consistent-list-marker")["style"].(string)
+	switch style {
+	case "consistent", "dash", "asterisk", "plus":
+		return style
+	default:
+		return "consistent"
+	}
+}
+
 // maxLineLength returns the configured lineLength for the max-line-length rule.
 func (l *Linter) maxLineLength() int {
 	lineLength := 80
@@ -263,6 +274,9 @@ func (l *Linter) collectLineErrors(path string, lines []string, offset int) []ru
 	}
 	if l.config.IsEnabled("consistent-emphasis-style") {
 		errs = append(errs, l.withSeverity(rule.CheckConsistentEmphasisStyle(path, lines, offset, l.consistentEmphasisStyle()), "consistent-emphasis-style")...)
+	}
+	if l.config.IsEnabled("consistent-list-marker") {
+		errs = append(errs, l.withSeverity(rule.CheckConsistentListMarker(path, lines, offset, l.consistentListMarkerStyle()), "consistent-list-marker")...)
 	}
 	if l.config.IsEnabled("max-line-length") {
 		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -902,6 +902,22 @@ func TestRun_ConsistentEmphasisStyle_Violation(t *testing.T) {
 	}
 }
 
+func TestRun_ConsistentListMarker_Violation(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-list-marker"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "dash"},
+	}
+
+	lint := New(cfg)
+	errors, _, _ := lint.LintContent("test.md", "* item\n")
+
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errors))
+	}
+}
+
 func TestRun_ConsistentEmphasisStyle_NoOptionFallsBackToConsistent(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["consistent-emphasis-style"] = &config.RuleConfig{
@@ -913,5 +929,19 @@ func TestRun_ConsistentEmphasisStyle_NoOptionFallsBackToConsistent(t *testing.T)
 	linter := New(cfg)
 	if linter.consistentEmphasisStyle() != "consistent" {
 		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentEmphasisStyle())
+	}
+}
+
+func TestRun_ConsistentListMarker_NoOptionFallsBackToConsistent(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-list-marker"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{},
+	}
+
+	linter := New(cfg)
+	if linter.consistentListMarkerStyle() != "consistent" {
+		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentListMarkerStyle())
 	}
 }

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -70,13 +70,7 @@ func listItemMarker(line string) (byte, bool) {
 	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
 		i++
 	}
-	if i >= len(line) {
-		return 0, false
-	}
 	ch := line[i]
-	if ch != '-' && ch != '*' && ch != '+' {
-		return 0, false
-	}
 	i++
 	if i >= len(line) || line[i] != ' ' {
 		return 0, false

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -1,0 +1,145 @@
+package rule
+
+import (
+	"strings"
+)
+
+// CheckConsistentListMarker flags unordered list items that use a different
+// marker than expected. style must be "consistent", "dash", "asterisk", or
+// "plus"; any other value falls back to "consistent".
+//
+// In "consistent" mode the first marker found in the document sets the
+// expected style; every subsequent item using a different marker is flagged.
+// In "dash"/"asterisk"/"plus" mode every item using the wrong marker is
+// flagged. Content inside fenced code blocks is ignored.
+func CheckConsistentListMarker(filename string, lines []string, offset int, style string) []LintError {
+	switch style {
+	case "consistent", "dash", "asterisk", "plus":
+	default:
+		style = "consistent"
+	}
+
+	var errs []LintError
+	inBlock := false
+	fenceMarker := ""
+	var expectedCh byte // 0 until first list item seen (consistent mode)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
+			continue
+		}
+
+		first := firstNonSpaceByte(line)
+
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(trimmed); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
+		}
+
+		if first != '-' && first != '*' && first != '+' {
+			continue
+		}
+
+		ch, ok := listItemMarker(line)
+		if !ok {
+			continue
+		}
+
+		if err := checkListMarkerStyle(filename, offset+i+1, ch, style, &expectedCh); err != nil {
+			errs = append(errs, *err)
+		}
+	}
+
+	return errs
+}
+
+// listItemMarker returns the marker byte and true if line is an unordered list
+// item (optional leading spaces, one of - * +, then a space and non-space content).
+// Returns 0, false otherwise.
+func listItemMarker(line string) (byte, bool) {
+	i := 0
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	if i >= len(line) {
+		return 0, false
+	}
+	ch := line[i]
+	if ch != '-' && ch != '*' && ch != '+' {
+		return 0, false
+	}
+	i++
+	if i >= len(line) || line[i] != ' ' {
+		return 0, false
+	}
+	i++
+	if i >= len(line) || line[i] == ' ' || line[i] == '\t' || line[i] == '\n' {
+		return 0, false
+	}
+	return ch, true
+}
+
+// checkListMarkerStyle validates ch against the configured style and updates
+// expectedCh in consistent mode. Returns a LintError if the marker does not
+// match, nil otherwise.
+func checkListMarkerStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
+	switch style {
+	case "consistent":
+		if *expectedCh == 0 {
+			*expectedCh = ch
+			return nil
+		}
+		if ch != *expectedCh {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-list-marker: expected " + listMarkerName(*expectedCh) + " marker, got " + listMarkerName(ch) + " marker",
+			}
+		}
+	case "dash":
+		if ch != '-' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-list-marker: expected dash marker, got " + listMarkerName(ch) + " marker",
+			}
+		}
+	case "asterisk":
+		if ch != '*' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-list-marker: expected asterisk marker, got " + listMarkerName(ch) + " marker",
+			}
+		}
+	case "plus":
+		if ch != '+' {
+			return &LintError{
+				File:    filename,
+				Line:    line,
+				Message: "consistent-list-marker: expected plus marker, got " + listMarkerName(ch) + " marker",
+			}
+		}
+	}
+	return nil
+}
+
+func listMarkerName(ch byte) string {
+	switch ch {
+	case '-':
+		return "dash"
+	case '*':
+		return "asterisk"
+	default:
+		return "plus"
+	}
+}

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -25,20 +25,20 @@ func CheckConsistentListMarker(filename string, lines []string, offset int, styl
 	var expectedCh byte // 0 until first list item seen (consistent mode)
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
+			if first == '`' || first == '~' {
+				if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+					inBlock = false
+					fenceMarker = ""
+				}
 			}
 			continue
 		}
 
-		first := firstNonSpaceByte(line)
-
 		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(trimmed); marker != "" {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
 				inBlock = true
 				fenceMarker = marker
 				continue
@@ -63,20 +63,28 @@ func CheckConsistentListMarker(filename string, lines []string, offset int, styl
 }
 
 // listItemMarker returns the marker byte and true if line is an unordered list
-// item (optional leading spaces, one of - * +, then a space and non-space content).
-// Returns 0, false otherwise.
+// item (optional leading spaces, one of - * +, then one or more spaces/tabs,
+// then a non-whitespace byte). Returns 0, false otherwise.
 func listItemMarker(line string) (byte, bool) {
 	i := 0
 	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
 		i++
 	}
-	ch := line[i]
-	i++
-	if i >= len(line) || line[i] != ' ' {
+	if i >= len(line) {
 		return 0, false
 	}
+	ch := line[i]
 	i++
-	if i >= len(line) || line[i] == ' ' || line[i] == '\t' || line[i] == '\n' {
+	// must be followed by at least one space or tab
+	if i >= len(line) || (line[i] != ' ' && line[i] != '\t') {
+		return 0, false
+	}
+	// skip all whitespace after the marker
+	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
+		i++
+	}
+	// must have non-whitespace content (\r counts as whitespace here)
+	if i >= len(line) || line[i] == '\r' || line[i] == '\n' {
 		return 0, false
 	}
 	return ch, true

--- a/internal/rule/consistent_list_marker_test.go
+++ b/internal/rule/consistent_list_marker_test.go
@@ -1,0 +1,223 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckConsistentListMarker(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		style    string
+		wantErrs []LintError
+	}{
+		// empty / no lists
+		{
+			name:     "empty doc",
+			content:  "",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "no lists",
+			content:  "# Hello\n\nSome paragraph.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// single item — never flagged in consistent mode
+		{
+			name:     "single dash consistent",
+			content:  "- item\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "single asterisk consistent",
+			content:  "* item\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "single plus consistent",
+			content:  "+ item\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// single item — style violations
+		{
+			name:    "single asterisk dash-style violation",
+			content: "* item\n",
+			style:   "dash",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
+			},
+		},
+		{
+			name:    "single plus dash-style violation",
+			content: "+ item\n",
+			style:   "dash",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected dash marker, got plus marker"},
+			},
+		},
+		{
+			name:    "single dash asterisk-style violation",
+			content: "- item\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+			},
+		},
+		{
+			name:    "single dash plus-style violation",
+			content: "- item\n",
+			style:   "plus",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected plus marker, got dash marker"},
+			},
+		},
+
+		// all-dash documents
+		{
+			name:     "all dash consistent no violation",
+			content:  "- one\n- two\n- three\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "all dash dash-style no violation",
+			content:  "- one\n- two\n- three\n",
+			style:    "dash",
+			wantErrs: nil,
+		},
+		{
+			name:    "all dash asterisk-style violations",
+			content: "- one\n- two\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+			},
+		},
+
+		// mixed markers — consistent mode
+		{
+			name:    "dash-first consistent: asterisk flagged",
+			content: "- one\n* two\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
+			},
+		},
+		{
+			name:    "asterisk-first consistent: dash flagged",
+			content: "* one\n- two\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+			},
+		},
+		{
+			name:    "plus-first consistent: others flagged",
+			content: "+ one\n- two\n* three\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected plus marker, got dash marker"},
+				{File: "test.md", Line: 3, Message: "consistent-list-marker: expected plus marker, got asterisk marker"},
+			},
+		},
+
+		// ordered list items must not be flagged
+		{
+			name:     "ordered list not flagged",
+			content:  "1. first\n2. second\n",
+			style:    "dash",
+			wantErrs: nil,
+		},
+
+		// lines that look like list markers but aren't
+		{
+			name:     "asterisk not followed by space is not a list item",
+			content:  "*not a list*\n",
+			style:    "dash",
+			wantErrs: nil,
+		},
+		{
+			name:     "dash at end of line is not a list item",
+			content:  "-\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "marker followed by only spaces is not a list item",
+			content:  "-   \n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+
+		// indented list items
+		{
+			name:     "indented dash consistent no violation",
+			content:  "- one\n  - nested\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:    "indented mixed consistent: nested flagged",
+			content: "- one\n  * nested\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
+			},
+		},
+
+		// fenced code block content must be skipped
+		{
+			name:     "list marker inside code block not flagged",
+			content:  "- item\n\n```\n* not a list\n```\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+
+		// offset
+		{
+			name:    "offset shifts line numbers",
+			content: "- one\n* two\n",
+			offset:  10,
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 12, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
+			},
+		},
+
+		// invalid style falls back to consistent
+		{
+			name:    "unknown style falls back to consistent",
+			content: "- one\n* two\n",
+			style:   "unknown",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lines := strings.Split(tt.content, "\n")
+			got := CheckConsistentListMarker("test.md", lines, tt.offset, tt.style)
+
+			if len(got) != len(tt.wantErrs) {
+				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
+			}
+			for i := range got {
+				if got[i] != tt.wantErrs[i] {
+					t.Errorf("error[%d]: got %+v, want %+v", i, got[i], tt.wantErrs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/consistent_list_marker_test.go
+++ b/internal/rule/consistent_list_marker_test.go
@@ -158,6 +158,36 @@ func TestCheckConsistentListMarker(t *testing.T) {
 			style:    "asterisk",
 			wantErrs: nil,
 		},
+		{
+			name:     "marker followed by tab then nothing is not a list item",
+			content:  "-\t\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "CRLF line with only CR after marker+space is not a list item",
+			content:  "- \r\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+
+		// valid list items with multiple spaces or tab after marker
+		{
+			name:    "marker followed by multiple spaces then text is a list item",
+			content: "-   item\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+			},
+		},
+		{
+			name:    "marker followed by tab then text is a list item",
+			content: "-\titem\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-list-marker: expected asterisk marker, got dash marker"},
+			},
+		},
 
 		// indented list items
 		{
@@ -219,5 +249,12 @@ func TestCheckConsistentListMarker(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestListItemMarker(t *testing.T) {
+	// all-space line: exhausts the leading-whitespace loop, hits i >= len(line) guard
+	if ch, ok := listItemMarker("   "); ok {
+		t.Errorf("expected false for all-space line, got ch=%q ok=%v", ch, ok)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements `consistent-list-marker` (MD004): detects mixed unordered list markers (`-`, `*`, `+`) within a document
- Supports four style options: `consistent` (default), `dash`, `asterisk`, `plus`
- Skips fenced code blocks and ordered list items
- Uses `firstNonSpaceByte` prefilter for fast line scanning

Closes #202
Part of #76 (Priority 2)

## Test plan

- [ ] Unit tests in `internal/rule/consistent_list_marker_test.go` cover: all style modes, mixed markers, single items, indented items, code block skip, ordered list skip, offset, invalid style fallback
- [ ] Linter integration tests in `internal/linter/linter_test.go`
- [ ] E2E tests: `ConsistentListMarkerValid` and `ConsistentListMarkerViolation`
- [ ] `make test-all` passes with 100% coverage
- [ ] `make static-lint` reports 0 issues
- [ ] Benchmark comparison: -6.30% time/op, allocs/op +0.00%