### PR TITLE
feat: consolidate GitHub Action into main repository

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,46 @@
+name: Test Action
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - 'Dockerfile'
+      - 'entrypoint.sh'
+      - 'testdata/action/**'
+  pull_request:
+    paths:
+      - 'action.yml'
+      - 'Dockerfile'
+      - 'entrypoint.sh'
+      - 'testdata/action/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run gomarklint Action
+        uses: ./
+        with:
+          args: testdata/action
+
+  test-comment:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run gomarklint Action with PR comment
+        uses: ./
+        with:
+          args: testdata/action
+          comment-on-pr: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.gomarklint.json
 !e2e/.gomarklint.json
 
 # Binary

--- a/.gomarklint.json
+++ b/.gomarklint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "rules": {
+    "external-link": false
+  },
+  "output": "text"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Use `make` targets — do not run raw `go build` / `go test` commands.
 - **Commits**: no `Co-Authored-By` trailer
 - **Updating a feature branch**: `git fetch origin main && git rebase origin/main` — never merge main into a feature branch
 - **Pre-push hook**: run `make install-hooks` once after cloning to automatically run lint and unit tests before each push
+- **Worktrees**: always create under `.claude/worktrees/<name>` with `git worktree add .claude/worktrees/<name> -b <branch>` — never use the Agent tool's `isolation: "worktree"` parameter (it places worktrees in `/tmp` / `/private/tmp`), and never create worktrees outside this project directory
 
 ## GitHub (issues, PRs, comments, commit messages)
 
@@ -43,6 +44,10 @@ When adding a new lint rule:
 2. If the rule is disabled by default, explicitly enable it in `benchmarkConfig()` with violation-free option values.
 3. Do **not** add a rule-level `_bench_test.go` under `internal/rule/` — the CI benchmark comparison runs only on `cmd/root_bench_test.go`.
 4. Verify `TestBenchmarkContentIsViolationFree` still passes after your changes.
