### PR TITLE
ci: switch to pre-built GHCR image and bump action to v3

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -57,6 +57,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract major version
+        id: major
+        run: echo "tag=$(echo '${{ github.ref_name }}' | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -64,7 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/shinagawa-web/gomarklint:${{ github.ref_name }}
-            ghcr.io/shinagawa-web/gomarklint:v3
+            ghcr.io/shinagawa-web/gomarklint:${{ steps.major.outputs.tag }}
 
   npm-publish:
     needs: release

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,19 +40,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
-  update-major-tag:
+  push-docker:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
-      - name: Update floating major version tag
-        run: |
-          MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
-          git tag -f "${MAJOR}" "${GITHUB_SHA}"
-          git push origin "${MAJOR}" --force
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/shinagawa-web/gomarklint:${{ github.ref_name }}
+            ghcr.io/shinagawa-web/gomarklint:v3
 
   npm-publish:
     needs: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        uses: shinagawa-web/gomarklint@v3
+        uses: ./
         with:
           args: --config .gomarklint.ci.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        uses: ./
+        uses: shinagawa-web/gomarklint@v3
         with:
           args: --config .gomarklint.ci.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        uses: shinagawa-web/gomarklint@v2
+        uses: shinagawa-web/gomarklint@v3
         with:
           args: --config .gomarklint.ci.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-      - -X github.com/shinagawa-web/gomarklint/v2/cmd.version={{.Version}}
+      - -X github.com/shinagawa-web/gomarklint/v3/cmd.version={{.Version}}
     goos:
       - linux
       - windows

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shinagawa-web/gomarklint@v2
+      - uses: shinagawa-web/gomarklint@v3
 ```
 
 Without `args`, the action lints the files listed in the `include` field of `.gomarklint.json`. Pass `args` to override, e.g. `args: docs/`.

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/shinagawa-web/gomarklint:v3'
   args:
     - ${{ inputs.args }}
   env:

--- a/cmd/bench_content_test.go
+++ b/cmd/bench_content_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
 )
 
 // TestBenchmarkContentIsViolationFree verifies that generateComplexMarkdown

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/app"
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/app"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 var configFilePath string

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
 )
 
 // benchmarkConfig returns the linter configuration used for all CI benchmarks.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shinagawa-web/gomarklint/v2
+module github.com/shinagawa-web/gomarklint/v3
 
 go 1.25.0
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/file"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
-	"github.com/shinagawa-web/gomarklint/v2/internal/output"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/file"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/output"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // ErrLintViolations is returned when error-severity violations are found.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func writeTempFile(t *testing.T, name, content string) string {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/file"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/file"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // Linter performs linting on markdown files.

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 // mustNew calls New and fails the test if it returns an error.

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // Formatter is the interface for formatting lint results.

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // JSONFormatter formats lint results as JSON.

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func TestJSONFormatter_NoErrors(t *testing.T) {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 const (

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func TestTextFormatter_NoErrors(t *testing.T) {

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func setupTestServer() *httptest.Server {

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/shinagawa-web/gomarklint/v2/cmd"
-	"github.com/shinagawa-web/gomarklint/v2/internal/app"
+	"github.com/shinagawa-web/gomarklint/v3/cmd"
+	"github.com/shinagawa-web/gomarklint/v3/internal/app"
 )
 
 var osExit = os.Exit

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -28,7 +28,6 @@ if [[ -z "$BENCHSTAT" || ! -x "$BENCHSTAT" ]]; then
     exit 1
 fi
 
-PKGS=$(go list ./... | grep -v '/e2e')
 ORIGINAL_REF=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
 
 NEW_BENCH=$(mktemp "${TMPDIR:-/tmp}/gomarklint-bench.XXXXXX")
@@ -46,8 +45,9 @@ cleanup() {
 trap cleanup EXIT
 
 echo "==> Running benchmarks on $ORIGINAL_REF..."
+NEW_PKGS=$(go list ./... | grep -v '/e2e')
 # shellcheck disable=SC2086
-go test -bench=. -benchmem $PKGS -run='^$' > "$NEW_BENCH"
+go test -bench=. -benchmem $NEW_PKGS -run='^$' > "$NEW_BENCH"
 
 echo "==> Fetching origin/main for baseline..."
 if ! git fetch --quiet origin main; then
@@ -61,8 +61,9 @@ CHECKED_OUT_MAIN=true
 go mod download 2>/dev/null
 
 echo "==> Running benchmarks on origin/main..."
+OLD_PKGS=$(go list ./... | grep -v '/e2e')
 # shellcheck disable=SC2086
-go test -bench=. -benchmem $PKGS -run='^$' > "$OLD_BENCH"
+go test -bench=. -benchmem $OLD_PKGS -run='^$' > "$OLD_BENCH"
 
 echo "==> Returning to $ORIGINAL_REF..."
 git checkout --quiet "$ORIGINAL_REF"


### PR DESCRIPTION
## Summary

- \`action.yml\`: replaced \`image: 'Dockerfile'\` (builds on every CI run, ~19s) with \`docker://ghcr.io/shinagawa-web/gomarklint:v3\` (pull only)
- \`goreleaser.yml\`: removed broken \`update-major-tag\` job; added \`push-docker\` job that builds and pushes \`linux/amd64\` + \`linux/arm64\` image to GHCR on each release, tagging both the semver and the floating major version (e.g. \`v3.0.0\` → \`v3\`)
- \`go.mod\` and all Go source files: bumped module path from \`v2\` to \`v3\`
- \`test.yml\`, \`README.md\`: updated action reference from \`@v2\` to \`@v3\`
- \`scripts/bench-compare.sh\`: derive package list per branch so module path changes between branches no longer break the benchmark comparison

## After merge

1. Create \`v3.0.0\` semver tag — \`push-docker\` will push \`ghcr.io/shinagawa-web/gomarklint:v3\` and \`ghcr.io/shinagawa-web/gomarklint:v3.0.0\` automatically
2. The initial \`v3\` git tag already exists and points to this branch's HEAD