### PR TITLE
chore: bump Go module to v3 and prepare v3.0.0 release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,6 +40,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
+  update-major-tag:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update floating major version tag
+        run: |
+          MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
+          git tag -f "${MAJOR}" "${GITHUB_SHA}"
+          git push origin "${MAJOR}" --force
+
   push-docker:
     needs: release
     runs-on: ubuntu-latest

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -57,6 +57,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract major version
+        id: major
+        run: echo "tag=$(echo '${{ github.ref_name }}' | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -64,7 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/shinagawa-web/gomarklint:${{ github.ref_name }}
-            ghcr.io/shinagawa-web/gomarklint:v3
+            ghcr.io/shinagawa-web/gomarklint:${{ steps.major.outputs.tag }}
 
   npm-publish:
     needs: release

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,19 +40,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
-  update-major-tag:
+  push-docker:
     needs: release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
-      - name: Update floating major version tag
-        run: |
-          MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
-          git tag -f "${MAJOR}" "${GITHUB_SHA}"
-          git push origin "${MAJOR}" --force
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/shinagawa-web/gomarklint:${{ github.ref_name }}
+            ghcr.io/shinagawa-web/gomarklint:v3
 
   npm-publish:
     needs: release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-      - -X github.com/shinagawa-web/gomarklint/v2/cmd.version={{.Version}}
+      - -X github.com/shinagawa-web/gomarklint/v3/cmd.version={{.Version}}
     goos:
       - linux
       - windows

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,7 +52,7 @@ npm install -g @shinagawa-web/gomarklint
 **`go install` を使う場合:**
 
 ```sh
-go install github.com/shinagawa-web/gomarklint/v2@latest
+go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
 - **100,000 行以上を約 170ms** で処理 — JIT ウォームアップなし、ランタイムオーバーヘッドなし。
@@ -90,7 +90,7 @@ jobs:
 ```yaml
 repos:
   - repo: https://github.com/shinagawa-web/gomarklint
-    rev: v2.8.0
+    rev: v3.0.0
     hooks:
       - id: gomarklint
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shinagawa-web/gomarklint@v2
+      - uses: shinagawa-web/gomarklint@v3
 ```
 
 Without `args`, the action lints the files listed in the `include` field of `.gomarklint.json`. Pass `args` to override, e.g. `args: docs/`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install -g @shinagawa-web/gomarklint
 **Via `go install`:**
 
 ```sh
-go install github.com/shinagawa-web/gomarklint/v2@latest
+go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
 - **100,000+ lines in ~170ms** — single binary, no JIT warmup, no runtime overhead.
@@ -94,7 +94,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/shinagawa-web/gomarklint
-    rev: v2.8.0
+    rev: v3.0.0
     hooks:
       - id: gomarklint
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/shinagawa-web/gomarklint:v3'
   args:
     - ${{ inputs.args }}
   env:

--- a/cmd/bench_content_test.go
+++ b/cmd/bench_content_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
 )
 
 // TestBenchmarkContentIsViolationFree verifies that generateComplexMarkdown

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/app"
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/app"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 var configFilePath string

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
 )
 
 // benchmarkConfig returns the linter configuration used for all CI benchmarks.

--- a/docs/content/docs/migration.md
+++ b/docs/content/docs/migration.md
@@ -32,7 +32,7 @@ brew install shinagawa-web/tap/gomarklint
 npm install -g @shinagawa-web/gomarklint
 
 # go install