+
+## GitHub Action
+
+The GitHub Action lives in this repository (`action.yml`, `Dockerfile`, `entrypoint.sh` at the root). Do **not** suggest creating a GitHub Action — it already exists and is published to the [GitHub Marketplace](https://github.com/marketplace/actions/gomarklint-markdown-linter). The former separate repository `shinagawa-web/gomarklint-action` is archived.
 
 ## Project context
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 
-RUN go install github.com/shinagawa-web/gomarklint/v2@latest
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o gomarklint .
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates curl jq
 
-COPY --from=builder /go/bin/gomarklint /usr/local/bin/gomarklint
+COPY --from=builder /app/gomarklint /usr/local/bin/gomarklint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+RUN go install github.com/shinagawa-web/gomarklint/v2@latest
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates curl jq
+
+COPY --from=builder /go/bin/gomarklint /usr/local/bin/gomarklint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ jobs:
       - uses: shinagawa-web/gomarklint@v2
 ```
 
+Without `args`, the action lints the files listed in the `include` field of `.gomarklint.json`. Pass `args` to override, e.g. `args: docs/`.
+
 Full options including PR comments: see [Marketplace listing](https://github.com/marketplace/actions/gomarklint-markdown-linter)
 
 ### pre-commit

--- a/README.md
+++ b/README.md
@@ -65,24 +65,25 @@ go install github.com/shinagawa-web/gomarklint/v2@latest
 
 ### GitHub Actions
 
+[![GitHub Marketplace](https://img.shields.io/badge/Marketplace-gomarklint-blue?logo=github)](https://github.com/marketplace/actions/gomarklint-markdown-linter)
+
 ```yaml
-name: gomarklint
+name: Lint Markdown
 
 on:
-  push:
   pull_request:
+    paths:
+      - '**/*.md'
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shinagawa-web/gomarklint-action@v1
-        with:
-          args: '.'
+      - uses: shinagawa-web/gomarklint@v2
 ```
 
-Full options and examples: [gomarklint-action](https://github.com/shinagawa-web/gomarklint-action)
+Full options including PR comments: see [Marketplace listing](https://github.com/marketplace/actions/gomarklint-markdown-linter)
 
 ### pre-commit
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Catch broken links before your readers do.'
 author: 'shinagawa-web'
 inputs:
   args:
-    description: 'Arguments to pass to gomarklint'
+    description: 'Files or directories to lint. Omit to use the include field in .gomarklint.json.'
     required: false
     default: ''
   comment-on-pr:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,27 @@
+name: 'gomarklint Markdown Linter'
+description: 'Catch broken links before your readers do.'
+author: 'shinagawa-web'
+inputs:
+  args:
+    description: 'Arguments to pass to gomarklint'
+    required: false
+    default: ''
+  comment-on-pr:
+    description: 'Post lint results as a PR comment (requires pull_request context)'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'GitHub token for posting PR comments'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.args }}
+  env:
+    INPUT_COMMENT_ON_PR: ${{ inputs.comment-on-pr }}
+    INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+branding:
+  icon: 'book'
+  color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -uo pipefail
+set -u
 
 CONFIG_FILE=".gomarklint.json"
 
@@ -10,13 +10,20 @@ else
   exit 1
 fi
 
-# Run gomarklint and capture output + exit code
-OUTPUT=$(gomarklint "$@" 2>&1) || true
-EXIT_CODE=${PIPESTATUS:-$?}
+# Filter empty args so gomarklint falls back to config's include when no path is given
+FILTERED_ARGS=""
+for arg in "$@"; do
+  if [ -n "$arg" ]; then
+    FILTERED_ARGS="$FILTERED_ARGS $arg"
+  fi
+done
 
-# Re-run to get the real exit code since capturing swallows it
-gomarklint "$@" > /dev/null 2>&1
+# Capture output and exit code in a single run
+set +e
+# shellcheck disable=SC2086
+OUTPUT=$(gomarklint $FILTERED_ARGS 2>&1)
 EXIT_CODE=$?
+set -e
 
 echo "$OUTPUT"
 
@@ -30,20 +37,17 @@ if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
     MARKER="<!-- gomarklint-result -->"
     REPO="${GITHUB_REPOSITORY}"
 
-    # Extract PR number from the event payload
     PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
 
     if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
       echo "Could not determine PR number. Skipping comment."
     else
-      # Build comment body
       if [ $EXIT_CODE -eq 0 ]; then
         BODY=$(printf '%s\n### gomarklint result\n\nNo issues found.\n' "$MARKER")
       else
         BODY=$(printf '%s\n### gomarklint result\n\n```\n%s\n```\n' "$MARKER" "$OUTPUT")
       fi
 
-      # Search for existing comment with marker
       EXISTING_COMMENT_ID=$(curl -s \
         -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
         -H "Accept: application/vnd.github.v3+json" \
@@ -52,7 +56,6 @@ if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
         | head -1)
 
       if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then
-        # Update existing comment
         curl -s -X PATCH \
           -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github.v3+json" \
@@ -60,7 +63,6 @@ if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
           -d "$(jq -n --arg body "$BODY" '{body: $body}')" > /dev/null
         echo "Updated existing PR comment."
       else
-        # Create new comment
         curl -s -X POST \
           -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github.v3+json" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -uo pipefail
+
+CONFIG_FILE=".gomarklint.json"
+
+if [ -f "$CONFIG_FILE" ]; then
+  echo "Found $CONFIG_FILE"
+else
+  echo "$CONFIG_FILE not found. This action requires a config file."
+  exit 1
+fi
+
+# Run gomarklint and capture output + exit code
+OUTPUT=$(gomarklint "$@" 2>&1) || true
+EXIT_CODE=${PIPESTATUS:-$?}
+
+# Re-run to get the real exit code since capturing swallows it
+gomarklint "$@" > /dev/null 2>&1
+EXIT_CODE=$?
+
+echo "$OUTPUT"
+
+# Post PR comment if enabled
+if [ "${INPUT_COMMENT_ON_PR:-false}" = "true" ]; then
+  if [ -z "${INPUT_GITHUB_TOKEN:-}" ]; then
+    echo "Warning: github-token is required for comment-on-pr. Skipping comment."
+  elif [ -z "${GITHUB_EVENT_NAME:-}" ] || [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+    echo "Not a pull_request event. Skipping comment."
+  else
+    MARKER="<!-- gomarklint-result -->"
+    REPO="${GITHUB_REPOSITORY}"
+
+    # Extract PR number from the event payload
+    PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+
+    if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+      echo "Could not determine PR number. Skipping comment."
+    else
+      # Build comment body
+      if [ $EXIT_CODE -eq 0 ]; then
+        BODY=$(printf '%s\n### gomarklint result\n\nNo issues found.\n' "$MARKER")
+      else
+        BODY=$(printf '%s\n### gomarklint result\n\n```\n%s\n```\n' "$MARKER" "$OUTPUT")
+      fi
+
+      # Search for existing comment with marker
+      EXISTING_COMMENT_ID=$(curl -s \
+        -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+        | jq -r ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+        | head -1)
+
+      if [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ]; then
+        # Update existing comment
+        curl -s -X PATCH \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+          -d "$(jq -n --arg body "$BODY" '{body: $body}')" > /dev/null
+        echo "Updated existing PR comment."
+      else
+        # Create new comment
+        curl -s -X POST \
+          -H "Authorization: token ${INPUT_GITHUB_TOKEN}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          -d "$(jq -n --arg body "$BODY" '{body: $body}')" > /dev/null
+        echo "Posted new PR comment."
+      fi
+    fi
+  fi
+fi
+
+exit $EXIT_CODE

--- a/testdata/action/sample.md
+++ b/testdata/action/sample.md
@@ -1,0 +1,1 @@
+## Hello, World


### PR DESCRIPTION
## Summary

- Move `action.yml`, `Dockerfile`, `entrypoint.sh` from the separate `shinagawa-web/gomarklint-action` repository into this repository
- Add `testdata/action/sample.md` for Action CI smoke test
- Add `.github/workflows/test-action.yml` to run the Action on relevant file changes
- Update README CI Integration section with Marketplace badge and corrected workflow example (`shinagawa-web/gomarklint@v2`)
- Update `CLAUDE.md` to document that the Action lives here — prevents Claude from suggesting to create one that already exists

## Why

The two-repo setup caused the Action to be invisible to anyone reading the main repository. Claude, contributors, and users reading the codebase would not know a GitHub Action existed and would suggest creating one. Consolidating into one repo makes the relationship obvious and eliminates the maintenance overhead of two separate release cycles.

## Test plan

- [ ] CI passes (lint, unit tests, E2E, benchmarks)
- [ ] `test-action.yml` workflow runs successfully on this PR
- [ ] README CI Integration section renders correctly
- [ ] `CLAUDE.md` note about the Action is clear

## Post-merge steps (tracked separately)

1. Create floating `v2` tag pointing to latest `v2.x.x` release — enables `uses: shinagawa-web/gomarklint@v2`
2. Re-register `shinagawa-web/gomarklint` on GitHub Marketplace to replace the `gomarklint-action` listing
3. Update `gomarklint-action` README with moved notice, then archive the repository