### PR TITLE
fix(link-fragments): slugMkDocs preserves Unicode letters and applies NFKD normalization

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -173,15 +173,18 @@ func slugKramdown(text string) string {
 }
 
 // slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.
-// Lowercases, strips non-ASCII characters, replaces spaces with hyphens, collapses.
+// NFKD-normalizes to decompose accented chars (é→e), lowercases, keeps Unicode letters,
+// decimal digits, hyphens, and underscores (matching Python's \w + [-]), replaces spaces
+// with hyphens, and collapses consecutive hyphens.
 func slugMkDocs(text string) string {
+	text = nfkdStripCombining(text)
 	var sb strings.Builder
 	sb.Grow(len(text))
 	for _, r := range text {
 		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
-		} else if r < 128 && ((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+		} else if unicode.IsLetter(r) || unicode.Is(unicode.Nd, r) || r == '-' || r == '_' {
 			sb.WriteRune(r)
 		}
 	}

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -174,8 +174,8 @@ func slugKramdown(text string) string {
 
 // slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.
 // NFKD-normalizes to decompose accented chars (é→e), lowercases, keeps Unicode letters,
-// decimal digits, hyphens, and underscores (matching Python's \w + [-]), replaces spaces
-// with hyphens, and collapses consecutive hyphens.
+// all Unicode numbers (Nd/Nl/No — matching Python's \w which includes roman numerals and
+// superscripts), hyphens, and underscores, replaces spaces with hyphens, and collapses.
 func slugMkDocs(text string) string {
 	text = nfkdStripCombining(text)
 	var sb strings.Builder
@@ -184,7 +184,7 @@ func slugMkDocs(text string) string {
 		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
-		} else if unicode.IsLetter(r) || unicode.Is(unicode.Nd, r) || r == '-' || r == '_' {
+		} else if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '-' || r == '_' {
 			sb.WriteRune(r)
 		}
 	}

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -70,6 +70,9 @@ func TestComputeSlug(t *testing.T) {
 		{"mkdocs: accented Latin normalized", "café", "mkdocs", "cafe"},
 		{"mkdocs: umlaut normalized", "über", "mkdocs", "uber"},
 		{"mkdocs: tilde normalized", "señor", "mkdocs", "senor"},
+		// NFKD maps Ⅳ→IV and ²→2 before the letter/number filter runs.
+		{"mkdocs: letter number Nl via NFKD", "chapter Ⅳ", "mkdocs", "chapter-iv"},
+		{"mkdocs: other number No via NFKD", "note ²", "mkdocs", "note-2"},
 
 		// DocFX (case-preserving)
 		{"docfx: preserves case", "Hello World", "docfx", "Hello-World"},

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -61,9 +61,15 @@ func TestComputeSlug(t *testing.T) {
 
 		// MkDocs
 		{"mkdocs: simple text", "Hello World", "mkdocs", "hello-world"},
-		{"mkdocs: strips non-ASCII", "日本語", "mkdocs", ""},
+		{"mkdocs: preserves CJK", "日本語", "mkdocs", "日本語"},
+		// NFKD decomposes Hangul syllables into conjoining jamo (matches Python-Markdown).
+		{"mkdocs: Korean NFKD to jamo", "한국어", "mkdocs", "한국어"},
+		{"mkdocs: mixed ASCII and CJK", "API の抽象化", "mkdocs", "api-の抽象化"},
 		{"mkdocs: collapses hyphens", "A  B", "mkdocs", "a-b"},
 		{"mkdocs: period stripped", "Go 1.21", "mkdocs", "go-121"},
+		{"mkdocs: accented Latin normalized", "café", "mkdocs", "cafe"},
+		{"mkdocs: umlaut normalized", "über", "mkdocs", "uber"},
+		{"mkdocs: tilde normalized", "señor", "mkdocs", "senor"},
 
 		// DocFX (case-preserving)
 		{"docfx: preserves case", "Hello World", "docfx", "Hello-World"},


### PR DESCRIPTION
## Summary

- `slugMkDocs` was gating on `r < 128`, stripping all non-ASCII characters (CJK, Korean, etc.)
- Python-Markdown `toc.py` uses `unicodedata.normalize('NFKD')` then strips non-`\w` characters; Python's `\w` is Unicode-aware and keeps letters/digits across all scripts
- Two bugs fixed:
  1. **CJK and other Unicode letters stripped**: replaced `r < 128` guard with `unicode.IsLetter(r) || unicode.Is(unicode.Nd, r)`
  2. **Accented Latin not NFKD-normalized**: added `nfkdStripCombining` call so `é→e`, `ü→u`, `ñ→n`

| Input | Before | After (matches Python-Markdown) |
|---|---|---|
| `日本語` | `` ❌ | `日本語` ✅ |
| `API の抽象化` | `api` ❌ | `api-の抽象化` ✅ |
| `café` | `caf` ❌ | `cafe` ✅ |
| `über` | `ber` ❌ | `uber` ✅ |
| `señor` | `seor` ❌ | `senor` ✅ |

Note: Korean input (`한국어`) is NFKD-decomposed into conjoining jamo — this matches Python-Markdown's behavior (both produce jamo rather than composed syllables).

## Test plan

- [x] Added 5 new test cases (CJK, Korean/jamo, mixed ASCII+CJK, 3 × accented Latin)
- [x] Updated existing `"strips non-ASCII"` test to `"preserves CJK"`
- [x] `make test` passes (100% coverage)
- [x] Benchmark: no regression