### PR TITLE
fix(ci): compile SLSA generator from source to fix SHA-pinned ref failure

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -62,6 +62,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true
+      compile-generator: true
 
   update-major-tag:
     needs: release


### PR DESCRIPTION
## Summary

- Adds `compile-generator: true` to the `provenance` job in `goreleaser.yml`
- Closes #262 (supersedes it with a correct root-cause fix)

## Root cause

The previous workaround in #262 (`private-repository: true`) was based on an incorrect diagnosis.

The actual failure chain in the v3.0.2 release run was:

```
BUILDER_REF: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
Invalid ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a. Expected ref of the form refs/tags/vX.Y.Z
```

When the caller pins the reusable workflow with `@<sha>`, `detect-workflow-js` emits the raw 40-char commit SHA as `BUILDER_REF`. `builder-fetch.sh` inside slsa-github-generator requires `BUILDER_REF` to start with `refs/tags/` before it will download the pre-built binary, so it exits 2. The SHA resolution code that exists later in the script is never reached.

This affects **both v2.0.0 and v2.1.0** and is independent of `private-repository`. The privacy-check (`if repoResp.data.private && !override`) always passes for this public repository — it was never the root cause.

## Fix

`compile-generator: true` switches from the download path (`builder-fetch.sh`) to the compile-from-source path (`git checkout <sha>` + `go build`), which accepts a bare SHA ref without the `refs/tags/` prefix requirement.

## Smoke test

Verified via `workflow_dispatch` on this branch (run [25362560733](https://github.com/shinagawa-web/gomarklint/actions/runs/25362560733)) with a valid base64-encoded subject. All provenance jobs passed:

- `provenance-test / detect-env` ✅
- `provenance-test / generator` ✅ (Generate builder, Create and sign provenance, Upload the signed provenance)
- `provenance-test / final` ✅

This is the first run where `provenance-test / final` succeeded. The `private-repository: true` workaround in #262 did not pass this test.

## Upstream

Filed slsa-framework/slsa-github-generator#4503 with a proposed fix (PR slsa-framework/slsa-github-generator#4502) so that the default `compile-generator: false` path can also handle bare SHA refs in a future release.

## Test plan

- [x] Smoke-tested via `workflow_dispatch` on this branch
- [ ] Push `v3.0.3` tag and verify the `provenance` job succeeds and `.intoto.jsonl` is attached to the release