### PR TITLE
fix(consistent-emphasis-style): separate emphasis/strong tracking and skip link URLs

### DIFF
--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -16,7 +16,8 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 	var errs []LintError
 	inBlock := false
 	fenceMarker := ""
-	var expectedCh byte // 0 until first emphasis seen (consistent mode)
+	var expectedEmphCh byte   // for runLen == 1 (emphasis)
+	var expectedStrongCh byte // for runLen == 2 (strong)
 
 	for i, line := range lines {
 		first := firstNonSpaceByte(line)
@@ -45,8 +46,11 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 		if strings.ContainsRune(scanned, '`') {
 			scanned = stripInlineCode(scanned)
 		}
+		if strings.Contains(scanned, "](") {
+			scanned = stripLinkURLs(scanned)
+		}
 
-		checkEmphasisLine(scanned, filename, offset+i+1, style, &expectedCh, &errs)
+		checkEmphasisLine(scanned, filename, offset+i+1, style, &expectedEmphCh, &expectedStrongCh, &errs)
 	}
 
 	return errs
@@ -56,7 +60,11 @@ func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, s
 // to errs. Only valid spans (opener + matching closer) are counted, so closing
 // delimiters followed by punctuation are never double-counted. The function is
 // allocation-free: no intermediate slice is created.
-func checkEmphasisLine(s string, filename string, lineNum int, style string, expectedCh *byte, errs *[]LintError) {
+//
+// expectedEmphCh tracks the expected marker for single-delimiter spans (emphasis);
+// expectedStrongCh tracks it for double-delimiter spans (strong). They are kept
+// separate so that *italic* and __strong__ can coexist without a violation.
+func checkEmphasisLine(s string, filename string, lineNum int, style string, expectedEmphCh *byte, expectedStrongCh *byte, errs *[]LintError) {
 	i := 0
 	for i < len(s) {
 		ch := s[i]
@@ -104,7 +112,11 @@ func checkEmphasisLine(s string, filename string, lineNum int, style string, exp
 			continue
 		}
 
-		if err := checkEmphasisStyle(filename, lineNum, ch, style, expectedCh); err != nil {
+		expected := expectedEmphCh
+		if runLen == 2 {
+			expected = expectedStrongCh
+		}
+		if err := checkEmphasisStyle(filename, lineNum, ch, style, expected); err != nil {
 			*errs = append(*errs, *err)
 		}
 		i = closerPos + runLen // advance past the entire span
@@ -192,4 +204,105 @@ func emphCharName(ch byte) string {
 		return "asterisk"
 	}
 	return "underscore"
+}
+
+// stripLinkURLs replaces the destination and title of inline Markdown links
+// with spaces so that underscores or asterisks in URLs are not mistaken for
+// emphasis markers. The link text between [ and ] is preserved.
+func stripLinkURLs(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		if s[i] != ']' || i+1 >= len(s) || s[i+1] != '(' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		b.WriteByte(']')
+		b.WriteByte('(')
+		i += 2
+
+		// Consume destination.
+		if i < len(s) && s[i] == '<' {
+			// Angle-bracket form: <dest>
+			b.WriteByte('<')
+			i++
+			for i < len(s) && s[i] != '>' {
+				b.WriteByte(' ')
+				i++
+			}
+			if i < len(s) {
+				b.WriteByte('>')
+				i++
+			}
+		} else {
+			// Regular form: balanced parentheses, stops at space.
+			depth := 0
+			for i < len(s) {
+				c := s[i]
+				if c == '(' {
+					depth++
+					b.WriteByte(' ')
+					i++
+				} else if c == ')' {
+					if depth == 0 {
+						break
+					}
+					depth--
+					b.WriteByte(' ')
+					i++
+				} else if c == ' ' || c == '\t' {
+					break
+				} else {
+					b.WriteByte(' ')
+					i++
+				}
+			}
+		}
+
+		// Optional whitespace before title.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			b.WriteByte(' ')
+			i++
+		}
+
+		// Optional title: "...", '...', or (...).
+		if i < len(s) {
+			var closer byte
+			switch s[i] {
+			case '"':
+				closer = '"'
+			case '\'':
+				closer = '\''
+			case '(':
+				closer = ')'
+			}
+			if closer != 0 {
+				b.WriteByte(s[i])
+				i++
+				for i < len(s) && s[i] != closer {
+					b.WriteByte(' ')
+					i++
+				}
+				if i < len(s) {
+					b.WriteByte(s[i])
+					i++
+				}
+			}
+		}
+
+		// Trailing whitespace before ')'.
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			b.WriteByte(' ')
+			i++
+		}
+
+		// Closing ')'.
+		if i < len(s) && s[i] == ')' {
+			b.WriteByte(')')
+			i++
+		}
+	}
+	return b.String()
 }

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -222,87 +222,92 @@ func stripLinkURLs(s string) string {
 		b.WriteByte(']')
 		b.WriteByte('(')
 		i += 2
-
-		// Consume destination.
-		if i < len(s) && s[i] == '<' {
-			// Angle-bracket form: <dest>
-			b.WriteByte('<')
-			i++
-			for i < len(s) && s[i] != '>' {
-				b.WriteByte(' ')
-				i++
-			}
-			if i < len(s) {
-				b.WriteByte('>')
-				i++
-			}
-		} else {
-			// Regular form: balanced parentheses, stops at space.
-			depth := 0
-			for i < len(s) {
-				c := s[i]
-				if c == '(' {
-					depth++
-					b.WriteByte(' ')
-					i++
-				} else if c == ')' {
-					if depth == 0 {
-						break
-					}
-					depth--
-					b.WriteByte(' ')
-					i++
-				} else if c == ' ' || c == '\t' {
-					break
-				} else {
-					b.WriteByte(' ')
-					i++
-				}
-			}
-		}
-
-		// Optional whitespace before title.
-		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
-			b.WriteByte(' ')
-			i++
-		}
-
-		// Optional title: "...", '...', or (...).
-		if i < len(s) {
-			var closer byte
-			switch s[i] {
-			case '"':
-				closer = '"'
-			case '\'':
-				closer = '\''
-			case '(':
-				closer = ')'
-			}
-			if closer != 0 {
-				b.WriteByte(s[i])
-				i++
-				for i < len(s) && s[i] != closer {
-					b.WriteByte(' ')
-					i++
-				}
-				if i < len(s) {
-					b.WriteByte(s[i])
-					i++
-				}
-			}
-		}
-
-		// Trailing whitespace before ')'.
-		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
-			b.WriteByte(' ')
-			i++
-		}
-
-		// Closing ')'.
+		i = consumeLinkDest(&b, s, i)
+		i = consumeLinkTitle(&b, s, i)
 		if i < len(s) && s[i] == ')' {
 			b.WriteByte(')')
 			i++
 		}
 	}
 	return b.String()
