### PR TITLE
feat: add SLSA L3 provenance to release artifacts

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,6 +10,8 @@ permissions: read-all
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     permissions:
       contents: write
     steps:
@@ -23,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0 
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -38,6 +40,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Generate artifact hashes
+        id: hash
+        run: |
+          hashes=$(base64 -w0 < dist/checksums.txt)
+          echo "hashes=$hashes" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: release
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: true
 
   update-major-tag:
     needs: release


### PR DESCRIPTION
## Summary

- Add `outputs: hashes` to the `release` job to expose `checksums.txt` as base64-encoded hashes
- Add a `provenance` job that calls `slsa-framework/slsa-github-generator` generic reusable workflow at SLSA Build L3
- The `.intoto.jsonl` provenance file is automatically attached to each GitHub Release

Closes #253

## What changes

```
release (GoReleaser → outputs checksums hash)
  ├── provenance (slsa-github-generator L3)  ← new
  ├── update-major-tag
  ├── push-docker
  └── npm-publish
```

## Verification (after next release)

```sh
slsa-verifier verify-artifact gomarklint_Linux_x86_64.tar.gz \
  --provenance-path gomarklint_*.intoto.jsonl \
  --source-uri github.com/shinagawa-web/gomarklint
```

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Tag a release and verify `.intoto.jsonl` appears in release assets
- [ ] Verify with `slsa-verifier` locally