### PR TITLE
feat: validate rule option values at startup (closes #203)

### DIFF
--- a/cmd/bench_content_test.go
+++ b/cmd/bench_content_test.go
@@ -12,7 +12,10 @@ import (
 func TestBenchmarkContentIsViolationFree(t *testing.T) {
 	content := generateComplexMarkdown(1000)
 	cfg := benchmarkConfig()
-	lint := linter.New(cfg)
+	lint, err := linter.New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	errs, _, _ := lint.LintContent("benchmark.md", content)
 	if len(errs) != 0 {

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -115,7 +115,10 @@ func generateComplexMarkdown(sections int) string {
 func BenchmarkFullLinting(b *testing.B) {
 	content := generateComplexMarkdown(1000)
 	cfg := benchmarkConfig()
-	lint := linter.New(cfg)
+	lint, err := linter.New(cfg)
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -126,7 +129,10 @@ func BenchmarkFullLinting(b *testing.B) {
 func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
 	content := generateComplexMarkdown(5000)
 	cfg := benchmarkConfig()
-	lint := linter.New(cfg)
+	lint, err := linter.New(cfg)
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -100,8 +100,22 @@ In the object form, `enabled` can be omitted — it defaults to `true`. These ar
 | `blanks-around-fences` | `error` | — |
 | `no-hard-tabs` | `error` | — |
 | `no-trailing-punctuation` | `error` | `punctuation` (string, default `".,;:!"`) |
+| `consistent-code-fence` | `error` | `style` (`consistent` \| `backtick` \| `tilde`, default `consistent`) |
+| `consistent-emphasis-style` | `error` | `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`) |
+| `consistent-list-marker` | `error` | `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length` | disabled | `lineLength` (int, default `80`) |
 | `external-link` | disabled | `timeoutSeconds` (int, default `5`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
+| `link-fragments` | disabled | `slug-algorithm` (string, default `github`), `slug-params` (object, for `custom` algorithm) |
+
+## Option validation
+
+Rule options are validated at startup. An invalid option value — such as an unrecognised `style` — causes gomarklint to exit with a descriptive error before any linting runs:
+
+```text
+gomarklint: invalid value "backticks" for consistent-code-fence.style (valid values: consistent, backtick, tilde)
+```
+
+This applies even when the rule is disabled, so misconfigured options are caught early.
 
 ## Notes
 

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -41,6 +41,24 @@ Rule severity must be one of: `true`, `false`, `"error"`, `"warning"`, or `"off"
 
 ---
 
+### `invalid value "x" for rule.style`
+
+A `style` option was set to an unrecognised value. gomarklint validates rule options at startup and exits immediately — it does not silently fall back to a default.
+
+Valid values per rule:
+
+| Rule | Valid `style` values |
+|---|---|
+| `consistent-code-fence` | `consistent`, `backtick`, `tilde` |
+| `consistent-emphasis-style` | `consistent`, `asterisk`, `underscore` |
+| `consistent-list-marker` | `consistent`, `dash`, `asterisk`, `plus` |
+
+A common mistake is using a plural form (`"backticks"`, `"tildes"`) or a synonym (`"bullet"`). Check the exact spelling shown above.
+
+→ [Rules](../rules/)
+
+---
+
 ### `failed to access config file`
 
 The file at the path passed to `--config` exists but cannot be accessed (for example, a permission error on the parent directory). If the file does not exist, `LoadOrDefault` falls back to the default configuration without an error. Check the file permissions and verify the file is committed if running in CI.

--- a/e2e/config-invalid-style-option.json
+++ b/e2e/config-invalid-style-option.json
@@ -1,0 +1,6 @@
+{
+  "default": false,
+  "rules": {
+    "consistent-code-fence": { "style": "hoge" }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -664,6 +664,16 @@ func TestE2E_EdgeCases(t *testing.T) {
 		assertOutputContains(t, output, "failed to parse config file")
 	})
 
+	t.Run("InvalidRuleOptionValue", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-invalid-style-option.json")
+		if err == nil {
+			t.Errorf("expected error for invalid rule option value, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, `invalid value "hoge" for consistent-code-fence.style`)
+		assertOutputContains(t, output, "valid values: consistent, backtick, tilde")
+	})
+
 	t.Run("EmptyFile", func(t *testing.T) {
 		output := runTest(t, "fixtures/empty.md", "--config", ".gomarklint.json")
 		assertOutputContains(t, output, "Errors in fixtures/empty.md:")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -56,7 +56,10 @@ func Run(w io.Writer, opts Options) error {
 
 	files := file.ExpandPaths(args, cfg.Ignore)
 
-	lint := linter.New(cfg)
+	lint, err := linter.New(cfg)
+	if err != nil {
+		return err
+	}
 	result := lint.Run(files)
 
 	if err := formatOutput(w, cfg, result, len(files)-len(result.FailedFiles), time.Since(start)); err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -76,6 +76,19 @@ func TestRun_InvalidConfigFile_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestRun_InvalidRuleOption_ReturnsError(t *testing.T) {
+	cfgFile := writeTempFile(t, "bad-option.json", `{"default":false,"rules":{"consistent-code-fence":{"style":"hoge"}}}`)
+
+	var buf bytes.Buffer
+	err := Run(&buf, Options{
+		ConfigPath: cfgFile,
+		Args:       []string{"somefile.md"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `invalid value "hoge" for consistent-code-fence.style`) {
+		t.Errorf("expected invalid rule option error, got: %v", err)
+	}
+}
+
 func TestRun_InvalidOutputFormat_ReturnsError(t *testing.T) {
 	cfgFile := writeTempFile(t, "bad-output.json", `{"default":true,"rules":{},"output":"xlsx"}`)
 

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -80,7 +80,7 @@ func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []str
 	}
 	val, ok := raw.(string)
 	if !ok {
-		return fmt.Errorf("gomarklint: invalid value %v for %s.%s (valid values: %s)", raw, ruleName, optKey, strings.Join(valid, ", "))
+		return fmt.Errorf("gomarklint: invalid value for %s.%s: expected string, got %T (%#v) (valid values: %s)", ruleName, optKey, raw, raw, strings.Join(valid, ", "))
 	}
 	if val == "" {
 		return nil

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -32,7 +32,18 @@ type Result struct {
 }
 
 // New creates a new Linter with the given configuration.
-func New(cfg config.Config) *Linter {
+// Returns an error if any rule option value is invalid.
+func New(cfg config.Config) (*Linter, error) {
+	if err := validateStyleOption(cfg, "consistent-code-fence", "style", []string{"consistent", "backtick", "tilde"}); err != nil {
+		return nil, err
+	}
+	if err := validateStyleOption(cfg, "consistent-emphasis-style", "style", []string{"consistent", "asterisk", "underscore"}); err != nil {
+		return nil, err
+	}
+	if err := validateStyleOption(cfg, "consistent-list-marker", "style", []string{"consistent", "dash", "asterisk", "plus"}); err != nil {
+		return nil, err
+	}
+
 	compiledPatterns := []*regexp.Regexp{}
 	if cfg.IsEnabled("external-link") {
 		opts := cfg.RuleOptions("external-link")
@@ -56,7 +67,30 @@ func New(cfg config.Config) *Linter {
 		config:           cfg,
 		compiledPatterns: compiledPatterns,
 		urlCache:         &sync.Map{},
+	}, nil
+}
+
+// validateStyleOption checks that the named option for a rule, if present and non-empty,
+// is one of the valid values. Returns a descriptive error if not.
+func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []string) error {
+	opts := cfg.RuleOptions(ruleName)
+	raw, exists := opts[optKey]
+	if !exists {
+		return nil
 	}
+	val, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("gomarklint: invalid value %v for %s.%s (valid values: %s)", raw, ruleName, optKey, strings.Join(valid, ", "))
+	}
+	if val == "" {
+		return nil
+	}
+	for _, v := range valid {
+		if val == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("gomarklint: invalid value %q for %s.%s (valid values: %s)", val, ruleName, optKey, strings.Join(valid, ", "))
 }
 
 // Run performs linting on the given file paths concurrently.
@@ -169,34 +203,28 @@ func (l *Linter) noTrailingPunctuation() string {
 // consistentCodeFenceStyle returns the configured style for the consistent-code-fence rule.
 func (l *Linter) consistentCodeFenceStyle() string {
 	style, _ := l.config.RuleOptions("consistent-code-fence")["style"].(string)
-	switch style {
-	case "consistent", "backtick", "tilde":
-		return style
-	default:
+	if style == "" {
 		return "consistent"
 	}
+	return style
 }
 
 // consistentEmphasisStyle returns the configured style for the consistent-emphasis-style rule.
 func (l *Linter) consistentEmphasisStyle() string {
 	style, _ := l.config.RuleOptions("consistent-emphasis-style")["style"].(string)
-	switch style {
-	case "consistent", "asterisk", "underscore":
-		return style
-	default:
+	if style == "" {
 		return "consistent"
 	}
+	return style
 }
 
 // consistentListMarkerStyle returns the configured style for the consistent-list-marker rule.
 func (l *Linter) consistentListMarkerStyle() string {
 	style, _ := l.config.RuleOptions("consistent-list-marker")["style"].(string)
-	switch style {
-	case "consistent", "dash", "asterisk", "plus":
-		return style
-	default:
+	if style == "" {
 		return "consistent"
 	}
+	return style
 }
 
 // maxLineLength returns the configured lineLength for the max-line-length rule.

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/shinagawa-web/gomarklint/v2/internal/config"
 )
 
+// mustNew calls New and fails the test if it returns an error.
+func mustNew(t *testing.T, cfg config.Config) *Linter {
+	t.Helper()
+	l, err := New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return l
+}
+
 // off returns a disabled RuleConfig.
 func off() *config.RuleConfig {
 	return &config.RuleConfig{Enabled: false, Severity: config.SeverityOff, Options: map[string]interface{}{}}
@@ -41,7 +51,7 @@ func TestNew(t *testing.T) {
 		},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if len(linter.compiledPatterns) != 1 {
 		t.Errorf("expected 1 compiled pattern, got %d", len(linter.compiledPatterns))
 	}
@@ -58,7 +68,7 @@ func TestNew_InvalidPattern(t *testing.T) {
 		},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if len(linter.compiledPatterns) != 0 {
 		t.Errorf("expected 0 compiled patterns (invalid pattern should be skipped), got %d", len(linter.compiledPatterns))
 	}
@@ -67,7 +77,7 @@ func TestNew_InvalidPattern(t *testing.T) {
 func TestRun_NoErrors(t *testing.T) {
 	cfg := allOff()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.md")
@@ -96,7 +106,7 @@ func TestRun_WithErrors(t *testing.T) {
 		Options:  map[string]interface{}{"minLevel": float64(2)},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.md")
@@ -117,7 +127,7 @@ func TestRun_WithErrors(t *testing.T) {
 func TestRun_MultipleFiles(t *testing.T) {
 	cfg := allOff()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	file1 := filepath.Join(tmpDir, "file1.md")
@@ -146,7 +156,7 @@ func TestRun_UnclosedCodeBlock(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["unclosed-code-block"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "unclosed.md")
@@ -165,7 +175,7 @@ func TestRun_FencedCodeLanguage(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["fenced-code-language"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "no-lang.md")
@@ -184,7 +194,7 @@ func TestRun_EmptyAltText(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["empty-alt-text"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "empty-alt.md")
@@ -201,7 +211,7 @@ func TestRun_EmptyAltText(t *testing.T) {
 
 func TestRun_FileReadError(t *testing.T) {
 	cfg := config.Default()
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	result := linter.Run([]string{"/non/existent/file.md"})
 
@@ -220,7 +230,7 @@ func TestRun_DuplicateHeadings(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["duplicate-heading"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "duplicate.md")
@@ -239,7 +249,7 @@ func TestRun_NoMultipleBlankLines(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-multiple-blank-lines"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "blank.md")
@@ -258,7 +268,7 @@ func TestRun_NoSetextHeadings(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-setext-headings"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "setext.md")
@@ -277,7 +287,7 @@ func TestRun_FinalBlankLine(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["final-blank-line"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "nofinal.md")
@@ -297,7 +307,7 @@ func TestRun_FinalBlankLine_FrontmatterOnly(t *testing.T) {
 	cfg.Rules["final-blank-line"] = on()
 	cfg.Rules["no-multiple-blank-lines"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "frontmatter_only.md")
@@ -323,7 +333,7 @@ func TestRun_LinkCheck(t *testing.T) {
 		},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "links.md")
@@ -350,7 +360,7 @@ func TestRun_LinkCheckWithSkipPattern(t *testing.T) {
 		},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "links.md")
@@ -369,7 +379,7 @@ func TestRun_LinkCheckWithSkipPattern(t *testing.T) {
 func TestRun_DuplicatePaths(t *testing.T) {
 	cfg := allOff()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.md")
@@ -390,7 +400,7 @@ func TestRun_DuplicatePaths(t *testing.T) {
 func TestLintContent_NoErrors(t *testing.T) {
 	cfg := allOff()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	errors, lineCount, linksChecked := linter.LintContent("test.md", "# Hello\n\nThis is a test.\n")
 
@@ -413,7 +423,7 @@ func TestLintContent_WithErrors(t *testing.T) {
 		Options:  map[string]interface{}{"minLevel": float64(2)},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	errors, lineCount, _ := linter.LintContent("test.md", "# Title\n\nContent\n")
 
@@ -429,7 +439,7 @@ func TestRun_SingleH1(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["single-h1"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "multi-h1.md")
@@ -448,7 +458,7 @@ func TestRun_BlanksAroundHeadings(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["blanks-around-headings"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "no-blanks.md")
@@ -467,7 +477,7 @@ func TestRun_NoBareURLs(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-bare-urls"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "bare-url.md")
@@ -486,7 +496,7 @@ func TestRun_NoEmptyLinks(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-empty-links"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "empty-link.md")
@@ -505,7 +515,7 @@ func TestRun_NoEmphasisAsHeading(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["no-emphasis-as-heading"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "emphasis-heading.md")
@@ -524,7 +534,7 @@ func TestRun_BlanksAroundLists(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["blanks-around-lists"] = on()
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "lists.md")
@@ -547,7 +557,7 @@ func TestRun_WarningSeverity(t *testing.T) {
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "setext.md")
@@ -581,7 +591,7 @@ func TestRun_DisableComment_BlockDisableAll(t *testing.T) {
 
 	content := "# Heading\n\n<!-- gomarklint-disable -->\nhttps://example.com\n<!-- gomarklint-enable -->\nhttps://example.com\n"
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", content)
 
 	if len(errors) != 1 {
@@ -599,7 +609,7 @@ func TestRun_DisableComment_BlockDisableNamedRule(t *testing.T) {
 
 	content := "<!-- gomarklint-disable no-bare-urls -->\nhttps://example.com\n[]()\n<!-- gomarklint-enable no-bare-urls -->\nhttps://example.com\n"
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", content)
 
 	// line 3 (empty link) should still be reported; line 2 (bare URL) should be suppressed
@@ -631,7 +641,7 @@ func TestRun_DisableComment_DisableLine(t *testing.T) {
 
 	content := "https://example.com <!-- gomarklint-disable-line no-bare-urls -->\nhttps://example.com\n"
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", content)
 
 	if len(errors) != 1 {
@@ -648,7 +658,7 @@ func TestRun_DisableComment_DisableNextLine(t *testing.T) {
 
 	content := "<!-- gomarklint-disable-next-line no-bare-urls -->\nhttps://example.com\nhttps://example.com\n"
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", content)
 
 	if len(errors) != 1 {
@@ -667,7 +677,7 @@ func TestRun_MaxLineLength_DefaultLimit(t *testing.T) {
 		Options:  map[string]interface{}{"lineLength": float64(80)},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "long.md")
@@ -691,7 +701,7 @@ func TestRun_MaxLineLength_CustomLimit(t *testing.T) {
 		Options:  map[string]interface{}{"lineLength": float64(120)},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "long.md")
@@ -720,7 +730,7 @@ func TestRun_MaxLineLength_NoOptionFallsBackToDefault(t *testing.T) {
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if linter.maxLineLength() != 80 {
 		t.Errorf("expected default maxLineLength 80, got %d", linter.maxLineLength())
 	}
@@ -732,7 +742,7 @@ func TestRun_DisableComment_NoDisableKeyword_NoOverhead(t *testing.T) {
 
 	content := "<!-- some comment -->\nhttps://example.com\n"
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", content)
 
 	if len(errors) != 1 {
@@ -762,7 +772,7 @@ func TestRun_LinkCheckWithAllowedStatuses(t *testing.T) {
 		},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "links.md")
@@ -786,7 +796,7 @@ func TestRun_NoTrailingPunctuation_Violation(t *testing.T) {
 		Options:  map[string]interface{}{"punctuation": config.DefaultNoTrailingPunctuation},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", "## Heading.\n")
 
 	if len(errors) != 1 {
@@ -802,7 +812,7 @@ func TestRun_NoTrailingPunctuation_NoOptionFallsBackToDefault(t *testing.T) {
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if linter.noTrailingPunctuation() != config.DefaultNoTrailingPunctuation {
 		t.Errorf("expected default punctuation %q, got %q", config.DefaultNoTrailingPunctuation, linter.noTrailingPunctuation())
 	}
@@ -816,7 +826,7 @@ func TestRun_LinkFragments_DetectsViolation(t *testing.T) {
 		Options:  map[string]interface{}{"slug-algorithm": "github"},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.md")
@@ -840,7 +850,7 @@ func TestRun_LinkFragments_ValidLink(t *testing.T) {
 		Options:  map[string]interface{}{"slug-algorithm": "github"},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.md")
@@ -864,7 +874,7 @@ func TestRun_ConsistentCodeFence_Violation(t *testing.T) {
 		Options:  map[string]interface{}{"style": "consistent"},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", "```go\ncode\n```\n\n~~~python\ncode\n~~~\n")
 
 	if len(errors) != 1 {
@@ -880,7 +890,7 @@ func TestRun_ConsistentCodeFence_NoOptionFallsBackToConsistent(t *testing.T) {
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if linter.consistentCodeFenceStyle() != "consistent" {
 		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentCodeFenceStyle())
 	}
@@ -894,7 +904,7 @@ func TestRun_ConsistentEmphasisStyle_Violation(t *testing.T) {
 		Options:  map[string]interface{}{"style": "asterisk"},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", "This is _italic_ text.\n")
 
 	if len(errors) != 1 {
@@ -910,7 +920,7 @@ func TestRun_ConsistentListMarker_Violation(t *testing.T) {
 		Options:  map[string]interface{}{"style": "dash"},
 	}
 
-	lint := New(cfg)
+	lint := mustNew(t, cfg)
 	errors, _, _ := lint.LintContent("test.md", "* item\n")
 
 	if len(errors) != 1 {
@@ -926,7 +936,7 @@ func TestRun_ConsistentEmphasisStyle_NoOptionFallsBackToConsistent(t *testing.T)
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if linter.consistentEmphasisStyle() != "consistent" {
 		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentEmphasisStyle())
 	}
@@ -940,8 +950,90 @@ func TestRun_ConsistentListMarker_NoOptionFallsBackToConsistent(t *testing.T) {
 		Options:  map[string]interface{}{},
 	}
 
-	linter := New(cfg)
+	linter := mustNew(t, cfg)
 	if linter.consistentListMarkerStyle() != "consistent" {
 		t.Errorf("expected fallback style %q, got %q", "consistent", linter.consistentListMarkerStyle())
+	}
+}
+
+func TestNew_InvalidStyleOption_ConsistentCodeFence(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "hoge"},
+	}
+
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid style, got nil")
+	}
+	want := `gomarklint: invalid value "hoge" for consistent-code-fence.style (valid values: consistent, backtick, tilde)`
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\ngot:  %s\nwant: %s", err.Error(), want)
+	}
+}
+
+func TestNew_InvalidStyleOption_ConsistentEmphasisStyle(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-emphasis-style"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "bold"},
+	}
+
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid style, got nil")
+	}
+	want := `gomarklint: invalid value "bold" for consistent-emphasis-style.style (valid values: consistent, asterisk, underscore)`
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\ngot:  %s\nwant: %s", err.Error(), want)
+	}
+}
+
+func TestNew_InvalidStyleOption_ConsistentListMarker(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-list-marker"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "bullet"},
+	}
+
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid style, got nil")
+	}
+	want := `gomarklint: invalid value "bullet" for consistent-list-marker.style (valid values: consistent, dash, asterisk, plus)`
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\ngot:  %s\nwant: %s", err.Error(), want)
+	}
+}
+
+func TestNew_InvalidStyleOption_NonStringValue(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": 123},
+	}
+
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-string style value, got nil")
+	}
+}
+
+func TestNew_InvalidStyleOption_DisabledRuleStillValidated(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  false,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": "hoge"},
+	}
+
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid style even when rule is disabled, got nil")
 	}
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1024,6 +1024,20 @@ func TestNew_InvalidStyleOption_NonStringValue(t *testing.T) {
 	}
 }
 
+func TestNew_EmptyStringStyleOption_TreatedAsDefault(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"style": ""},
+	}
+
+	_, err := New(cfg)
+	if err != nil {
+		t.Fatalf("expected no error for empty style string, got: %v", err)
+	}
+}
+
 func TestNew_InvalidStyleOption_DisabledRuleStillValidated(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["consistent-code-fence"] = &config.RuleConfig{

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -5,19 +5,12 @@ import (
 )
 
 // CheckConsistentCodeFence flags fenced code blocks that use a different fence
-// character than expected. style must be "consistent", "backtick", or "tilde";
-// any other value falls back to "consistent".
+// character than expected. style must be "consistent", "backtick", or "tilde".
 //
 // In "consistent" mode the first fence character found in the document sets the
 // expected style; every subsequent opener that differs is flagged.
 // In "backtick"/"tilde" mode every opener using the wrong character is flagged.
 func CheckConsistentCodeFence(filename string, lines []string, offset int, style string) []LintError {
-	switch style {
-	case "consistent", "backtick", "tilde":
-	default:
-		style = "consistent"
-	}
-
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -168,16 +168,6 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			},
 		},
 
-		// invalid style falls back to consistent
-		{
-			name:    "unknown style falls back to consistent",
-			content: "```go\ncode\n```\n\n~~~python\ncode\n~~~\n",
-			style:   "unknown",
-			wantErrs: []LintError{
-				{File: "test.md", Line: 5, Message: "consistent-code-fence: expected backtick fence, got tilde fence"},
-			},
-		},
-
 		// longer fence markers
 		{
 			name:     "longer backtick fence consistent no violation",

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -5,8 +5,7 @@ import (
 )
 
 // CheckConsistentEmphasisStyle flags emphasis spans that use a different marker
-// than expected. style must be "consistent", "asterisk", or "underscore";
-// any other value falls back to "consistent".
+// than expected. style must be "consistent", "asterisk", or "underscore".
 //
 // In "consistent" mode the first emphasis character found in the document sets
 // the expected style; every subsequent span using a different character is
@@ -14,12 +13,6 @@ import (
 // is flagged. Underscores inside words (e.g. snake_case) are not treated as
 // emphasis. Content inside fenced code blocks and inline code spans is ignored.
 func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, style string) []LintError {
-	switch style {
-	case "consistent", "asterisk", "underscore":
-	default:
-		style = "consistent"
-	}
-
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -254,16 +254,6 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 				{File: "test.md", Line: 13, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
 			},
 		},
-
-		// invalid style falls back to consistent
-		{
-			name:    "unknown style falls back to consistent",
-			content: "This is *italic* text.\n\nThis is _also italic_ text.\n",
-			style:   "unknown",
-			wantErrs: []LintError{
-				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -5,20 +5,13 @@ import (
 )
 
 // CheckConsistentListMarker flags unordered list items that use a different
-// marker than expected. style must be "consistent", "dash", "asterisk", or
-// "plus"; any other value falls back to "consistent".
+// marker than expected. style must be "consistent", "dash", "asterisk", or "plus".
 //
 // In "consistent" mode the first marker found in the document sets the
 // expected style; every subsequent item using a different marker is flagged.
 // In "dash"/"asterisk"/"plus" mode every item using the wrong marker is
 // flagged. Content inside fenced code blocks is ignored.
 func CheckConsistentListMarker(filename string, lines []string, offset int, style string) []LintError {
-	switch style {
-	case "consistent", "dash", "asterisk", "plus":
-	default:
-		style = "consistent"
-	}
-
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""

--- a/internal/rule/consistent_list_marker_test.go
+++ b/internal/rule/consistent_list_marker_test.go
@@ -223,16 +223,6 @@ func TestCheckConsistentListMarker(t *testing.T) {
 				{File: "test.md", Line: 12, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
 			},
 		},
-
-		// invalid style falls back to consistent
-		{
-			name:    "unknown style falls back to consistent",
-			content: "- one\n* two\n",
-			style:   "unknown",
-			wantErrs: []LintError{
-				{File: "test.md", Line: 2, Message: "consistent-list-marker: expected dash marker, got asterisk marker"},
-			},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Change `linter.New()` signature from `*Linter` to `(*Linter, error)` so invalid rule options are caught before any linting begins
- Add `validateStyleOption` helper that rejects unknown `style` values for `consistent-code-fence`, `consistent-emphasis-style`, and `consistent-list-marker`, with a clear error message matching the format in the issue (`gomarklint: invalid value "hoge" for consistent-code-fence.style (valid values: consistent, backtick, tilde)`)
- Remove the duplicate silent-fallback switches from the three `Check*` rule functions — `linter.New()` is now the single validation point
- Validation runs regardless of whether the rule is enabled, so a misconfigured-but-disabled rule is still caught at startup

## Test plan

- [x] Unit tests for each invalid-option case (all three rules, non-string value, disabled-rule-still-validated)
- [x] Unit test for empty-string style (treated as default, no error)
- [x] `app` integration test for the new error propagation path
- [x] E2E test (`TestE2E_EdgeCases/InvalidRuleOptionValue`) verifying exit code and message
- [x] `make test-all` passes with 100% coverage
- [x] `make static-lint` passes

Closes #203