+}
+
+// consumeLinkDest blanks out the link destination starting at i and returns
+// the position after it. Handles both angle-bracket form (<dest>) and the
+// regular balanced-paren form.
+func consumeLinkDest(b *strings.Builder, s string, i int) int {
+	if i >= len(s) {
+		return i
+	}
+	if s[i] == '<' {
+		b.WriteByte('<')
+		i++
+		for i < len(s) && s[i] != '>' {
+			b.WriteByte(' ')
+			i++
+		}
+		if i < len(s) {
+			b.WriteByte('>')
+			i++
+		}
+		return i
+	}
+	depth := 0
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == '(':
+			depth++
+			b.WriteByte(' ')
+			i++
+		case c == ')' && depth > 0:
+			depth--
+			b.WriteByte(' ')
+			i++
+		case c == ')' || c == ' ' || c == '\t':
+			return i
+		default:
+			b.WriteByte(' ')
+			i++
+		}
+	}
+	return i
+}
+
+// consumeLinkTitle blanks out optional whitespace and the link title (if any)
+// starting at i and returns the position after it.
+func consumeLinkTitle(b *strings.Builder, s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		b.WriteByte(' ')
+		i++
+	}
+	if i >= len(s) {
+		return i
+	}
+	var closer byte
+	switch s[i] {
+	case '"':
+		closer = '"'
+	case '\'':
+		closer = '\''
+	case '(':
+		closer = ')'
+	default:
+		return i
+	}
+	b.WriteByte(s[i])
+	i++
+	for i < len(s) && s[i] != closer {
+		b.WriteByte(' ')
+		i++
+	}
+	if i < len(s) {
+		b.WriteByte(s[i])
+		i++
+	}
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		b.WriteByte(' ')
+		i++
+	}
+	return i
 }

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -113,10 +113,12 @@ func checkEmphasisLine(s string, filename string, lineNum int, style string, exp
 		}
 
 		expected := expectedEmphCh
