### PR TITLE
chore(renovate): disable digest-only updates for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,11 @@
       "automerge": true,
       "automergeType": "pr",
       "requiredStatusChecks": ["Test / test"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Disable Renovate digest-only updates for GitHub Actions

Digest-only PRs (commit hash bumps with no version change) add maintenance overhead with no meaningful benefit. Version updates (`minor`/`patch`) continue to be tracked and auto-merged as before.

Closes #261