### PR TITLE
fix(link-fragments): use Unicode category checks in githubStripRune

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -82,23 +82,12 @@ func stripHeadingFormatting(s string) string {
 }
 
 // githubStripRune reports whether r should be removed by the GitHub slug algorithm.
-// Matches github-slugger v2: strips U+2000–U+206F, U+2E00–U+2E7F, and specific ASCII punctuation.
-// Preserves hyphens, underscores, Unicode letters, and digits.
+// Matches github-slugger v2: keeps \p{L}, \p{Nd}, \p{Nl}, hyphens, and underscores.
 func githubStripRune(r rune) bool {
-	if r >= 0x2000 && r <= 0x206F {
-		return true // General Punctuation
+	if r == '-' || r == '_' {
+		return false
 	}
-	if r >= 0x2E00 && r <= 0x2E7F {
-		return true // Supplemental Punctuation
-	}
-	switch r {
-	case '\\', '\'', '!', '"', '#', '$', '%', '&',
-		'(', ')', '*', '+', ',', '.', '/', ':',
-		';', '<', '=', '>', '?', '@', '[', ']',
-		'^', '`', '{', '|', '}', '~':
-		return true
-	}
-	return false
+	return !unicode.IsLetter(r) && !unicode.Is(unicode.Nd, r) && !unicode.Is(unicode.Nl, r)
 }
 
 // slugGitHub computes the GitHub-compatible slug (github-slugger v2).

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -91,7 +91,7 @@ func githubStripRune(r rune) bool {
 }
 
 // slugGitHub computes the GitHub-compatible slug (github-slugger v2).
-// Lowercases, strips specific punctuation ranges, replaces whitespace with hyphens.
+// Lowercases, strips all runes outside \p{L}/\p{Nd}/\p{Nl}/-/_, replaces whitespace with hyphens.
 // Consecutive whitespace produces consecutive hyphens (no collapsing).
 func slugGitHub(text string) string {
 	var sb strings.Builder

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -26,6 +26,9 @@ func TestComputeSlug(t *testing.T) {
 		{"github: section number", "Section 1", "github", "section-1"},
 		{"github: em dash (U+2014, General Punctuation) stripped", "hello—world", "github", "helloworld"},
 		{"github: supplemental punctuation (U+2E3A) stripped", "hello⸺world", "github", "helloworld"},
+		{"github: emoji stripped (globe)", "Hello 🌍", "github", "hello-"},
+		{"github: emoji stripped (rocket at start)", "🚀 Getting Started", "github", "-getting-started"},
+		{"github: accented Latin preserved", "café", "github", "café"},
 
 		// GitLab (goldmark)
 		{"gitlab: simple text", "Hello World", "gitlab", "hello-world"},


### PR DESCRIPTION
## Summary

- Replace the range/set-based `githubStripRune` with Unicode category checks (`\p{L}`, `\p{Nd}`, `\p{Nl}`)
- Emoji and other symbols outside the previously hardcoded ranges (U+2000–U+206F, U+2E00–U+2E7F) are now correctly stripped, matching github-slugger v2 behaviour
- Adds three new test cases: emoji globe, emoji rocket at start, and accented Latin preserved

Closes #213

## Test plan

- [x] `TestComputeSlug` — new emoji and accented Latin cases pass
- [x] `make test` — 100% coverage, all packages green
- [x] `make test-all` — lint, unit, E2E, self-lint, and benchmark comparison all pass (+0.60% geomean, within threshold)