### PR TITLE
fix: restrict goreleaser workflow to read-all top-level permissions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,8 +5,7 @@ on:
     tags:
       - 'v[0-9]*.[0-9]*.[0-9]*'
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Change top-level `permissions: contents: write` to `permissions: read-all` in `goreleaser.yml`
- All jobs already have their own job-level permissions — no behaviour change

Fixes OpenSSF Scorecard `Token-Permissions` check (currently 0/10).

Closes #254

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Confirm next release workflow still succeeds (job-level permissions unchanged)