### PR TITLE
fix(action): rename to gomarklint for unique Marketplace listing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'gomarklint Markdown Linter'
+name: 'gomarklint'
 description: 'Catch broken links before your readers do.'
 author: 'shinagawa-web'
 inputs:


### PR DESCRIPTION
The name `gomarklint Markdown Linter` conflicts with the existing `shinagawa-web/gomarklint-action` Marketplace listing. Rename to `gomarklint` — unique, matches the tool name exactly.

After merging, update the `v2` floating tag and register on Marketplace.