### PR TITLE
docs: realign README and docs to link-checker-first positioning

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 
-> Go 製の超高速 Markdown リンター — **100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要、HTTP リンクバリデーション機能を内蔵。
+> リンク切れをユーザーより先に発見。Markdown を整えながら、外部 URL と内部アンカーを検証。**100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要。
 
 **かんたんインストール**（macOS / Linux）:
 
@@ -56,8 +56,8 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
+- リンク切れをユーザーより先に発見 — 外部 URL と内部アンカーを検証。
 - **100,000 行以上を約 170ms** で処理 — JIT ウォームアップなし、ランタイムオーバーヘッドなし。
-- リンク切れや見出しの問題をドキュメント公開前にキャッチ。
 - 予測可能な構造を強制（「なぜ H2 の下に H4 があるの？」をなくす）。
 - 人間にも機械にも優しい出力（JSON 対応）。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 
-> リンク切れをユーザーより先に発見。Markdown を整えながら、外部 URL と内部アンカーを検証。**100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要。
+> リンク切れをユーザーより先に発見。内部アンカーはデフォルトで検証、外部 URL は `external-link` を有効化して検証。**100,000 行以上を約 170ms** で処理。シングルバイナリで Node.js 不要。
 
 **かんたんインストール**（macOS / Linux）:
 
@@ -56,7 +56,7 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
-- リンク切れをユーザーより先に発見 — 外部 URL と内部アンカーを検証。
+- リンク切れをユーザーより先に発見 — 内部アンカーはデフォルトで検証。`external-link` を有効化すると外部 URL も検証。
 - **100,000 行以上を約 170ms** で処理 — JIT ウォームアップなし、ランタイムオーバーヘッドなし。
 - 予測可能な構造を強制（「なぜ H2 の下に H4 があるの？」をなくす）。
 - 人間にも機械にも優しい出力（JSON 対応）。

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
-- Catch broken links before your readers do — validates external URLs and internal anchors.
+- Catch broken links before your readers do — validates internal anchors by default; enable `external-link` to also check external URLs.
 - **100,000+ lines in ~170ms** — single binary, no JIT warmup, no runtime overhead.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [日本語](README.ja.md)
 <!-- gomarklint-disable-next-line no-bare-urls -->
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 
-> Blazing-fast Markdown linter built in Go — **100,000+ lines in ~170ms**. Single binary, no Node.js required, and built-in HTTP link validation.
+> Catch broken links before your readers do — and keep your Markdown clean while you're at it. **100,000+ lines in ~170ms**, single binary, no Node.js required.
 
 **Quick install** (macOS / Linux):
 
@@ -57,8 +57,8 @@ npm install -g @shinagawa-web/gomarklint
 go install github.com/shinagawa-web/gomarklint/v3@latest
 ```
 
+- Catch broken links before your readers do — validates external URLs and internal anchors.
 - **100,000+ lines in ~170ms** — single binary, no JIT warmup, no runtime overhead.
-- Catch broken links and headings before your docs ship.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
 
@@ -69,7 +69,7 @@ go install github.com/shinagawa-web/gomarklint/v3@latest
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-gomarklint-blue?logo=github)](https://github.com/marketplace/actions/gomarklint-markdown-linter)
 
 ```yaml
-name: Lint Markdown
+name: gomarklint
 
 on:
   pull_request:

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -26,11 +26,6 @@ func benchmarkConfig() config.Config {
 		Severity: config.SeverityError,
 		Options:  map[string]interface{}{"lineLength": float64(120)},
 	}
-	cfg.Rules["link-fragments"] = &config.RuleConfig{
-		Enabled:  true,
-		Severity: config.SeverityError,
-		Options:  map[string]interface{}{"slug-algorithm": "github"},
-	}
 	return cfg
 }
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -13,7 +13,7 @@ title: "gomarklint"
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 
 > Catch broken links before your readers do.
-> A fast Markdown checker built in Go — validates links, headings, and structure for local dev and CI alike.
+> A fast Markdown checker built in Go — validates internal anchors by default, external URLs when enabled, and enforces structure for local dev and CI alike.
 
 ```sh
 # macOS / Linux — one-line install
@@ -28,7 +28,7 @@ npm install -g @shinagawa-web/gomarklint
 
 [Quick Start →]({{< relref "/docs/quick-start" >}})
 
-- Catch broken links before your readers do — validates external URLs and internal anchors.
+- Catch broken links before your readers do — validates internal anchors by default; enable `external-link` to also check external URLs.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -12,8 +12,8 @@ title: "gomarklint"
 
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 
-> Lint your Markdown like you lint your code.
-> A fast Markdown linter built in Go — for local dev and CI alike.
+> Catch broken links before your readers do.
+> A fast Markdown checker built in Go — validates links, headings, and structure for local dev and CI alike.
 
 ```sh
 # macOS / Linux — one-line install
@@ -28,7 +28,7 @@ npm install -g @shinagawa-web/gomarklint
 
 [Quick Start →]({{< relref "/docs/quick-start" >}})
 
