### PR TITLE
fix(link-fragments): keep periods and strip leading non-letters in slugPandoc

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -140,7 +140,8 @@ func slugZenn(text string) string {
 }
 
 // slugPandoc computes the Pandoc auto_identifiers slug.
-// Lowercases, keeps only ASCII letters/digits/hyphens/underscores, collapses consecutive hyphens.
+// Lowercases, keeps only ASCII letters/digits/hyphens/underscores/periods, collapses consecutive
+// hyphens, then strips everything up to the first letter (Pandoc auto_identifiers step 5).
 func slugPandoc(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -148,11 +149,17 @@ func slugPandoc(text string) string {
 		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) {
 			sb.WriteByte('-')
-		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+		} else if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == '.' {
 			sb.WriteRune(r)
 		}
 	}
-	return collapseDashes(sb.String())
+	s := collapseDashes(sb.String())
+	for i, r := range s {
+		if r >= 'a' && r <= 'z' {
+			return s[i:]
+		}
+	}
+	return ""
 }
 
 // slugKramdown computes the kramdown header_ids slug.

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -46,8 +46,11 @@ func TestComputeSlug(t *testing.T) {
 		// Pandoc (auto_identifiers)
 		{"pandoc: simple text", "Hello World", "pandoc", "hello-world"},
 		{"pandoc: strips non-ASCII", "日本語", "pandoc", ""},
-		{"pandoc: period stripped", "Go 1.21", "pandoc", "go-121"},
+		{"pandoc: period kept", "Go 1.21", "pandoc", "go-1.21"},
 		{"pandoc: collapses hyphens from double space", "A  B", "pandoc", "a-b"},
+		{"pandoc: leading digits stripped", "123abc", "pandoc", "abc"},
+		{"pandoc: numbered list item strips prefix", "1. Introduction", "pandoc", "introduction"},
+		{"pandoc: section with period", "Section 1.1", "pandoc", "section-1.1"},
 
 		// Kramdown
 		{"kramdown: simple text", "Hello World", "kramdown", "hello-world"},


### PR DESCRIPTION
## Summary

Two deviations from the Pandoc `auto_identifiers` spec, both fixed:

1. **Bug 1 — periods stripped**: Added `'.'` to the allowed character set (spec step 2: "remove all punctuation, except underscores, hyphens, and periods")
2. **Bug 2 — leading non-letters kept**: Added a post-`collapseDashes` scan that returns from the first `a-z` rune (spec step 5: "remove everything up to the first letter")

The `quarto` preset delegates to `slugPandoc` and is fixed automatically.

Updated existing test `"pandoc: period stripped" → "go-121"` to `"pandoc: period kept" → "go-1.21"`, and added three new cases: leading digits, numbered list item prefix, and section with period.

Closes #217

## Test plan

- [x] `TestComputeSlug` — updated and new pandoc/quarto cases pass
- [x] `make test` — 100% coverage, all packages green
- [x] `make test-all` — lint, unit, E2E, self-lint, and benchmark comparison all pass