### PR TITLE
bench(PR-16): no-hard-tabs — firstNonSpaceByte prefilter + IndexByte

### DIFF
--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -79,6 +79,20 @@ func writeSubsection(sb *strings.Builder, i int) {
 	sb.WriteString("More detailed information goes here.\n\n")
 }
 
+// writeHardTabContent exercises no-hard-tabs: a fenced code block with
+// tab-indented lines (excluded from the rule) forces the code-block tracking
+// path, and a line with a tab inside inline code forces the stripInlineCode
+// path — both without producing any violation.
+func writeHardTabContent(sb *strings.Builder) {
+	sb.WriteString("Example Makefile recipe:\n\n")
+	sb.WriteString("```makefile\n")
+	sb.WriteString("build:\n")
+	sb.WriteString("\tgo build ./...\n")
+	sb.WriteString("\tgo test ./...\n")
+	sb.WriteString("```\n\n")
+	sb.WriteString("Use the `\t` character for Makefile recipes.\n\n")
+}
+
 // generateComplexMarkdown generates a realistic markdown file with mixed content.
 func generateComplexMarkdown(sections int) string {
 	var sb strings.Builder
@@ -100,6 +114,10 @@ func generateComplexMarkdown(sections int) string {
 
 		if i%4 == 0 {
 			writeImage(&sb, i)
+		}
+
+		if i%8 == 0 {
+			writeHardTabContent(&sb)
 		}
 
 		writeSubsection(&sb, i)

--- a/internal/rule/no_hard_tabs.go
+++ b/internal/rule/no_hard_tabs.go
@@ -13,28 +13,32 @@ func CheckNoHardTabs(filename string, lines []string, offset int) []LintError {
 	fenceMarker := ""
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
+			if first == '`' || first == '~' {
+				if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+					inBlock = false
+					fenceMarker = ""
+				}
 			}
 			continue
 		}
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
 		}
 
-		if !strings.ContainsRune(line, '\t') {
+		if strings.IndexByte(line, '\t') < 0 {
 			continue
 		}
 
 		scanned := line
-		if strings.ContainsRune(line, '`') {
+		if strings.IndexByte(line, '`') >= 0 {
 			scanned = stripInlineCode(line)
 		}
 


### PR DESCRIPTION
## Summary

Exercises `no-hard-tabs`'s two main scan paths via a new `writeHardTabContent` writer (called every 8 sections):

- A fenced code block with tab-indented lines forces the code-block tracking path (lines with first byte `\t` skip the fence-check `TrimSpace` call once the optimization is in place)
- A line with a tab inside inline code forces the `stripInlineCode` path — both without producing any violation

Optimization in `CheckNoHardTabs`:

1. **`firstNonSpaceByte` prefilter for code-block tracking** (same pattern as PR-11–15): avoids unconditional `TrimSpace` on every line — `TrimSpace` is now called only when the first non-space byte is `` ` `` or `~` (potential fence)
2. **`strings.IndexByte` instead of `strings.ContainsRune`** for single-byte ASCII searches (`\t` and `` ` ``): consistency with prior PRs

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 778 812 ns | 3 959 017 ns | +4.8% (content shift) |
| B/op | 782 695 B | 839 611 B | +7.3% (content shift) |
| allocs/op | 2 023 | 2 149 | +6.2% (content shift) |

The regression is an expected content/activation shift: `writeHardTabContent` adds ~125 fenced code blocks and inline-tab lines per 1 000-section run, increasing total processed line count. The `firstNonSpaceByte` prefilter offsets what would otherwise be a larger regression.

Note: CI (AMD EPYC) geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146