### PR TITLE
fix(ci): restrict goreleaser trigger to semver tags only

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: write

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,6 +14,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Validate semver tag
+        run: |
+          if ! echo "${GITHUB_REF_NAME}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Tag '${GITHUB_REF_NAME}' is not a strict semver tag (e.g. v1.2.3). Skipping release."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The trigger `v*` matched floating tags like `v2`, causing GoReleaser to create unintended releases when the major version tag was updated.

Change to `v[0-9]*.[0-9]*.[0-9]*` so only semver tags like `v2.15.0` trigger the release pipeline.