### PR TITLE
fix(link-fragments): add dedicated slugMdBook — underscore → hyphen, strip trailing hyphen

### DIFF
--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -248,6 +248,29 @@ func slugQiita(text string) string {
 	return sb.String()
 }
 
+// slugMdBook computes the mdBook (normalize_id) slug.
+// Rust's is_alphanumeric() keeps Unicode letters and numbers; underscores,
+// spaces, and hyphens collapse to a single hyphen; trailing hyphens are stripped.
+func slugMdBook(text string) string {
+	var sb strings.Builder
+	sb.Grow(len(text))
+	prevWasHyphen := true // start true to suppress any leading hyphen
+	for _, r := range text {
+		r = unicode.ToLower(r)
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			sb.WriteRune(r)
+			prevWasHyphen = false
+		} else if unicode.IsSpace(r) || r == '-' || r == '_' {
+			if !prevWasHyphen {
+				sb.WriteByte('-')
+				prevWasHyphen = true
+			}
+		}
+		// else: strip
+	}
+	return strings.TrimRight(sb.String(), "-")
+}
+
 // slugVitePress computes the VitePress (markdown-it-anchor) slug.
 // NFKD-normalizes to strip combining chars (accented Latin → ASCII base),
 // then lowercases and replaces non-alphanumeric chars with hyphens, collapsing runs.
@@ -534,7 +557,7 @@ var slugRegistry = map[string]func(string) string{
 	"docfx": slugDocFX,
 	// Qiita / mdBook (same character set)
 	"qiita":  slugQiita,
-	"mdbook": slugQiita,
+	"mdbook": slugMdBook,
 	// VitePress
 	"vitepress": slugVitePress,
 	// Gitea / Forgejo

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -555,8 +555,9 @@ var slugRegistry = map[string]func(string) string{
 	"mkdocs": slugMkDocs,
 	// DocFX
 	"docfx": slugDocFX,
-	// Qiita / mdBook (same character set)
-	"qiita":  slugQiita,
+	// Qiita
+	"qiita": slugQiita,
+	// mdBook (Rust is_alphanumeric — underscore → hyphen, trailing hyphen stripped)
 	"mdbook": slugMdBook,
 	// VitePress
 	"vitepress": slugVitePress,

--- a/internal/rule/link_fragments_slug_test.go
+++ b/internal/rule/link_fragments_slug_test.go
@@ -85,14 +85,20 @@ func TestComputeSlug(t *testing.T) {
 		{"docfx: strips non-ASCII", "日本語", "docfx", ""},
 		{"docfx: strips punctuation except hyphen underscore dot", "Hello, World!", "docfx", "Hello-World"},
 
-		// Qiita / mdbook (same character set)
+		// Qiita
 		{"qiita: simple text", "Hello World", "qiita", "hello-world"},
 		{"qiita: preserves Unicode letters", "日本語", "qiita", "日本語"},
 		{"qiita: preserves underscore", "go_lang", "qiita", "go_lang"},
 		{"qiita: strips punctuation", "Hello, World!", "qiita", "hello-world"},
 		{"qiita: no collapse", "A  B", "qiita", "a--b"},
-		{"mdbook: same as qiita", "Hello World", "mdbook", "hello-world"},
-		{"mdbook: preserves Unicode", "日本語", "mdbook", "日本語"},
+
+		// mdBook (Rust is_alphanumeric — differs from Qiita)
+		{"mdbook: simple text", "Hello World", "mdbook", "hello-world"},
+		{"mdbook: preserves Unicode letters", "日本語", "mdbook", "日本語"},
+		{"mdbook: underscore becomes hyphen", "foo_bar", "mdbook", "foo-bar"},
+		{"mdbook: trailing hyphen stripped", "Hello 🌍", "mdbook", "hello"},
+		{"mdbook: accented letters preserved", "café", "mdbook", "café"},
+		{"mdbook: dots stripped", "Section 1.1", "mdbook", "section-11"},
 
 		// VitePress
 		{"vitepress: simple text", "Hello World", "vitepress", "hello-world"},

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -235,6 +235,8 @@ func TestCheckLinkFragments_NewPresets(t *testing.T) {
 	}{
 		{"qiita: valid CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "qiita", 0},
 		{"mdbook: valid CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "mdbook", 0},
+		{"mdbook: underscore in heading becomes hyphen", "## foo_bar\n\nSee [foo_bar](#foo-bar).\n", "mdbook", 0},
+		{"mdbook: underscore link not matching", "## foo_bar\n\nSee [foo_bar](#foo_bar).\n", "mdbook", 1},
 		{"vitepress: accented heading", "## Héllo\n\nSee [Héllo](#hello).\n", "vitepress", 0},
 		{"vitepress: CJK heading", "## 日本語\n\nSee [日本語](#日本語).\n", "vitepress", 0},
 		{"gitea: valid link without user-content prefix", "## Hello World\n\nSee [Hello](#hello-world).\n", "gitea", 0},


### PR DESCRIPTION
## Summary

- `mdbook` preset was delegating to `slugQiita`, but mdBook's `normalize_id` (Rust `is_alphanumeric()`) differs from Qiita's Ruby `\p{Word}` in two ways:
  - **Underscores** → hyphen in mdBook, kept in Qiita (`foo_bar` → `foo-bar` vs `foo_bar`)
  - **Trailing hyphens** → stripped in mdBook, kept in Qiita (`Hello 🌍` → `hello` vs `hello-`)
- Adds a dedicated `slugMdBook` function and updates `slugRegistry` to use it.
- Updates test vectors in `link_fragments_slug_test.go` and adds underscore-specific cases to `link_fragments_test.go`.

Closes #220

## Test plan

- [x] `make test-all` passes (unit + E2E + benchmark comparison)
- [x] `TestComputeSlug` vectors cover `foo_bar → foo-bar`, `Hello 🌍 → hello`, `café → café`, `Section 1.1 → section-11`
- [x] `TestCheckLinkFragments_NewPresets` verifies `#foo-bar` is valid and `#foo_bar` is a violation for `mdbook`