### PR TITLE
bench(PR-19): consistent-code-fence — firstNonSpaceByte prefilter

### DIFF
--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -18,11 +18,11 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 	var expectedCh byte // 0 until first fence seen (consistent mode)
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		// Inside a code block: only look for the closing fence.
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
@@ -31,8 +31,16 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 
 		// Inside an HTML comment block: skip until "-->" is found.
 		if inHTMLComment {
-			if strings.Contains(trimmed, "-->") {
+			if strings.Contains(line, "-->") {
 				inHTMLComment = false
+			}
+			continue
+		}
+
+		// Lines that cannot open a fence are checked only for "<!--".
+		if first != '`' && first != '~' {
+			if strings.IndexByte(line, '<') >= 0 {
+				inHTMLComment = isHTMLCommentStart(line)
 			}
 			continue
 		}
@@ -40,6 +48,7 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 		// Check for an opening fence before inspecting the line for "<!--" so
 		// that fence openers whose info string contains "<!--" (e.g.
 		// "```go <!-- note -->") are treated as fences, not comment starts.
+		trimmed := strings.TrimSpace(line)
 		if marker := openingFenceMarker(trimmed); marker != "" {
 			ch := marker[0]
 			inBlock = true
@@ -50,9 +59,9 @@ func CheckConsistentCodeFence(filename string, lines []string, offset int, style
 			continue
 		}
 
-		// Track HTML comment blocks so fences inside them are ignored.
-		if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
-			inHTMLComment = true
+		// `` ` ``/`~` line that is not a fence opener: still check for "<!--".
+		if strings.IndexByte(line, '<') >= 0 {
+			inHTMLComment = isHTMLCommentStart(trimmed)
 		}
 	}
 
@@ -94,6 +103,12 @@ func checkFenceStyle(filename string, line int, ch byte, style string, expectedC
 		}
 	}
 	return nil
+}
+
+// isHTMLCommentStart reports whether line opens an HTML comment that does not
+// close on the same line (contains "<!--" but not "-->").
+func isHTMLCommentStart(line string) bool {
+	return strings.Contains(line, "<!--") && !strings.Contains(line, "-->")
 }
 
 func fenceCharName(ch byte) string {

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -175,6 +175,14 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 			style:    "consistent",
 			wantErrs: nil,
 		},
+
+		// backtick/tilde non-fence line containing "<"
+		{
+			name:     "backtick non-fence line with < does not enter HTML comment mode",
+			content:  "`<br>` is inline code\n\n```go\nfmt.Println()\n```\n\nDone.\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Two optimizations to `CheckConsistentCodeFence`:

1. **`firstNonSpaceByte` prefilter**: `TrimSpace` + `openingFenceMarker` called only when the first non-space byte is `` ` `` or `~` — skips all other lines with no string work (same pattern as PR-11–15)
2. **`first == fenceMarker[0] &&` guard inside blocks**: `TrimSpace` + `IsClosingFence` called only when the first non-space byte matches the opening fence character — skips all non-fence lines inside the block
3. **`strings.IndexByte(line, '<')` prefilter** before HTML comment detection: avoids `strings.Contains` calls on lines with no `<` character
4. **`isHTMLCommentStart` helper** extracted to deduplicate the `<!--`/`-->` check used in two call sites

Also adds one test case to reach 100% coverage: a backtick non-fence line containing `<` exercises the `isHTMLCommentStart` call path after `openingFenceMarker` returns empty.

No content change needed: `writeCodeBlock` already emits properly-spaced ` ```go ` blocks that exercise the rule's main scan path on every even section.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 728 446 ns | 3 580 799 ns | -3.96% |
| B/op | 782 622 B | 782 622 B | 0% |
| allocs/op | 2 023 | 2 023 | 0% |

Note: CI (AMD EPYC) geomean is the authoritative delta.

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146