### PR TITLE
fix: use glob to find GoReleaser checksums file in SLSA workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -44,7 +44,12 @@ jobs:
       - name: Generate artifact hashes
         id: hash
         run: |
-          hashes=$(base64 -w0 < dist/*_checksums.txt)
+          files=(dist/*_checksums.txt)
+          if [[ ${#files[@]} -ne 1 ]]; then
+            echo "Expected exactly one checksums file, found: ${files[*]}" >&2
+            exit 1
+          fi
+          hashes=$(base64 -w0 < "${files[0]}")
           echo "hashes=$hashes" >> "$GITHUB_OUTPUT"
 
   provenance:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate artifact hashes
         id: hash
         run: |
-          hashes=$(base64 -w0 < dist/checksums.txt)
+          hashes=$(base64 -w0 < dist/*_checksums.txt)
           echo "hashes=$hashes" >> "$GITHUB_OUTPUT"
 
   provenance:


### PR DESCRIPTION
## Summary

GoReleaser names the checksums file `gomarklint_{version}_checksums.txt`, not `checksums.txt`. The previous implementation used a hardcoded path that didn't exist, causing the `Generate artifact hashes` step to fail.

Fix: use `dist/*_checksums.txt` glob to match the actual filename.

## Test plan

- [ ] Merge and tag a new release to confirm the `provenance` job completes successfully
- [ ] Verify `.intoto.jsonl` appears in release assets