### PR TITLE
feat(output): add JUnit XML output format

### DIFF
--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -1,0 +1,28 @@
+name: Check Invisible Unicode
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for invisible Unicode characters
+        run: |
+          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]' \
+            --include="*.go" \
+            --include="*.sh" \
+            .; then
+            echo "Invisible Unicode characters detected. Review the matches above."
+            exit 1
+          fi

--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -6,8 +6,14 @@ permissions:
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - '**.sh'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**.go'
+      - '**.sh'
 
 jobs:
   check:
@@ -19,10 +25,16 @@ jobs:
 
       - name: Scan for invisible Unicode characters
         run: |
-          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
+          grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
             --include="*.go" \
             --include="*.sh" \
-            .; then
+            . || status=$?
+          if [ "${status:-0}" -eq 2 ]; then
+            echo "grep encountered an error. Scan could not complete."
+            exit 2
+          elif [ "${status:-0}" -eq 1 ]; then
+            exit 0
+          else
             echo "Invisible Unicode characters detected. Review the matches above."
             exit 1
           fi

--- a/.github/workflows/check-invisible-unicode.yml
+++ b/.github/workflows/check-invisible-unicode.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Scan for invisible Unicode characters
         run: |
-          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{FE00}-\x{FE0F}\x{E0100}-\x{E01EF}]' \
+          if grep -rPn '[\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{E0100}-\x{E01EF}]' \
             --include="*.go" \
             --include="*.sh" \
             .; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout code
@@ -41,6 +44,13 @@ jobs:
           fail_ci_if_error: true
 
       - name: Lint Markdown files
-        uses: shinagawa-web/gomarklint@fa7f82ab243d82375836601e98e9e4171903e95f # v3
+        run: ./gomarklint --output junit --config .gomarklint.ci.json > gomarklint.xml
+        continue-on-error: true
+
+      - name: Publish gomarklint results
+        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
+        if: always()
         with:
-          args: --config .gomarklint.ci.json
+          report_paths: gomarklint.xml
+          check_name: gomarklint
+          fail_on_failure: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,3 +54,4 @@ jobs:
           report_paths: gomarklint.xml
           check_name: gomarklint
           fail_on_failure: true
+          include_passed: true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.SilenceErrors = true
 	rootCmd.Flags().StringVar(&configFilePath, "config", ".gomarklint.json", "path to config file (default: .gomarklint.json)")
