### PR TITLE
docs: document sphinx id1/id2 false-positive in FAQ and rules table

### DIFF
--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -164,6 +164,32 @@ External link checking has inherent limits — the tool flags candidates, but fi
 
 ---
 
+## Fragment link checking
+
+### `link-fragments`: false "not found" for `#id1` or `#id2` under `sphinx` {#sphinx-id1}
+
+Sphinx (docutils) assigns dynamic IDs (`id1`, `id2`, …) to headings whose normal slug would be empty:
+
+- **Digits-only headings** — `# 123` produces no ASCII slug
+- **Non-Latin-only headings** — `# 日本語` contains no ASCII characters
+
+Because these IDs are assigned at Sphinx build time, gomarklint cannot reproduce them statically. The heading is excluded from the valid fragment set, so any link pointing to it is reported as broken even when it is valid at render time.
+
+**Workarounds:**
+
+1. **Rename the heading** to start with an ASCII letter — gomarklint can then verify it normally.
+2. **Suppress the false positive** with a disable comment around the affected link:
+
+```markdown
+<!-- gomarklint-disable link-fragments -->
+[See section](#id1)
+<!-- gomarklint-enable link-fragments -->
+```
+
+→ [Disable comments](../disable-comments/)
+
+---
+
 ### Not sure if a link is truly broken
 
 Before opening an issue, verify the link using the same User-Agent gomarklint uses:

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -166,18 +166,21 @@ External link checking has inherent limits — the tool flags candidates, but fi
 
 ## Fragment link checking
 
-### `link-fragments`: false "not found" for `#id1` or `#id2` under `sphinx` {#sphinx-id1}
+### `link-fragments`: fragment reported as "not found" for a heading that exists {#unverifiable-fragment}
 
-Sphinx (docutils) assigns dynamic IDs (`id1`, `id2`, …) to headings whose normal slug would be empty:
+Some slug algorithms strip characters aggressively, causing certain headings to produce an empty slug. When this happens, gomarklint cannot statically determine the fragment ID and excludes the heading from the valid set — so any link pointing to it is reported as broken even when it is valid at render time.
 
-- **Digits-only headings** — `# 123` produces no ASCII slug
-- **Non-Latin-only headings** — `# 日本語` contains no ASCII characters
+Common triggers by preset:
 
-Because these IDs are assigned at Sphinx build time, gomarklint cannot reproduce them statically. The heading is excluded from the valid fragment set, so any link pointing to it is reported as broken even when it is valid at render time.
+| Preset | Heading that produces an empty slug |
+|---|---|
+| `sphinx` | Digits-only (`# 123`) or non-Latin-only (`# 日本語`) — Sphinx falls back to `id1`, `id2`, … at build time |
+| `mkdocs` | Non-ASCII-only (`# 日本語`) — all non-ASCII characters are stripped |
+| `pandoc`, `kramdown`, `eleventy` | Non-ASCII-only headings with no transliterable characters |
 
 **Workarounds:**
 
-1. **Rename the heading** to start with an ASCII letter — gomarklint can then verify it normally.
+1. **Rename the heading** to include at least one ASCII letter — gomarklint can then verify it normally.
 2. **Suppress the false positive** with a disable comment around the affected link:
 
 ```markdown

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -65,7 +65,7 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 | `mdbook` | mdBook | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
 | `gitea` | Gitea | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; identical to GitHub algorithm. Gitea adds `user-content-` to the DOM id for CSP isolation, but users write fragments **without** that prefix (e.g. `#hello-world`) |
 | `forgejo` | Forgejo | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
