### PR TITLE
ci: add invisible Unicode character check

### DIFF
--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -1,0 +1,28 @@
+name: Check Invisible Unicode
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for invisible Unicode characters
+        run: |
+          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]' \
+            --include="*.go" \
+            --include="*.sh" \
+            .; then
+            echo "Invisible Unicode characters detected. Review the matches above."
+            exit 1
+          fi

--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -6,8 +6,14 @@ permissions:
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - '**.sh'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - '**.sh'
 
 jobs:
   check:
@@ -19,10 +25,16 @@ jobs:
 
       - name: Scan for invisible Unicode characters
         run: |
-          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
+          grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
             --include="*.go" \
             --include="*.sh" \
-            .; then
+            . || status=$?
+          if [ "${status:-0}" -eq 2 ]; then
+            echo "grep encountered an error. Scan could not complete."
+            exit 2
+          elif [ "${status:-0}" -eq 1 ]; then
+            exit 0
+          else
             echo "Invisible Unicode characters detected. Review the matches above."
             exit 1
           fi

--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Scan for invisible Unicode characters
         run: |
-          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]' \
+          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
             --include="*.go" \
             --include="*.sh" \
             .; then


### PR DESCRIPTION
Closes #267

## Summary

- Adds a CI workflow that scans Go and shell script files for invisible Unicode characters
- Detects zero-width characters (U+200B/C/D, U+2060, U+FEFF) and supplemental variation selectors (U+E0100–E01EF)
- Fails the build if any match is found, blocking contaminated contributions
- Treats grep exit code 2 as a hard failure so scan errors cannot silently bypass the check
- Runs only when `*.go` or `*.sh` files change (paths filter)

## Background

The GlassWorm attack (reported April 2026) embeds malicious code inside invisible Unicode variation selector characters. A single visible line can hide ~18,000 lines of hidden code. 151+ GitHub repos and 72+ VS Code extensions were confirmed compromised.

## Scope

Scans `*.go` and `*.sh` files only. Markdown and other docs are excluded to avoid false positives from legitimate emoji variant selectors (U+FE0F).