+		kind := "emphasis"
 		if runLen == 2 {
 			expected = expectedStrongCh
+			kind = "strong"
 		}
-		if err := checkEmphasisStyle(filename, lineNum, ch, style, expected); err != nil {
+		if err := checkEmphasisStyle(filename, lineNum, ch, style, expected, kind); err != nil {
 			*errs = append(*errs, *err)
 		}
 		i = closerPos + runLen // advance past the entire span
@@ -163,9 +165,10 @@ func isEmphWordChar(b byte) bool {
 }
 
 // checkEmphasisStyle validates ch against the configured style and updates
-// expectedCh in consistent mode. Returns a LintError if the emphasis character
-// does not match, nil otherwise.
-func checkEmphasisStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
+// expectedCh in consistent mode. kind is "emphasis" for single-delimiter spans
+// and "strong" for double-delimiter spans. Returns a LintError if the marker
+// character does not match, nil otherwise.
+func checkEmphasisStyle(filename string, line int, ch byte, style string, expectedCh *byte, kind string) *LintError {
 	switch style {
 	case "consistent":
 		if *expectedCh == 0 {
@@ -176,7 +179,7 @@ func checkEmphasisStyle(filename string, line int, ch byte, style string, expect
 			return &LintError{
 				File:    filename,
 				Line:    line,
-				Message: "consistent-emphasis-style: expected " + emphCharName(*expectedCh) + " emphasis, got " + emphCharName(ch) + " emphasis",
+				Message: "consistent-emphasis-style: expected " + emphCharName(*expectedCh) + " " + kind + ", got " + emphCharName(ch) + " " + kind,
 			}
 		}
 	case "asterisk":
@@ -184,7 +187,7 @@ func checkEmphasisStyle(filename string, line int, ch byte, style string, expect
 			return &LintError{
 				File:    filename,
 				Line:    line,
-				Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis",
+				Message: "consistent-emphasis-style: expected asterisk " + kind + ", got underscore " + kind,
 			}
 		}
 	case "underscore":
@@ -192,7 +195,7 @@ func checkEmphasisStyle(filename string, line int, ch byte, style string, expect
 			return &LintError{
 				File:    filename,
 				Line:    line,
-				Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis",
+				Message: "consistent-emphasis-style: expected underscore " + kind + ", got asterisk " + kind,
 			}
 		}
 	}
@@ -214,7 +217,7 @@ func stripLinkURLs(s string) string {
 	b.Grow(len(s))
 	i := 0
 	for i < len(s) {
-		if s[i] != ']' || i+1 >= len(s) || s[i+1] != '(' {
+		if s[i] != ']' || i+1 >= len(s) || s[i+1] != '(' || !hasPrecedingBracket(s, i) {
 			b.WriteByte(s[i])
 			i++
 			continue
@@ -230,6 +233,16 @@ func stripLinkURLs(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// hasPrecedingBracket reports whether there is an unescaped '[' before position i in s.
+func hasPrecedingBracket(s string, i int) bool {
+	for j := i - 1; j >= 0; j-- {
+		if s[j] == '[' {
+			return true
+		}
+	}
+	return false
 }
 
 // consumeLinkDest blanks out the link destination starting at i and returns

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -142,8 +142,57 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			style:   "consistent",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
-				{File: "test.md", Line: 5, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
 			},
+		},
+
+		// emphasis and strong are tracked independently in consistent mode
+		{
+			name:     "asterisk emphasis with underscore strong no violation",
+			content:  "*italic* and __bold__\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:     "underscore emphasis with asterisk strong no violation",
+			content:  "_italic_ and **bold**\n",
+			style:    "consistent",
+			wantErrs: nil,
+		},
+		{
+			name:    "mixed emphasis consistent violation not affected by strong",
+			content: "*italic* **bold** _also italic_\n",
+			style:   "consistent",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+
+		// URL with underscores must not be flagged
+		{
+			name:     "underscore in link URL not treated as emphasis",
+			content:  "[text](https://example.com/_foo_bar_/path) more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "underscore in link title not treated as emphasis",
+			content:  "[text](https://example.com/ \"_title_\") more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:    "emphasis outside link still checked when URL has underscores",
+			content: "[text](https://example.com/_path_/) _italic_\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
+		},
+		{
+			name:     "URL with underscores and title paren from issue #279",
+			content:  "[or text](https://example.com/_path_ \"title (2015)\") **essai_strong** _inconsistent_\n",
+			style:    "consistent",
+			wantErrs: nil,
 		},
 
 		// mid-word underscores must not be flagged

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -69,7 +69,7 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			content: "This is __bold__ text.\n",
 			style:   "asterisk",
 			wantErrs: []LintError{
-				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk strong, got underscore strong"},
 			},
 		},
 
@@ -92,7 +92,7 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			style:   "underscore",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
-				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected underscore emphasis, got asterisk emphasis"},
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected underscore strong, got asterisk strong"},
 			},
 		},
 
@@ -115,7 +115,7 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			style:   "asterisk",
 			wantErrs: []LintError{
 				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
-				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+				{File: "test.md", Line: 3, Message: "consistent-emphasis-style: expected asterisk strong, got underscore strong"},
 			},
 		},
 
@@ -229,6 +229,14 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			content:  "[text](https://example.com/_path_\n",
 			style:    "asterisk",
 			wantErrs: nil,
+		},
+		{
+			name:    "bare ]( sequence without preceding [ is not treated as link",
+			content: "array](index) contains _value_\n",
+			style:   "asterisk",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "consistent-emphasis-style: expected asterisk emphasis, got underscore emphasis"},
+			},
 		},
 		{
 			name:     "malformed link with opening paren at end of line not flagged",

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -194,6 +194,54 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 			style:    "consistent",
 			wantErrs: nil,
 		},
+		{
+			name:     "angle-bracket link destination with underscores not flagged",
+			content:  "[text](<https://example.com/_path_>) more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "link destination with nested parentheses not flagged",
+			content:  "[text](https://en.wikipedia.org/wiki/Foo_(bar)/_path_) more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "link with single-quoted title containing underscores not flagged",
+			content:  "[text](https://example.com/ '_title_') more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "link with paren title containing underscores not flagged",
+			content:  "[text](https://example.com/ (_title_)) more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "link with trailing whitespace in destination not flagged",
+			content:  "[text](https://example.com/_path_   ) more text\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "malformed link with no closing paren not flagged",
+			content:  "[text](https://example.com/_path_\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "malformed link with opening paren at end of line not flagged",
+			content:  "[text_label](\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
+		{
+			name:     "link with trailing whitespace after title not flagged",
+			content:  "[text](https://example.com/ \"_title_\"   ) more\n",
+			style:    "asterisk",
+			wantErrs: nil,
+		},
 
 		// mid-word underscores must not be flagged
 		{


### PR DESCRIPTION
## Summary

Fixes #279.

- **Separate emphasis/strong tracking**: In `consistent` mode, single-delimiter spans (`*`/`_`) and double-delimiter spans (`**`/`__`) are now tracked independently. This means `*italic*` and `__strong__` can coexist without a violation, as they are different markup constructs.
- **Skip link URL/title content**: Added `stripLinkURLs` to blank out link destinations and titles before scanning for emphasis markers, preventing underscores in URLs (e.g. `https://example.com/_path_`) from being mistaken for emphasis.

## Test plan

- [ ] `*italic* and __strong__` → no violation in consistent mode
- [ ] `_italic_` and `**strong**` → no violation in consistent mode
- [ ] URL with `_underscores_` in path/title → no violation
- [ ] Angle-bracket URL form `<...>` → correctly skipped
- [ ] Nested parentheses in URL → correctly skipped
- [ ] Single-quoted and paren titles → correctly skipped
- [ ] `make test-all` passes with 100% coverage