### PR TITLE
fix(external-link): allow balanced parentheses in URLs (DOI, Wikipedia style)

### DIFF
--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -10,9 +10,10 @@ import (
 
 var (
 	// Link pattern matchers
-	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://[^\s)]+)\)`)
-	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://[^\s)]+)\)`)
-	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://[^\s<>"'()]+).*?$`)
+	// Inline/image patterns allow balanced (...) groups inside the URL per CommonMark spec.
+	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://(?:[^\s()\[\]]+|\([^\s()]*\))*)\)`)
+	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://(?:[^\s()\[\]]+|\([^\s()]*\))*)\)`)
+	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://(?:[^\s<>"'()]+|\([^\s<>"'()]*\))+).*?$`)
 )
 
 type cacheResult struct {

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -11,8 +11,10 @@ import (
 var (
 	// Link pattern matchers
 	// Inline/image patterns allow balanced (...) groups inside the URL per CommonMark spec.
-	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://(?:[^\s()\[\]]+|\([^\s()]*\))*)\)`)
-	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://(?:[^\s()\[\]]+|\([^\s()]*\))*)\)`)
+	// [^\s()]+ allows square brackets (needed for IPv6 hosts like https://[::1]/).
+	// + quantifier ensures at least one character after the scheme (rejects bare https://).
+	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://(?:[^\s()]+|\([^\s()]*\))+)\)`)
+	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://(?:[^\s()]+|\([^\s()]*\))+)\)`)
 	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://(?:[^\s<>"'()]+|\([^\s<>"'()]*\))+).*?$`)
 )
 

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -620,6 +620,31 @@ See (https://example.com/page) for details.
 				{URL: "https://example.com/page", Line: 2},
 			},
 		},
+		{
+			name: "inline link with IPv6 host",
+			input: `
+[local](https://[::1]/path)
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://[::1]/path", Line: 2},
+			},
+		},
+		{
+			name: "image link with IPv6 host",
+			input: `
+![img](https://[::1]/image.png)
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://[::1]/image.png", Line: 2},
+			},
+		},
+		{
+			name: "scheme-only URL is not extracted",
+			input: `
+[broken](https://)
+`,
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -584,6 +584,42 @@ See [link1](https://first.com) and [link2](https://second.com)
 				{URL: "https://example.com/img.png", Line: 2},
 			},
 		},
+		{
+			name: "inline link with parentheses in URL (DOI style)",
+			input: `
+[DOI](https://doi.org/10.1016/0026-0495(67)90027-3)
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://doi.org/10.1016/0026-0495(67)90027-3", Line: 2},
+			},
+		},
+		{
+			name: "bare URL with parentheses (DOI style)",
+			input: `
+https://doi.org/10.1016/0026-0495(67)90027-3
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://doi.org/10.1016/0026-0495(67)90027-3", Line: 2},
+			},
+		},
+		{
+			name: "image link with parentheses in URL",
+			input: `
+![fig](https://example.com/image(v2).png)
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://example.com/image(v2).png", Line: 2},
+			},
+		},
+		{
+			name: "unmatched closing paren terminates bare URL",
+			input: `
+See (https://example.com/page) for details.
+`,
+			expected: []rule.ExtractedLink{
+				{URL: "https://example.com/page", Line: 2},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #273

## Summary

- URLs containing balanced parentheses (e.g. DOI URLs) were split into multiple broken fragments
- Update all three URL extraction patterns to allow `(...)` groups per the CommonMark spec
- Adds four new test cases: inline link, bare URL, image link with parens, and unmatched `)` termination

## Root cause

```go
// Before: ) is unconditionally treated as URL terminator
inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://[^\s)]+)\)`)
bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://[^\s<>"'()]+).*?$`)

// After: balanced (...) groups are allowed inside the URL
inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://(?:[^\s()\[\]]+|\([^\s()]*\))*)\)`)
bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://(?:[^\s<>"'()]+|\([^\s<>"'()]*\))+).*?$`)
```

## Before / After

| Input | Before | After |
|---|---|---|
| `https://doi.org/10.1016/0026-0495(67)90027-3` | Split into 2 broken URLs | Single correct URL |
| `[DOI](https://doi.org/10.1016/0026-0495(67)90027-3)` | Truncated | Extracted correctly |