-	rootCmd.Flags().StringVar(&outputFormat, "output", "text", "output format: text or json")
+	rootCmd.Flags().StringVar(&outputFormat, "output", "text", "output format: text, json, or junit")
 	rootCmd.Flags().StringVar(&minSeverity, "severity", "warning", "minimum severity to report: warning or error")
 
 	rootCmd.AddCommand(initCmd)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,9 +74,12 @@ func Run(w io.Writer, opts Options) error {
 
 func formatOutput(w io.Writer, cfg config.Config, result *linter.Result, fileCount int, duration time.Duration) error {
 	var formatter output.Formatter
-	if cfg.OutputFormat == "json" {
+	switch cfg.OutputFormat {
+	case "json":
 		formatter = output.NewJSONFormatter()
-	} else {
+	case "junit":
+		formatter = output.NewJUnitFormatter()
+	default:
 		formatter = output.NewTextFormatter()
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -119,6 +119,23 @@ func TestRun_OutputFormatOverride(t *testing.T) {
 	}
 }
 
+func TestRun_JUnitOutputFormat(t *testing.T) {
+	f := writeTempFile(t, "valid.md", "## Hello\n\nWorld.\n")
+
+	var buf bytes.Buffer
+	err := Run(&buf, Options{
+		ConfigPath:   "/nonexistent/.gomarklint.json",
+		Args:         []string{f},
+		OutputFormat: "junit",
+	})
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), `<testsuites`) {
+		t.Errorf("expected JUnit XML output, got: %s", buf.String())
+	}
+}
+
 func TestRun_MinSeverityOverride(t *testing.T) {
 	cfgFile := writeTempFile(t, "warning-rule.json", `{
 		"default": false,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,7 +170,7 @@ type Config struct {
 	// Ignore lists glob patterns to exclude from linting.
 	Ignore []string `json:"ignore"`
 
-	// OutputFormat controls output: "text" or "json".
+	// OutputFormat controls output: "text", "json", or "junit".
 	OutputFormat string `json:"output"`
 
 	// MinSeverity filters output: only report rules at or above this severity ("warning" or "error").

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -37,8 +37,8 @@ func MergeFlags(cfg Config, cmd *cobra.Command, flags FlagValues) Config {
 
 // Validate checks if the configuration values are valid.
 func Validate(cfg Config) error {
-	if cfg.OutputFormat != "text" && cfg.OutputFormat != "json" {
-		return fmt.Errorf("invalid output format: %q (must be 'text' or 'json')", cfg.OutputFormat)
+	if cfg.OutputFormat != "text" && cfg.OutputFormat != "json" && cfg.OutputFormat != "junit" {
+		return fmt.Errorf("invalid output format: %q (must be 'text', 'json', or 'junit')", cfg.OutputFormat)
 	}
 	switch cfg.MinSeverity {
 	case SeverityWarning, SeverityError:

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -1,0 +1,100 @@
+package output
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+)
+
+// JUnitFormatter formats lint results as JUnit XML.
+type JUnitFormatter struct{}
+
+// NewJUnitFormatter creates a new JUnitFormatter.
+func NewJUnitFormatter() *JUnitFormatter {
+	return &JUnitFormatter{}
+}
+
+type junitTestSuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Name     string           `xml:"name,attr"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Time     string           `xml:"time,attr"`
+	Suites   []junitTestSuite `xml:"testsuite"`
+}
+
+type junitTestSuite struct {
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Cases    []junitTestCase `xml:"testcase"`
+}
+
+type junitTestCase struct {
+	Name      string        `xml:"name,attr"`
+	Classname string        `xml:"classname,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+}
+
+// Format implements the Formatter interface for JUnit XML output.
+func (f *JUnitFormatter) Format(w io.Writer, result *Result) error {
+	totalTests := 0
+	totalFailures := 0
+	suites := make([]junitTestSuite, 0, len(result.OrderedPaths))
+
+	for _, path := range result.OrderedPaths {
+		errs := result.Details[path]
+		suite := junitTestSuite{
+			Name: path,
+		}
+		if len(errs) == 0 {
+			suite.Tests = 1
+			suite.Cases = []junitTestCase{{Name: path, Classname: path}}
+		} else {
+			suite.Tests = len(errs)
+			suite.Failures = len(errs)
+			suite.Cases = make([]junitTestCase, 0, len(errs))
+			for _, e := range errs {
+				severity := e.Severity
+				if severity == "" {
+					severity = "error"
+				}
+				tc := junitTestCase{
+					Name:      fmt.Sprintf("line %d: %s", e.Line, e.Message),
+					Classname: path,
+					Failure: &junitFailure{
+						Message: e.Message,
+						Type:    severity,
+					},
+				}
+				suite.Cases = append(suite.Cases, tc)
+			}
+		}
+		totalTests += suite.Tests
+		totalFailures += suite.Failures
+		suites = append(suites, suite)
+	}
+
+	root := junitTestSuites{
+		Name:     "gomarklint",
+		Tests:    totalTests,
+		Failures: totalFailures,
+		Time:     fmt.Sprintf("%.2f", result.Duration.Seconds()),
+		Suites:   suites,
+	}
+
+	if _, err := fmt.Fprint(w, xml.Header); err != nil {
+		return err
+	}
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	if err := enc.Encode(root); err != nil {
+		return err
+	}
+	return enc.Flush()
+}

--- a/internal/output/junit_test.go
+++ b/internal/output/junit_test.go
@@ -1,0 +1,203 @@
+package output
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
+)
+
+func TestJUnitFormatter_NoErrors(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files:        2,
+		Lines:        100,
+		Total:        0,
+		Duration:     420 * time.Millisecond,
+		Details:      map[string][]rule.LintError{},
+		OrderedPaths: []string{"README.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	assertContains(t, output, `<?xml version="1.0" encoding="UTF-8"?>`)
+	assertContains(t, output, `name="gomarklint"`)
+	assertContains(t, output, `failures="0"`)
+	assertContains(t, output, `name="README.md"`)
+	// passing file: single testcase with no failure child
+	assertNotContains(t, output, "<failure")
+}
+
+func TestJUnitFormatter_WithErrors(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files: 1,
+		Lines: 50,
+		Total: 2,
+		Details: map[string][]rule.LintError{
+			"docs/guide.md": {
+				{File: "docs/guide.md", Line: 12, Message: "Link unreachable: https://example.com/broken", Severity: "error"},
+				{File: "docs/guide.md", Line: 5, Message: "heading-increment", Severity: "error"},
+			},
+		},
+		Duration:     420 * time.Millisecond,
+		OrderedPaths: []string{"docs/guide.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	assertContains(t, output, `tests="2"`)
+	assertContains(t, output, `failures="2"`)
+	assertContains(t, output, `name="docs/guide.md"`)
+	assertContains(t, output, `line 12: Link unreachable`)
+	assertContains(t, output, `line 5: heading-increment`)
+	assertContains(t, output, `type="error"`)
+}
+
+func TestJUnitFormatter_MixedFiles(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files: 2,
+		Lines: 80,
+		Total: 1,
+		Details: map[string][]rule.LintError{
+			"docs/guide.md": {
+				{File: "docs/guide.md", Line: 12, Message: "Link unreachable", Severity: "error"},
+			},
+		},
+		Duration:     420 * time.Millisecond,
+		OrderedPaths: []string{"docs/guide.md", "README.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	// total tests: 1 violation + 1 passing testcase = 2
+	assertContains(t, output, `tests="2"`)
+	assertContains(t, output, `failures="1"`)
+}
+
+func TestJUnitFormatter_WarningType(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files: 1,
+		Lines: 20,
+		Total: 1,
+		Details: map[string][]rule.LintError{
+			"file.md": {
+				{File: "file.md", Line: 3, Message: "setext heading", Severity: "warning"},
+			},
+		},
+		Duration:     100 * time.Millisecond,
+		OrderedPaths: []string{"file.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, buf.String(), `type="warning"`)
+}
+
+func TestJUnitFormatter_DefaultSeverity(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files: 1,
+		Lines: 10,
+		Total: 1,
+		Details: map[string][]rule.LintError{
+			"file.md": {
+				{File: "file.md", Line: 1, Message: "some issue"},
+			},
+		},
+		Duration:     50 * time.Millisecond,
+		OrderedPaths: []string{"file.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, buf.String(), `type="error"`)
+}
+
+func TestJUnitFormatter_TimeFormatting(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files:        1,
+		Lines:        10,
+		Total:        0,
+		Duration:     1234 * time.Millisecond,
+		Details:      map[string][]rule.LintError{},
+		OrderedPaths: []string{"file.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), `time="1.23"`) {
+		t.Errorf("expected time=1.23, got: %s", buf.String())
+	}
+}
+
+func TestJUnitFormatter_ValidXML(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files: 2,
+		Lines: 100,
+		Total: 1,
+		Details: map[string][]rule.LintError{
+			"docs/guide.md": {
+				{File: "docs/guide.md", Line: 12, Message: "Link unreachable: https://example.com/broken", Severity: "error"},
+			},
+		},
+		Duration:     420 * time.Millisecond,
+		OrderedPaths: []string{"docs/guide.md", "README.md"},
+	}
+
+	var buf bytes.Buffer
+	if err := formatter.Format(&buf, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var decoded interface{}
+	if err := xml.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid XML: %v", err)
+	}
+}
+
+func TestJUnitFormatter_WriteError(t *testing.T) {
+	formatter := NewJUnitFormatter()
+	result := &Result{
+		Files:        1,
+		Lines:        10,
+		Total:        0,
+		Duration:     100 * time.Millisecond,
+		Details:      map[string][]rule.LintError{},
+		OrderedPaths: []string{},
+	}
+
+	ew := &errorWriter{}
+	err := formatter.Format(ew, result)
+	if err == nil {
+		t.Error("expected error when writing to errorWriter")
+	}
+}

--- a/internal/output/junit_test.go
+++ b/internal/output/junit_test.go
@@ -195,9 +195,20 @@ func TestJUnitFormatter_WriteError(t *testing.T) {
 		OrderedPaths: []string{},
 	}
 
-	ew := &errorWriter{}
-	err := formatter.Format(ew, result)
-	if err == nil {
-		t.Error("expected error when writing to errorWriter")
-	}
+	t.Run("HeaderWriteError", func(t *testing.T) {
+		ew := &errorWriter{}
+		err := formatter.Format(ew, result)
+		if err == nil {
+			t.Error("expected error when writing to errorWriter")
+		}
+	})
+
+	t.Run("EncodeError", func(t *testing.T) {
+		// Allow xml.Header (39 bytes) through, then fail on enc.Encode's internal flush.
+		lw := &limitedErrorWriter{limit: 39}
+		err := formatter.Format(lw, result)
+		if err == nil {
+			t.Error("expected error when encode flush fails")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Adds `--output junit` (or `"output": "junit"` in config) to produce JUnit XML consumable by CI/CD test report dashboards
- Each file maps to a `<testsuite>`; each violation maps to a `<testcase>` with `<failure>`; files with no violations emit a single passing `<testcase>` so they appear in the report
- `time` attribute on `<testsuites>` reflects actual elapsed time in seconds
- CI now generates JUnit XML from the built binary and publishes it via `mikepenz/action-junit-report` — gomarklint violations appear in the **Checks** tab as annotations

## Files changed

- `internal/output/junit.go` — new `JUnitFormatter` implementing `Formatter`
- `internal/output/junit_test.go` — unit tests covering no-error, error, warning, mixed, XML validity, and write-error paths
- `internal/app/app.go` — added `"junit"` branch in `formatOutput`
- `internal/config/config.go` — updated comment to include `"junit"`
- `internal/config/merge.go` — added `"junit"` to valid `output_format` values and updated error message
- `cmd/root.go` — updated `--output` flag help text
- `.github/workflows/test.yml` — replaced Docker action lint step with binary + JUnit output; added `mikepenz/action-junit-report` step; added `checks: write` permission

## Test plan

- [x] `make test` — all unit tests pass, coverage 100%
- [x] `make static-lint` — 0 issues
- [x] Pre-push hook passed (lint + unit tests + E2E + self-lint + benchmark comparison)

Closes #271