-| `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings fall back to `id1`, `id2`, etc. |
+| `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings and digits-only headings (e.g. `# 123`, `# 日本語`) produce an empty slug and fall back to `id1`, `id2`, … assigned at build time — gomarklint cannot verify links to these headings statically; see [FAQ](../faq/#sphinx-id1) |
 | `eleventy` | Eleventy | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |
 | `azure-devops` | Azure DevOps Wiki | ✓ | ✓ | `-` | non-RFC-3986-unreserved chars percent-encoded | — | Unicode Zs category → `-`; non-ASCII preserved as percent-encoded |
 | `myst` | MyST Parser | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | MyST-Parser (Python/Sphinx); documented as GitHub-compatible |

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -56,17 +56,17 @@ Set `slug-algorithm` to the name of the platform you are writing for. Each platf
 | `astro` | Astro | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Documented as GitHub-compatible in Astro official docs |
 | `starlight` | Starlight | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Starlight (Astro-based); same algorithm as `astro` |
 | `nuxt-content` | Nuxt Content | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Uses `rehype-slug` (github-slugger wrapper) |
-| `pandoc` | Pandoc (`auto_identifiers`) | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | `auto_identifiers` extension; strips non-ASCII |
+| `pandoc` | Pandoc (`auto_identifiers`) | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | `auto_identifiers` extension; strips non-ASCII. Non-ASCII-only headings produce an empty slug — links to them cannot be verified statically; see [FAQ](../faq/#unverifiable-fragment) |
 | `pandoc-gfm` | Pandoc (`gfm_auto_identifiers`) | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | `gfm_auto_identifiers` extension; equivalent to GitHub |
 | `quarto` | Quarto | ✓ | — | `-` | `[^a-zA-Z0-9_-]` | ✓ | Uses `auto_identifiers` extension by default; same as `pandoc` |
-| `kramdown` | kramdown | ✓ | — | `-` | `[^a-zA-Z0-9 -]` | ✓ | `header_ids` extension default |
-| `mkdocs` | MkDocs | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode |
+| `kramdown` | kramdown | ✓ | — | `-` | `[^a-zA-Z0-9 -]` | ✓ | `header_ids` extension default. Non-ASCII-only headings produce an empty slug — links to them cannot be verified statically; see [FAQ](../faq/#unverifiable-fragment) |
+| `mkdocs` | MkDocs | ✓ | — | `-` | NFKD then ASCII-encode | ✓ | Python-Markdown `toc.py` default; `uslugify` variant preserves Unicode. Non-ASCII-only headings produce an empty slug — links to them cannot be verified statically; see [FAQ](../faq/#unverifiable-fragment) |
 | `docfx` | DocFX | — | — | `-` | `[^a-zA-Z0-9-_.]` | ✓ | Markdig AutoIdentifiers; does **not** lowercase |
 | `mdbook` | mdBook | ✓ | ✓ | `-` | non-alphanumeric except `_` and `-` (Rust `is_alphanumeric()`) | — | CJK preserved via Unicode alphanumeric check |
 | `gitea` | Gitea | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | goldmark-based; identical to GitHub algorithm. Gitea adds `user-content-` to the DOM id for CSP isolation, but users write fragments **without** that prefix (e.g. `#hello-world`) |
 | `forgejo` | Forgejo | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | Fork of Gitea; identical algorithm |
-| `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Non-Latin-only headings and digits-only headings (e.g. `# 123`, `# 日本語`) produce an empty slug and fall back to `id1`, `id2`, … assigned at build time — gomarklint cannot verify links to these headings statically; see [FAQ](../faq/#sphinx-id1) |
-| `eleventy` | Eleventy | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin` |
+| `sphinx` | Sphinx | ✓ | — | `-` | NFKD then ASCII then `[^a-z0-9]+`→`-` | ✓ | Digits-only or non-Latin-only headings produce an empty slug; Sphinx falls back to `id1`, `id2`, … at build time — gomarklint cannot verify links to these headings statically; see [FAQ](../faq/#unverifiable-fragment) |
+| `eleventy` | Eleventy | ✓ | — | `-` | `@sindresorhus/slugify` (transliterate to approximate ASCII) | ✓ | Used via `IdAttributePlugin`. Characters with no ASCII equivalent (CJK, etc.) are stripped — non-ASCII-only headings produce an empty slug; see [FAQ](../faq/#unverifiable-fragment) |
 | `azure-devops` | Azure DevOps Wiki | ✓ | ✓ | `-` | non-RFC-3986-unreserved chars percent-encoded | — | Unicode Zs category → `-`; non-ASCII preserved as percent-encoded |
 | `myst` | MyST Parser | ✓ | ✓ | `-` | Unicode punctuation/symbols | — | MyST-Parser (Python/Sphinx); documented as GitHub-compatible |
 | `custom` | — | — | — | — | — | — | Parameterized engine — see below |


### PR DESCRIPTION
## Summary

- Adds a new **Fragment link checking** section to `faq.md` explaining that digits-only (`# 123`) and non-Latin-only (`# 日本語`) headings under the `sphinx` preset produce an empty slug and cannot be statically verified by gomarklint.
- Provides two workarounds: rename the heading, or use a disable comment.
- Expands the `sphinx` row in `rules.md` with the same explanation and a pointer to the FAQ.

No code changes — documentation only.

Refs #223