### PR TITLE
docs: update gomarklint init example to current config format

### DIFF
--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -70,18 +70,35 @@ This creates `.gomarklint.json` with sensible defaults:
 
 ```json
 {
-  "minHeadingLevel": 2,
-  "enableLinkCheck": false,
-  "linkCheckTimeoutSeconds": 5,
-  "skipLinkPatterns": [],
+  "default": true,
+  "rules": {
+    "final-blank-line": true,
+    "unclosed-code-block": true,
+    "empty-alt-text": true,
+    "fenced-code-language": true,
+    "heading-level": { "severity": "error", "minLevel": 2 },
+    "duplicate-heading": true,
+    "no-multiple-blank-lines": true,
+    "no-setext-headings": true,
+    "single-h1": true,
+    "blanks-around-headings": true,
+    "no-bare-urls": true,
+    "no-empty-links": true,
+    "no-emphasis-as-heading": true,
+    "blanks-around-lists": true,
+    "blanks-around-fences": true,
+    "no-hard-tabs": true,
+    "no-trailing-punctuation": { "punctuation": ".,;:!" },
+    "consistent-code-fence": { "style": "consistent" },
+    "consistent-emphasis-style": { "style": "consistent" },
+    "consistent-list-marker": { "style": "consistent" },
+    "max-line-length": { "enabled": false, "lineLength": 80 },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
+    "link-fragments": { "enabled": false, "slug-algorithm": "github" }
+  },
   "include": ["README.md", "testdata"],
   "ignore": [],
-  "output": "text",
-  "enableDuplicateHeadingCheck": true,
-  "enableHeadingLevelCheck": true,
-  "enableNoMultipleBlankLinesCheck": true,
-  "enableNoSetextHeadingsCheck": true,
-  "enableFinalBlankLineCheck": true
+  "output": "text"
 }
 ```
 


### PR DESCRIPTION
## Summary

- The Quick Start guide showed a v1 flat config format (`enableXxxCheck`, `minHeadingLevel`, etc.) in the `gomarklint init` section
- Updated to the current `rules`-object format that matches `DefaultConfigJSON` in `internal/config/config.go`

## Test plan

- [x] JSON block in `docs/content/docs/quick-start.md` now matches `DefaultConfigJSON` in `internal/config/config.go`