### PR TITLE
fix(external-link): fall back to GET when HEAD returns 403 or 405

### DIFF
--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -207,13 +207,15 @@ func performCheck(client *http.Client, url string) (int, error) {
 
 	resp, err := client.Do(req)
 	if err == nil {
-		defer func() {
-			_ = resp.Body.Close()
-		}()
-		return resp.StatusCode, nil
+		_ = resp.Body.Close()
+		// Some servers reject HEAD with 405 (Method Not Allowed) or 403 (Forbidden)
+		// but serve GET normally. Fall back to GET in those cases.
+		if resp.StatusCode != http.StatusMethodNotAllowed && resp.StatusCode != http.StatusForbidden {
+			return resp.StatusCode, nil
+		}
 	}
 
-	// fallback to GET: reuse the existing request to avoid a second NewRequest call
+	// fallback to GET: covers both network errors and HEAD 405/403
 	req.Method = "GET"
 
 	resp, err = client.Do(req)

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -644,6 +644,70 @@ func TestCheckExternalLinks_GETFallback(t *testing.T) {
 	}
 }
 
+func TestCheckExternalLinks_GETFallback_On405(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
+	lines, offset := toLines(markdown)
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+
+	if len(results) != 0 {
+		t.Errorf("expected no errors (GET fallback on 405 should succeed), got: %v", results)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 link checked, got %d", count)
+	}
+}
+
+func TestCheckExternalLinks_GETFallback_On403(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
+	lines, offset := toLines(markdown)
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+
+	if len(results) != 0 {
+		t.Errorf("expected no errors (GET fallback on 403 should succeed), got: %v", results)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 link checked, got %d", count)
+	}
+}
+
+func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
+	var methods []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
+	lines, offset := toLines(markdown)
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+
+	if len(results) != 1 {
+		t.Errorf("expected 1 error for 404, got: %v", results)
+	}
+	if len(methods) != 1 || methods[0] != http.MethodHead {
+		t.Errorf("expected only HEAD request for 404 (no GET fallback), got: %v", methods)
+	}
+}
+
 func TestCheckExternalLinks_429NotFlagged(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -689,9 +689,12 @@ func TestCheckExternalLinks_GETFallback_On403(t *testing.T) {
 }
 
 func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
+	var mu sync.Mutex
 	var methods []string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		methods = append(methods, r.Method)
+		mu.Unlock()
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
@@ -700,6 +703,8 @@ func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
 	lines, offset := toLines(markdown)
 	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
 
+	mu.Lock()
+	defer mu.Unlock()
 	if len(results) != 1 {
 		t.Errorf("expected 1 error for 404, got: %v", results)
 	}


### PR DESCRIPTION
Closes #274

## Summary

- Fall back to GET when HEAD returns 403 (Forbidden) or 405 (Method Not Allowed)
- Previously these were reported as broken links even though GET would succeed
- Adds three new test cases covering 405→GET, 403→GET, and 404 (no fallback)

## Changes

`performCheck` in `internal/rule/external_link.go`:

**Before:** GET fallback only triggered on network-level HEAD error  
**After:** GET fallback also triggered on HEAD 403 and 405