### PR TITLE
ci: restrict test-action to PR only and add Go source paths

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -27,7 +27,8 @@ jobs:
             if (title.startsWith('docs:') || title.startsWith('docs(')) {
               labels.push('documentation');
             }
-            if (title.startsWith('chore:') || title.startsWith('chore(')) {
+            if (title.startsWith('chore:') || title.startsWith('chore(') ||
+                title.startsWith('ci:') || title.startsWith('ci(')) {
               labels.push('chore');
             }
             if (title.startsWith('refactor:') || title.startsWith('refactor(')) {

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,9 +7,6 @@ on:
       - 'Dockerfile'
       - 'entrypoint.sh'
       - 'testdata/action/**'
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
 
 permissions:
   contents: read
@@ -17,24 +14,13 @@ permissions:
 jobs:
   test-action:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run gomarklint Action
-        uses: ./
-        with:
-          args: testdata/action
-
-  test-comment:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run gomarklint Action with PR comment
+      - name: Run gomarklint Action
         uses: ./
         with:
           args: testdata/action

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -9,6 +9,7 @@ on:
       - 'testdata/action/**'
       - '**/*.go'
       - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: read

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -7,6 +7,9 @@ on:
       - 'Dockerfile'
       - 'entrypoint.sh'
       - 'testdata/action/**'
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: read

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,19 +1,14 @@
 name: Test Action
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'action.yml'
-      - 'Dockerfile'
-      - 'entrypoint.sh'
-      - 'testdata/action/**'
   pull_request:
     paths:
       - 'action.yml'
       - 'Dockerfile'
       - 'entrypoint.sh'
       - 'testdata/action/**'
+      - '**/*.go'
+      - 'go.mod'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        uses: shinagawa-web/gomarklint@v2
+        uses: shinagawa-web/gomarklint@v3
         with:
           args: --config .gomarklint.ci.json


### PR DESCRIPTION
## Summary

- Remove `on.push` trigger — running after merge to main provides no safety net; if broken, the damage is already done
- Add `**/*.go` and `go.mod` to path filters so Go source changes also trigger a Docker image build and smoke test before merge

## Test plan

- [ ] Open a PR that changes a `.go` file and confirm `Test Action` workflow runs
- [ ] Confirm no `Test Action` run appears on a direct push to main