### PR TITLE
docs: introduce DDD ubiquitous language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,19 @@ Always run `make test-all` before opening a pull request.
 
 ## Adding a new lint rule
 
+### Criteria for adding a new rule
+
+A new Rule belongs in gomarklint's core domain when **all** of the following are true:
+
+- It detects a structural or stylistic issue expressible as a single-file scan — no cross-file or project-wide context required.
+- It is language-agnostic: the check applies to any Markdown document, not to a specific framework, tool, or authoring convention.
+- It produces a Diagnostic with a stable rule key and a clear, actionable fix message.
+- It is a linter, not a formatter — gomarklint reports violations; it does not rewrite files.
+
+If a proposed rule requires knowledge of multiple files, targets a specific toolchain, or would rewrite content, it falls outside the core domain and should not be added.
+
+### Implementation steps
+
 1. Create the rule implementation under `internal/rule/`.
 2. Register the rule in the linter.
 3. Add unit tests in `internal/rule/`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ go install github.com/shinagawa-web/gomarklint/v3@latest
 - Enforce predictable structure (no more "why is this H4 under H2?").
 - Output that's friendly for both humans and machines (JSON).
 
+## Concepts
+
+gomarklint is built around four core concepts:
+
+| Term | Description |
+|---|---|
+| **Rule** | A named, versioned check applied to a Markdown file, identified by a stable key (e.g. `heading-level`) |
+| **Diagnostic** | A single violation emitted by a Rule, carrying file path, line number, rule key, message, and severity |
+| **Severity** | The impact level of a violation: `error` causes a non-zero exit code; `warning` is informational only |
+| **Config** | The per-rule and global settings that control enablement, severity, and rule-specific options |
+
+Rule keys are stable identifiers — they will not be renamed without a major version bump.
+Severity controls exit code behavior: any `error`-level Diagnostic makes gomarklint exit non-zero, making it safe as a CI gate.
+
+See [docs/glossary.md](docs/glossary.md) for full definitions and Go type references.
+
 ## CI Integration
 
 ### GitHub Actions

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,50 @@
+# Glossary
+
+This glossary defines the ubiquitous language of the gomarklint domain.
+All contributors, documentation, and code use these terms consistently.
+
+## Rule
+
+A named, versioned check applied to a single Markdown file.
+Each rule has a stable string key (e.g. `heading-level`, `no-bare-urls`) that serves as its public identifier in configuration, output, and documentation.
+Rules are implemented as functions inside `internal/rule/` and invoked by `internal/linter/`.
+
+## Diagnostic
+
+A single violation emitted by a Rule.
+Represented in Go as [`rule.LintError`](../internal/rule/heading_level.go):
+
+```go
+type LintError struct {
+    File     string
+    Line     int
+    Rule     string
+    Message  string
+    Severity string
+}
+```
+
+A Diagnostic carries everything needed to locate the problem (file, line), identify its source (rule key), describe it (message), and determine its impact (severity).
+
+## Severity
+
+The impact level of a Diagnostic.
+Represented in Go as [`config.RuleSeverity`](../internal/config/config.go):
+
+| Value | Meaning |
+|---|---|
+| `error` | Violation causes a non-zero exit code |
+| `warning` | Violation is reported but does not affect the exit code |
+| `off` | Rule is disabled; no Diagnostics are emitted |
+
+Users can rely on this contract: an `error`-severity violation always produces a non-zero exit, making gomarklint safe to use as a CI gate.
+
+## Config
+
+The settings that control rule enablement and options.
+Two Go types compose the full configuration:
+
+- [`config.Config`](../internal/config/config.go) — global settings: which files to include/ignore, output format, and a map of per-rule configs.
+- [`config.RuleConfig`](../internal/config/config.go) — per-rule settings: enabled flag, severity, and rule-specific options.
+
+Config is loaded from `.gomarklint.json` (or the path given via `--config`) and validated at startup.


### PR DESCRIPTION
## Summary

- Add `docs/glossary.md` defining the four core domain terms (Rule, Diagnostic, Severity, Config) with Go type references
- Add a **Concepts** section to `README.md` (between the intro and CI Integration) with one-sentence definitions and a link to the glossary
- Add a **Criteria for adding a new rule** subsection to `CONTRIBUTING.md` that protects the core domain boundary

Closes #282

## Test plan

- [x] `make test-all` passes