### PR TITLE
ci: auto-update floating major tag (v2) on each release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,6 +33,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
+  update-major-tag:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update floating major version tag
+        run: |
+          MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
+          git tag -f "${MAJOR}" "${GITHUB_REF_NAME}"
+          git push origin "${MAJOR}" --force
+
   npm-publish:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Update floating major version tag
         run: |
           MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
-          git tag -f "${MAJOR}" "${GITHUB_REF_NAME}"
+          git tag -f "${MAJOR}" "${GITHUB_SHA}"
           git push origin "${MAJOR}" --force
 
   npm-publish:


### PR DESCRIPTION
Add a `update-major-tag` job to the release workflow that automatically moves the floating `v2` tag to the new release commit after each `v2.x.x` release.

Before this, updating `v2` was a manual step after every release. Now `uses: shinagawa-web/gomarklint@v2` always points to the latest release automatically.