-- Catch broken links and headings before your docs ship.
+- Catch broken links before your readers do — validates external URLs and internal anchors.
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
 

--- a/docs/content/docs/faq.md
+++ b/docs/content/docs/faq.md
@@ -94,7 +94,7 @@ In CI, add both commands as separate steps.
 
 ---
 
-## Running the linter
+## Running gomarklint
 
 ### `unknown shorthand flag: 'v'`
 

--- a/docs/content/docs/github-actions.md
+++ b/docs/content/docs/github-actions.md
@@ -14,7 +14,7 @@ You can use gomarklint in your CI workflows using the official [GitHub Action](h
 
 ```yml
 # .github/workflows/docs-lint.yml
-name: Lint Markdown
+name: gomarklint
 
 on:
   pull_request:

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -94,7 +94,7 @@ This creates `.gomarklint.json` with sensible defaults:
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
-    "link-fragments": { "enabled": false, "slug-algorithm": "github" }
+    "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],
@@ -110,7 +110,7 @@ You can edit it anytime — CLI flags override config values.
 # check current directory recursively
 gomarklint .
 
-# lint specific targets
+# check specific targets
 gomarklint docs README.md internal/rule
 ```
 

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -107,7 +107,7 @@ You can edit it anytime — CLI flags override config values.
 ## 2) Run it
 
 ```sh
-# lint current directory recursively
+# check current directory recursively
 gomarklint .
 
 # lint specific targets

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -10,7 +10,7 @@ weight: 9
 ### Link checks
 
 - [x] `external-link`: Validate external HTTP/HTTPS URLs
-- [x] `link-fragments`: Internal anchor links must resolve to an existing heading (MD051)
+- [x] `link-fragments`: Internal anchor links must resolve to an existing heading
 
 ### Structure and formatting
 
@@ -25,21 +25,10 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] `no-emphasis-as-heading`: Bold/italic must not substitute for headings
 - [x] `no-setext-headings`: Setext-style headings must use ATX style instead
 - [x] `blanks-around-lists`: Lists must be surrounded by blank lines
-- [x] `max-line-length`: Enforce a maximum line length (MD013)
-- [x] `no-hard-tabs`: No hard tab characters in body text (MD010)
-- [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
-- [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`) (MD048)
-- [x] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
-- [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
-- [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
-
+- [x] `max-line-length`: Enforce a maximum line length- [x] `no-hard-tabs`: No hard tab characters in body text- [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines- [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`)- [x] `no-trailing-punctuation`: No trailing punctuation in headings- [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`)- [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`)
 ## Rules — Planned
 
-- [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
-- [ ] `no-undefined-references`: Reference-style links/images must have a matching definition (MD052/MD053)
-- [ ] `table-formatting`: Table structure and cell-padding consistency (MD055/MD056/MD058)
-- [ ] `descriptive-link-text`: Link text must not be generic ("click here", "here") (MD059)
-- [ ] `consistent-line-endings`: Enforce consistent line endings (LF vs CRLF)
+- [ ] `no-trailing-spaces`: No trailing whitespace at end of lines- [ ] `no-undefined-references`: Reference-style links/images must have a matching definition- [ ] `table-formatting`: Table structure and cell-padding consistency- [ ] `descriptive-link-text`: Link text must not be generic ("click here", "here")- [ ] `consistent-line-endings`: Enforce consistent line endings (LF vs CRLF)
 
 ## Extensibility
 

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -25,10 +25,21 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] `no-emphasis-as-heading`: Bold/italic must not substitute for headings
 - [x] `no-setext-headings`: Setext-style headings must use ATX style instead
 - [x] `blanks-around-lists`: Lists must be surrounded by blank lines
-- [x] `max-line-length`: Enforce a maximum line length- [x] `no-hard-tabs`: No hard tab characters in body text- [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines- [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`)- [x] `no-trailing-punctuation`: No trailing punctuation in headings- [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`)- [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`)
+- [x] `max-line-length`: Enforce a maximum line length
+- [x] `no-hard-tabs`: No hard tab characters in body text
+- [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines
+- [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`)
+- [x] `no-trailing-punctuation`: No trailing punctuation in headings
+- [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`)
+- [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`)
+
 ## Rules — Planned
 
-- [ ] `no-trailing-spaces`: No trailing whitespace at end of lines- [ ] `no-undefined-references`: Reference-style links/images must have a matching definition- [ ] `table-formatting`: Table structure and cell-padding consistency- [ ] `descriptive-link-text`: Link text must not be generic ("click here", "here")- [ ] `consistent-line-endings`: Enforce consistent line endings (LF vs CRLF)
+- [ ] `no-trailing-spaces`: No trailing whitespace at end of lines
+- [ ] `no-undefined-references`: Reference-style links/images must have a matching definition
+- [ ] `table-formatting`: Table structure and cell-padding consistency
+- [ ] `descriptive-link-text`: Link text must not be generic ("click here", "here")
+- [ ] `consistent-line-endings`: Enforce consistent line endings (LF vs CRLF)
 
 ## Extensibility
 

--- a/docs/content/docs/roadmap.md
+++ b/docs/content/docs/roadmap.md
@@ -7,6 +7,13 @@ weight: 9
 
 ## Rules — Completed
 
+### Link checks
+
+- [x] `external-link`: Validate external HTTP/HTTPS URLs
+- [x] `link-fragments`: Internal anchor links must resolve to an existing heading (MD051)
+
+### Structure and formatting
+
 All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shinagawa-web/gomarklint/issues/76) have landed.
 
 - [x] `no-multiple-blank-lines`: Disallow multiple consecutive blank lines
@@ -22,19 +29,13 @@ All Priority 1 rules from the [ecosystem analysis (#76)](https://github.com/shin
 - [x] `no-hard-tabs`: No hard tab characters in body text (MD010)
 - [x] `blanks-around-fences`: Fenced code blocks must be surrounded by blank lines (MD031)
 - [x] `consistent-code-fence`: Consistent fence character (`` ``` `` vs `~~~`) (MD048)
-
-## Rules — Planned
-
-### Priority 2
-
-- [ ] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
+- [x] `no-trailing-punctuation`: No trailing punctuation in headings (MD026)
 - [x] `consistent-emphasis-style`: Consistent emphasis marker (`*` vs `_`) (MD049)
 - [x] `consistent-list-marker`: Consistent unordered list marker (`-` vs `*` vs `+`) (MD004)
 
-### Priority 3
+## Rules — Planned
 
 - [ ] `no-trailing-spaces`: No trailing whitespace at end of lines (MD009)
-- [ ] `link-fragments`: Internal anchor links must resolve to an existing heading (MD051)
 - [ ] `no-undefined-references`: Reference-style links/images must have a matching definition (MD052/MD053)
 - [ ] `table-formatting`: Table structure and cell-padding consistency (MD055/MD056/MD058)
 - [ ] `descriptive-link-text`: Link text must not be generic ("click here", "here") (MD059)

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -12,7 +12,7 @@ weight: 2
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
-| `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
+| `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks
 

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -5,7 +5,16 @@ weight: 2
 
 # Rules
 
-`gomarklint` currently runs the following checks (ordered as executed):
+`gomarklint` currently runs the following checks:
+
+## Link checks
+
+| Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
+| `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
+
+## Structure and formatting checks
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -30,8 +39,6 @@ weight: 2
 | `consistent-emphasis-style`    | Inconsistent emphasis marker (`*text*` vs `_text_`)                     | Default **on**. Option: `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`)   |
 | `consistent-list-marker`       | Inconsistent unordered list marker (`-` vs `*` vs `+`)                 | Default **on**. Option: `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
-| `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **off**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## link-fragments
 

--- a/e2e/fixtures/no_empty_links_valid.md
+++ b/e2e/fixtures/no_empty_links_valid.md
@@ -1,7 +1,7 @@
 ## Valid Link Formats
 
-Use a normal link: [Example](#example)
+Use a normal link: [Valid Link Formats](#valid-link-formats)
 
-Use a fragment link: [Section](#section)
+Use a fragment link: [Valid Link Formats](#valid-link-formats)
 
 Use a relative path: [Page](./page.md)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ const DefaultConfigJSON = `{
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
     "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
-    "link-fragments": { "enabled": false, "slug-algorithm": "github" }
+    "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],
@@ -267,8 +267,8 @@ func Default() Config {
 				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "skipPatterns": []interface{}{}},
 			},
 			"link-fragments": {
-				Enabled:  false,
-				Severity: SeverityOff,
+				Enabled:  true,
+				Severity: SeverityError,
 				Options:  map[string]interface{}{"slug-algorithm": "github"},
 			},
 		},


### PR DESCRIPTION
## Summary

Realigns all user-facing copy to lead with link-checking, resolving the mismatch between the updated tagline ("Catch broken links before your readers do") and the remaining lint-first framing throughout the docs.

### Breaking / behavior change

- **`link-fragments` is now enabled by default** (`internal/config/config.go`, `cmd/root_bench_test.go`): previously opt-in, it now runs on every document unless explicitly disabled.

### Critical — hero text and taglines

- **README.md**: hero quote and bullet list now lead with link-checking; workflow name changed from `Lint Markdown` to `gomarklint`
- **README.ja.md**: equivalent Japanese changes
- **docs/content/_index.md**: taglines updated to link-checker-first

### Medium — structure and ordering

- **docs/content/docs/rules.md**: split into `## Link checks` (top) and `## Structure and formatting checks` sections; `external-link` and `link-fragments` are now immediately visible
- **docs/content/docs/roadmap.md**: completed rules reorganized with `## Link checks` subsection at the top; `link-fragments` removed from the planned list (it is already shipped)

### Low — terminology

- **docs/content/docs/github-actions.md**: `name: Lint Markdown` → `name: gomarklint`
- **docs/content/docs/faq.md**: `## Running the linter` → `## Running gomarklint`
- **docs/content/docs/quick-start.md**: `# lint current directory recursively` → `# check current directory recursively`

## Test plan

- [x] `gomarklint --config .gomarklint.ci.json` passes on all modified files (no violations)

Closes #268