-go install github.com/shinagawa-web/gomarklint/v2@latest
+go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
 Remove the old linter from your project:

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -28,7 +28,7 @@ npm install -g @shinagawa-web/gomarklint
 **Via `go install`:**
 
 ```sh
-go install github.com/shinagawa-web/gomarklint/v2@latest
+go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
 **Download binary** (no Go required):

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shinagawa-web/gomarklint/v2
+module github.com/shinagawa-web/gomarklint/v3
 
 go 1.25.0
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/file"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
-	"github.com/shinagawa-web/gomarklint/v2/internal/output"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/file"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/output"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // ErrLintViolations is returned when error-severity violations are found.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/linter"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func writeTempFile(t *testing.T, name, content string) string {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
-	"github.com/shinagawa-web/gomarklint/v2/internal/file"
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/file"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // Linter performs linting on markdown files.

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 // mustNew calls New and fails the test if it returns an error.

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // Formatter is the interface for formatting lint results.

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 // JSONFormatter formats lint results as JSON.

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func TestJSONFormatter_NoErrors(t *testing.T) {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/config"
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 )
 
 const (

--- a/internal/output/text_test.go
+++ b/internal/output/text_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func TestTextFormatter_NoErrors(t *testing.T) {

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -30,7 +30,7 @@ const (
 	// DefaultRetryDelayMs is the default delay in milliseconds before retrying a failed HTTP request
 	DefaultRetryDelayMs = 1000
 
-	userAgent = "gomarklint/v2 (+https://github.com/shinagawa-web/gomarklint)"
+	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )
 
 // defaultAllowedStatuses contains status codes never treated as link failures.

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/shinagawa-web/gomarklint/v2/internal/rule"
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
 func setupTestServer() *httptest.Server {

--- a/main.go
+++ b/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/shinagawa-web/gomarklint/v2/cmd"
-	"github.com/shinagawa-web/gomarklint/v2/internal/app"
+	"github.com/shinagawa-web/gomarklint/v3/cmd"
+	"github.com/shinagawa-web/gomarklint/v3/internal/app"
 )
 
 var osExit = os.Exit

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -28,7 +28,6 @@ if [[ -z "$BENCHSTAT" || ! -x "$BENCHSTAT" ]]; then
     exit 1
 fi
 
-PKGS=$(go list ./... | grep -v '/e2e')
 ORIGINAL_REF=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
 
 NEW_BENCH=$(mktemp "${TMPDIR:-/tmp}/gomarklint-bench.XXXXXX")
@@ -46,8 +45,9 @@ cleanup() {
 trap cleanup EXIT
 
 echo "==> Running benchmarks on $ORIGINAL_REF..."
+NEW_PKGS=$(go list ./... | grep -v '/e2e')
 # shellcheck disable=SC2086
-go test -bench=. -benchmem $PKGS -run='^$' > "$NEW_BENCH"
+go test -bench=. -benchmem $NEW_PKGS -run='^$' > "$NEW_BENCH"
 
 echo "==> Fetching origin/main for baseline..."
 if ! git fetch --quiet origin main; then
@@ -61,8 +61,9 @@ CHECKED_OUT_MAIN=true
 go mod download 2>/dev/null
 
 echo "==> Running benchmarks on origin/main..."
+OLD_PKGS=$(go list ./... | grep -v '/e2e')
 # shellcheck disable=SC2086
-go test -bench=. -benchmem $PKGS -run='^$' > "$OLD_BENCH"
+go test -bench=. -benchmem $OLD_PKGS -run='^$' > "$OLD_BENCH"
 
 echo "==> Returning to $ORIGINAL_REF..."
 git checkout --quiet "$ORIGINAL_REF"


### PR DESCRIPTION
## Summary

- Switch CI to pre-built GHCR image and bump action references to v3
- Update Go module path from `github.com/shinagawa-web/gomarklint/v2` to `github.com/shinagawa-web/gomarklint/v3` across all files
- Fix benchmark harness to derive package list dynamically per branch

These commits were developed on the `feat/v3-prebuilt-docker-image` branch and are now being integrated into main as the final preparation for the v3.0.0 release. After this PR is merged, the `v3.0.0` tag will be pushed to trigger the release workflow.

## Test plan

- [x] All unit tests pass (100% coverage)
- [x] All E2E tests pass
- [x] Static lint passes
- [x] Benchmark comparison shows no regression