### PR TITLE
fix(link-fragments): slugSphinx strips leading digits to match docutils make_id

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -288,7 +288,9 @@ func slugSphinx(text string) string {
 		}
 	}
 	result := reSphinxNonAlnum.ReplaceAllString(ascii.String(), "-")
-	return strings.Trim(result, "-")
+	// docutils _non_id_at_ends strips leading hyphens AND leading digits, trailing hyphens only.
+	result = strings.TrimLeft(result, "-0123456789")
+	return strings.TrimRight(result, "-")
 }
 
 // slugEleventy computes an approximation of the Eleventy (@sindresorhus/slugify) slug.

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -274,7 +274,8 @@ func slugGitea(text string) string {
 
 // slugSphinx computes the Sphinx (Python-Sphinx auto-section-label) slug.
 // NFKD-normalizes to strip combining chars, keeps only lowercase ASCII alphanumerics,
-// replaces runs of non-alphanumeric with a single hyphen, and trims leading/trailing hyphens.
+// replaces runs of non-alphanumeric with a single hyphen, then strips leading hyphens and
+// leading digits (matching docutils _non_id_at_ends: ^[-0-9]+|-+$) and trailing hyphens.
 // Non-Latin-only headings that produce an empty result return "" (the id1/id2 fallback
 // is document-level state that cannot be reproduced outside the build context).
 func slugSphinx(text string) string {

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -95,7 +95,7 @@ func TestComputeSlug(t *testing.T) {
 		{"sphinx: collapses non-alphanumeric", "A  B", "sphinx", "a-b"},
 		{"sphinx: punctuation collapsed", "Go 1.21", "sphinx", "go-1-21"},
 		{"sphinx: strips leading digits", "123abc", "sphinx", "abc"},
-		{"sphinx: strips leading digit single char", "1test", "sphinx", "test"},
+		{"sphinx: strips single leading digit", "1test", "sphinx", "test"},
 		{"sphinx: preserves interior digits", "abc123def", "sphinx", "abc123def"},
 		{"sphinx: all digits produces empty", "123", "sphinx", ""},
 

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -94,6 +94,10 @@ func TestComputeSlug(t *testing.T) {
 		{"sphinx: strips non-ASCII CJK", "日本語", "sphinx", ""},
 		{"sphinx: collapses non-alphanumeric", "A  B", "sphinx", "a-b"},
 		{"sphinx: punctuation collapsed", "Go 1.21", "sphinx", "go-1-21"},
+		{"sphinx: strips leading digits", "123abc", "sphinx", "abc"},
+		{"sphinx: strips leading digit single char", "1test", "sphinx", "test"},
+		{"sphinx: preserves interior digits", "abc123def", "sphinx", "abc123def"},
+		{"sphinx: all digits produces empty", "123", "sphinx", ""},
 
 		// Eleventy
 		{"eleventy: simple text", "Hello World", "eleventy", "hello-world"},


### PR DESCRIPTION
## Summary

- `slugSphinx` was using `strings.Trim(result, "-")` which only strips hyphens from both ends
- docutils `nodes.make_id()` applies `^[-0-9]+|-+$` which also strips leading digits
- Fixed by using `strings.TrimLeft(result, "-0123456789")` + `strings.TrimRight(result, "-")`

| Input | Expected | Before | After |
|---|---|---|---|
| `123abc` | `abc` | `123abc` ❌ | `abc` ✅ |
| `1test` | `test` | `1test` ❌ | `test` ✅ |
| `Hello World` | `hello-world` | `hello-world` ✅ | `hello-world` ✅ |
| `123` | `` | `123` ❌ | `` ✅ |

## Test plan

- [x] Added 4 test cases covering leading digits, single leading digit, interior digits (preserved), and all-digit input (empty)
- [x] `make test` passes