### PR TITLE
bench(PR-20): consistent-emphasis-style — firstNonSpaceByte prefilter

### DIFF
--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -19,20 +19,22 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 	var expectedCh byte // 0 until first emphasis seen (consistent mode)
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
+			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
 			}
 			continue
 		}
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
+		if first == '`' || first == '~' {
+			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
+				inBlock = true
+				fenceMarker = marker
+				continue
+			}
 		}
 
 		if !strings.ContainsAny(line, "*_") {


### PR DESCRIPTION
## Summary

Two optimizations to `CheckConsistentEmphasisStyle`:

1. **`firstNonSpaceByte` prefilter for fence detection**: `TrimSpace` + `openingFenceMarker` called only when the first non-space byte is `` ` `` or `~` — skips all other lines with no string work (same pattern as PR-11–15, PR-19)
2. **`first == fenceMarker[0] &&` guard inside blocks**: `TrimSpace` + `IsClosingFence` called only when the first non-space byte matches the opening fence character — skips all non-fence lines inside the block

The existing `strings.ContainsAny(line, "*_")` check already short-circuits emphasis scanning on most lines; these changes reduce overhead in the code-block tracking path which runs on every line regardless.

No content change needed: `writeCodeBlock` already emits ` ```go ` blocks and `writeParagraph`/`writeList` emit `*`-prefixed content that exercises the rule's main scan path on every section.

## Benchmark delta (1 000-section document)

| metric | before | after | delta |
|---|---|---|---|
| time/op | 3 585 496 ns | 3 503 285 ns | -2.29% |
| B/op | 782 622 B | 782 622 B | 0% |
| allocs/op | 2 023 | 2 023 | 0% |

Note: CI (AMD EPYC) geomean is the authoritative delta (pre-push hook: -8.46%).

## Checklist

- [x] `TestBenchmarkContentIsViolationFree` passes
- [x] `make test-all` passes (100% coverage)
- [x] `golangci-lint` passes
- [x] PR body includes before/after bench numbers
- [x] References #146

Part of #146