### PR TITLE
fix(link-fragments): strip leading digits from slugKramdown

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -156,7 +156,8 @@ func slugPandoc(text string) string {
 }
 
 // slugKramdown computes the kramdown header_ids slug.
-// Lowercases, keeps only ASCII letters/digits/hyphens, replaces spaces with hyphens, collapses.
+// Lowercases, keeps only ASCII letters/digits/hyphens, replaces spaces with hyphens, collapses,
+// then strips leading digits and hyphens (kramdown skips chars until the first letter).
 func slugKramdown(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -169,7 +170,8 @@ func slugKramdown(text string) string {
 			sb.WriteByte('-')
 		}
 	}
-	return collapseDashes(sb.String())
+	result := collapseDashes(sb.String())
+	return strings.TrimLeft(result, "0123456789-")
 }
 
 // slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -54,6 +54,8 @@ func TestComputeSlug(t *testing.T) {
 		{"kramdown: strips non-ASCII", "日本語", "kramdown", ""},
 		{"kramdown: period stripped", "Go 1.21", "kramdown", "go-121"},
 		{"kramdown: underscore stripped (not in keep set)", "go_lang", "kramdown", "golang"},
+		{"kramdown: leading digits stripped", "123abc", "kramdown", "abc"},
+		{"kramdown: single leading digit stripped", "1test", "kramdown", "test"},
 
 		// Hugo (= GitHub)
 		{"hugo: same as github", "Hello World", "hugo", "hello-world"},


### PR DESCRIPTION
## Summary

- Add `strings.TrimLeft(result, "0123456789-")` after `collapseDashes` in `slugKramdown`
- kramdown's `header_ids` algorithm skips characters until the first letter, so leading digits (and any preceding hyphens) are absent from the final slug
- Adds two regression tests: `"123abc" → "abc"`, `"1test" → "test"`

Closes #216

## Test plan

- [x] `TestComputeSlug` — new leading-digit cases pass
- [x] `make test` — 100% coverage, all packages green
- [x] `make test-all` — lint, unit, E2E, self-lint, and benchmark comparison all pass