### PR TITLE
bench(PR-17): blanks-around-fences — firstNonSpaceByte prefilter

### DIFF
--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -19,50 +19,45 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 		// HTML comment tracking only applies outside fenced code blocks;
 		// `<!--`-like content inside a fenced block is just code and must not
 		// interfere with detecting the closing fence.
-		if !inBlock {
-			if inHTMLComment || strings.IndexByte(line, '<') >= 0 {
-				if skip, stillInComment := stepHTMLComment(strings.TrimSpace(line), inHTMLComment); skip {
-					inHTMLComment = stillInComment
-					prevBlank = false
-					continue
-				}
+		if !inBlock && (inHTMLComment || strings.IndexByte(line, '<') >= 0) {
+			skip, stillInComment := stepHTMLComment(strings.TrimSpace(line), inHTMLComment)
+			if skip {
+				inHTMLComment = stillInComment
+				prevBlank = false
+				continue
 			}
 		}
 
 		if inBlock {
-			if first == fenceMarker[0] {
-				if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-					inBlock = false
-					fenceMarker = ""
-					// closing fence: check the next line
-					if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
-						errs = append(errs, LintError{
-							File:    filename,
-							Line:    offset + i + 1,
-							Message: "blanks-around-fences: fenced code block must be followed by a blank line",
-						})
-					}
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+				// closing fence: check the next line
+				if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "blanks-around-fences: fenced code block must be followed by a blank line",
+					})
 				}
 			}
 			prevBlank = false
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				// opening fence: check the previous line
-				if i > 0 && !prevBlank {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
-					})
-				}
-				prevBlank = false
-				continue
+		if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			// opening fence: check the previous line
+			if i > 0 && !prevBlank {
+				errs = append(errs, LintError{
+					File:    filename,
+					Line:    offset + i + 1,
+					Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
+				})
 			}
+			prevBlank = false
+			continue
 		}
 
 		prevBlank = isBlank

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -13,50 +13,56 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 	prevBlank := true
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		isBlank := trimmed == ""
+		first := firstNonSpaceByte(line)
+		isBlank := first == 0
 
 		// HTML comment tracking only applies outside fenced code blocks;
 		// `<!--`-like content inside a fenced block is just code and must not
 		// interfere with detecting the closing fence.
 		if !inBlock {
-			if skip, stillInComment := stepHTMLComment(trimmed, inHTMLComment); skip {
-				inHTMLComment = stillInComment
-				prevBlank = false
-				continue
+			if inHTMLComment || strings.IndexByte(line, '<') >= 0 {
+				if skip, stillInComment := stepHTMLComment(strings.TrimSpace(line), inHTMLComment); skip {
+					inHTMLComment = stillInComment
+					prevBlank = false
+					continue
+				}
 			}
 		}
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-				// closing fence: check the next line
-				if i+1 < len(lines) && strings.TrimSpace(lines[i+1]) != "" {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "blanks-around-fences: fenced code block must be followed by a blank line",
-					})
+			if first == fenceMarker[0] {
+				if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
+					inBlock = false
+					fenceMarker = ""
+					// closing fence: check the next line
+					if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
+						errs = append(errs, LintError{
+							File:    filename,
+							Line:    offset + i + 1,
+							Message: "blanks-around-fences: fenced code block must be followed by a blank line",
+						})
+					}
 				}
 			}
 			prevBlank = false
 			continue
 		}
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			// opening fence: check the previous line
-			if i > 0 && !prevBlank {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    offset + i + 1,
-					Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
-				})
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				// opening fence: check the previous line
+				if i > 0 && !prevBlank {
+					errs = append(errs, LintError{
+						File:    filename,
+						Line:    offset + i + 1,
+						Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
+					})
+				}
+				prevBlank = false
+				continue
 			}
-			prevBlank = false
-			continue
 		}
 
 		prevBlank = isBlank

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -116,6 +116,11 @@ func TestCheckBlanksAroundFences(t *testing.T) {
 			content:  "text\n\n```\n<!--\n-->\n```\n\ntext\n",
 			wantErrs: nil,
 		},
+		{
+			name:     "valid: line with < but no <!-- does not trigger HTML comment mode",
+			content:  "Use <br> for line breaks.\n\n```go\nfmt.Println()\n```\n\nDone.\n",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Three optimizations to `CheckBlanksAroundFences`:

1. **`firstNonSpaceByte` prefilter inside code blocks**: `TrimSpace` + `IsClosingFence` called only when the first non-space byte matches the opening fence character — skips all non-fence lines inside the block with no string work (same pattern as PR-11–15)
2. **`strings.IndexByte(line, '<')` prefilter before `stepHTMLComment`**: avoids two `strings.Contains` calls on lines with no `<` character, which is the vast majority of lines in a typical document
3. **`firstNonSpaceByte(lines[i+1]) != 0`** replaces `strings.TrimSpace` on the look-ahead blank check after a closing fence

Also adds one test case to restore 100% coverage: a line containing `<` but not `<!--` now exercises the `stepHTMLComment` false-return path (previously reached on every non-block text line before the prefilter was added).

No content change needed: `writeCodeBlock` already emits properly-spaced ` ```go ` blocks that exercise the rule's main scan path on every even section.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 650 625 ns | 3 674 833 ns | ≈0% (within noise) |
| B/op | 782 632 B | 782 172 B | ≈0% |
| allocs/op | 2 023 | 2 023 | 0% |

Note: CI (AMD EPYC) geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146