### PR TITLE
ci: use gomarklint GitHub Action for Markdown lint step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,6 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        run: ./gomarklint README.md README.ja.md docs/content --config .gomarklint.ci.json
+        uses: shinagawa-web/gomarklint@v2
+        with:
+          args: README.md README.ja.md docs/content --config .gomarklint.ci.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Lint Markdown files
         uses: shinagawa-web/gomarklint@v2
         with:
-          args: README.md README.ja.md docs/content --config .gomarklint.ci.json
+          args: --config .gomarklint.ci.json

--- a/.gomarklint.ci.json
+++ b/.gomarklint.ci.json
@@ -1,4 +1,5 @@
 {
+  "include": ["README.md", "README.ja.md", "docs/content"],
   "default": true,
   "rules": {
     "heading-level": { "enabled": true, "severity": "error", "minLevel": 1 },


### PR DESCRIPTION
## Summary

- Replace `./gomarklint` binary invocation in `test.yml` with `shinagawa-web/gomarklint@v2` action
- Add `include` field to `.gomarklint.ci.json` so file paths don't need to be repeated in the workflow

## Test plan

- [ ] CI passes with the action running the Markdown lint step
- [ ] `@v2` tag resolves correctly and the action executes