### PR TITLE
feat(external-link): make maxConcurrency and maxRetries configurable

### DIFF
--- a/.gomarklint.example.json
+++ b/.gomarklint.example.json
@@ -16,7 +16,7 @@
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] }
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -104,7 +104,7 @@ In the object form, `enabled` can be omitted — it defaults to `true`. These ar
 | `consistent-emphasis-style` | `error` | `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`) |
 | `consistent-list-marker` | `error` | `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length` | disabled | `lineLength` (int, default `80`) |
-| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
+| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `10`), `maxRetries` (int, default `2`, max `2`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
 | `link-fragments` | disabled | `slug-algorithm` (string, default `github`), `slug-params` (object, for `custom` algorithm) |
 
 ## Option validation

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -104,7 +104,7 @@ In the object form, `enabled` can be omitted — it defaults to `true`. These ar
 | `consistent-emphasis-style` | `error` | `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`) |
 | `consistent-list-marker` | `error` | `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length` | disabled | `lineLength` (int, default `80`) |
-| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `10`), `maxRetries` (int, default `2`, max `2`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
+| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `15`), `maxRetries` (int, default `2`, max `4`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
 | `link-fragments` | disabled | `slug-algorithm` (string, default `github`), `slug-params` (object, for `custom` algorithm) |
 
 ## Option validation

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -93,7 +93,7 @@ This creates `.gomarklint.json` with sensible defaults:
     "consistent-emphasis-style": { "style": "consistent" },
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] },
     "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -11,7 +11,7 @@ weight: 2
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `skipPatterns` (regex list)                 |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `10`), `maxRetries` (default `2`, max `2`), `skipPatterns` (regex list)                 |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -11,7 +11,7 @@ weight: 2
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `10`), `maxRetries` (default `2`, max `2`), `skipPatterns` (regex list)                 |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `skipPatterns` (regex list)                 |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks

--- a/e2e/config-external-link-max-concurrency-too-high.json
+++ b/e2e/config-external-link-max-concurrency-too-high.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "external-link": { "enabled": true, "maxConcurrency": 11 }
+    "external-link": { "enabled": true, "maxConcurrency": 16 }
   }
 }

--- a/e2e/config-external-link-max-concurrency-too-high.json
+++ b/e2e/config-external-link-max-concurrency-too-high.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "external-link": { "enabled": true, "maxConcurrency": 11 }
+  }
+}

--- a/e2e/config-external-link-max-retries-too-high.json
+++ b/e2e/config-external-link-max-retries-too-high.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "external-link": { "enabled": true, "maxRetries": 3 }
+  }
+}

--- a/e2e/config-external-link-max-retries-too-high.json
+++ b/e2e/config-external-link-max-retries-too-high.json
@@ -1,5 +1,5 @@
 {
   "rules": {
-    "external-link": { "enabled": true, "maxRetries": 3 }
+    "external-link": { "enabled": true, "maxRetries": 5 }
   }
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -674,6 +674,24 @@ func TestE2E_EdgeCases(t *testing.T) {
 		assertOutputContains(t, output, "valid values: consistent, backtick, tilde")
 	})
 
+	t.Run("ExternalLinkMaxConcurrencyTooHigh", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-external-link-max-concurrency-too-high.json")
+		if err == nil {
+			t.Errorf("expected error for maxConcurrency above limit, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, "external-link.maxConcurrency")
+	})
+
+	t.Run("ExternalLinkMaxRetriesTooHigh", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-external-link-max-retries-too-high.json")
+		if err == nil {
+			t.Errorf("expected error for maxRetries above limit, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, "external-link.maxRetries")
+	})
+
 	t.Run("EmptyFile", func(t *testing.T) {
 		output := runTest(t, "fixtures/empty.md", "--config", ".gomarklint.json")
 		assertOutputContains(t, output, "Errors in fixtures/empty.md:")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ const DefaultConfigJSON = `{
     "consistent-emphasis-style": { "style": "consistent" },
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "skipPatterns": [] },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] },
     "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
@@ -264,7 +264,7 @@ func Default() Config {
 			"external-link": {
 				Enabled:  false,
 				Severity: SeverityError,
-				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "skipPatterns": []interface{}{}},
+				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "maxConcurrency": float64(10), "maxRetries": float64(2), "skipPatterns": []interface{}{}},
 			},
 			"link-fragments": {
 				Enabled:  true,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -249,6 +249,26 @@ func (l *Linter) externalLinkTimeout() int {
 	return timeoutSeconds
 }
 
+// externalLinkMaxConcurrency returns the configured maxConcurrency for the external-link rule.
+func (l *Linter) externalLinkMaxConcurrency() int {
+	if v, ok := l.config.RuleOptions("external-link")["maxConcurrency"]; ok {
+		if f, ok := v.(float64); ok && int(f) > 0 {
+			return int(f)
+		}
+	}
+	return rule.DefaultMaxConcurrency
+}
+
+// externalLinkMaxRetries returns the configured maxRetries for the external-link rule.
+func (l *Linter) externalLinkMaxRetries() int {
+	if v, ok := l.config.RuleOptions("external-link")["maxRetries"]; ok {
+		if f, ok := v.(float64); ok && int(f) >= 0 {
+			return int(f)
+		}
+	}
+	return rule.DefaultMaxRetries
+}
+
 // externalLinkAllowedStatuses returns the configured allowedStatuses for the external-link rule.
 func (l *Linter) externalLinkAllowedStatuses() []int {
 	raw, _ := l.config.RuleOptions("external-link")["allowedStatuses"].([]interface{})
@@ -332,7 +352,7 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {
-		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkAllowedStatuses(), l.urlCache)
+		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkMaxConcurrency(), l.externalLinkMaxRetries(), l.externalLinkAllowedStatuses(), l.urlCache)
 		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
 		linksChecked = count
 	}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -44,6 +44,13 @@ func New(cfg config.Config) (*Linter, error) {
 		return nil, err
 	}
 
+	if err := validateExternalLinkIntOption(cfg, "maxConcurrency", 1, rule.MaxConcurrencyLimit); err != nil {
+		return nil, err
+	}
+	if err := validateExternalLinkIntOption(cfg, "maxRetries", 0, rule.MaxRetriesLimit); err != nil {
+		return nil, err
+	}
+
 	compiledPatterns := []*regexp.Regexp{}
 	if cfg.IsEnabled("external-link") {
 		opts := cfg.RuleOptions("external-link")
@@ -91,6 +98,24 @@ func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []str
 		}
 	}
 	return fmt.Errorf("gomarklint: invalid value %q for %s.%s (valid values: %s)", val, ruleName, optKey, strings.Join(valid, ", "))
+}
+
+// validateExternalLinkIntOption checks that a numeric external-link option, if present,
+// is within [min, max]. Returns a descriptive error if not.
+func validateExternalLinkIntOption(cfg config.Config, optKey string, min, max int) error {
+	raw, exists := cfg.RuleOptions("external-link")[optKey]
+	if !exists {
+		return nil
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("gomarklint: invalid value for external-link.%s: expected integer, got %T (%#v)", optKey, raw, raw)
+	}
+	v := int(f)
+	if v < min || v > max {
+		return fmt.Errorf("gomarklint: external-link.%s must be between %d and %d, got %d", optKey, min, max, v)
+	}
+	return nil
 }
 
 // Run performs linting on the given file paths concurrently.

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -101,8 +101,8 @@ func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []str
 }
 
 // validateExternalLinkIntOption checks that a numeric external-link option, if present,
-// is within [min, max]. Returns a descriptive error if not.
-func validateExternalLinkIntOption(cfg config.Config, optKey string, min, max int) error {
+// is within [minVal, maxVal]. Returns a descriptive error if not.
+func validateExternalLinkIntOption(cfg config.Config, optKey string, minVal, maxVal int) error {
 	raw, exists := cfg.RuleOptions("external-link")[optKey]
 	if !exists {
 		return nil
@@ -112,8 +112,8 @@ func validateExternalLinkIntOption(cfg config.Config, optKey string, min, max in
 		return fmt.Errorf("gomarklint: invalid value for external-link.%s: expected integer, got %T (%#v)", optKey, raw, raw)
 	}
 	v := int(f)
-	if v < min || v > max {
-		return fmt.Errorf("gomarklint: external-link.%s must be between %d and %d, got %d", optKey, min, max, v)
+	if v < minVal || v > maxVal {
+		return fmt.Errorf("gomarklint: external-link.%s must be between %d and %d, got %d", optKey, minVal, maxVal, v)
 	}
 	return nil
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1091,6 +1091,19 @@ func TestExternalLink_MaxRetriesZeroIsValid(t *testing.T) {
 	}
 }
 
+func TestExternalLink_MaxConcurrencyWrongTypeReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxConcurrency": "five"},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-integer maxConcurrency, got nil")
+	}
+}
+
 func TestExternalLink_MaxConcurrencyTooHighReturnsError(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["external-link"] = &config.RuleConfig{

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1051,3 +1051,42 @@ func TestNew_InvalidStyleOption_DisabledRuleStillValidated(t *testing.T) {
 		t.Fatal("expected error for invalid style even when rule is disabled, got nil")
 	}
 }
+
+func TestExternalLink_ConfigurableMaxConcurrency(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxConcurrency": float64(3)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkMaxConcurrency(); got != 3 {
+		t.Errorf("expected maxConcurrency 3, got %d", got)
+	}
+}
+
+func TestExternalLink_ConfigurableMaxRetries(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxRetries": float64(5)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkMaxRetries(); got != 5 {
+		t.Errorf("expected maxRetries 5, got %d", got)
+	}
+}
+
+func TestExternalLink_MaxRetriesZeroIsValid(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxRetries": float64(0)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkMaxRetries(); got != 0 {
+		t.Errorf("expected maxRetries 0, got %d", got)
+	}
+}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1070,11 +1070,11 @@ func TestExternalLink_ConfigurableMaxRetries(t *testing.T) {
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  true,
 		Severity: config.SeverityError,
-		Options:  map[string]interface{}{"maxRetries": float64(5)},
+		Options:  map[string]interface{}{"maxRetries": float64(1)},
 	}
 	l := mustNew(t, cfg)
-	if got := l.externalLinkMaxRetries(); got != 5 {
-		t.Errorf("expected maxRetries 5, got %d", got)
+	if got := l.externalLinkMaxRetries(); got != 1 {
+		t.Errorf("expected maxRetries 1, got %d", got)
 	}
 }
 
@@ -1088,5 +1088,44 @@ func TestExternalLink_MaxRetriesZeroIsValid(t *testing.T) {
 	l := mustNew(t, cfg)
 	if got := l.externalLinkMaxRetries(); got != 0 {
 		t.Errorf("expected maxRetries 0, got %d", got)
+	}
+}
+
+func TestExternalLink_MaxConcurrencyTooHighReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxConcurrency": float64(11)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for maxConcurrency above limit, got nil")
+	}
+}
+
+func TestExternalLink_MaxConcurrencyZeroReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxConcurrency": float64(0)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for maxConcurrency=0, got nil")
+	}
+}
+
+func TestExternalLink_MaxRetriesTooHighReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"maxRetries": float64(3)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for maxRetries above limit, got nil")
 	}
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1109,7 +1109,7 @@ func TestExternalLink_MaxConcurrencyTooHighReturnsError(t *testing.T) {
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  true,
 		Severity: config.SeverityError,
-		Options:  map[string]interface{}{"maxConcurrency": float64(11)},
+		Options:  map[string]interface{}{"maxConcurrency": float64(16)},
 	}
 	_, err := New(cfg)
 	if err == nil {
@@ -1135,7 +1135,7 @@ func TestExternalLink_MaxRetriesTooHighReturnsError(t *testing.T) {
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  true,
 		Severity: config.SeverityError,
-		Options:  map[string]interface{}{"maxRetries": float64(3)},
+		Options:  map[string]interface{}{"maxRetries": float64(5)},
 	}
 	_, err := New(cfg)
 	if err == nil {

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -32,6 +32,10 @@ type ExtractedLink struct {
 const (
 	// DefaultRetryDelayMs is the default delay in milliseconds before retrying a failed HTTP request
 	DefaultRetryDelayMs = 1000
+	// DefaultMaxConcurrency is the default maximum number of concurrent HTTP requests
+	DefaultMaxConcurrency = 10
+	// DefaultMaxRetries is the default maximum number of retry attempts for failed requests
+	DefaultMaxRetries = 2
 
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )
@@ -90,7 +94,7 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 // CheckExternalLinks checks external links in the given lines.
 // The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
 // Returns lint errors and the count of unique URLs checked.
-func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, allowedStatuses []int, urlCache *sync.Map) ([]LintError, int) {
+func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map) ([]LintError, int) {
 	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
 	links := ExtractExternalLinksWithLineNumbers(lines, offset)
 
@@ -108,8 +112,6 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	// maxConcurrency limits the number of concurrent HTTP requests
-	const maxConcurrency = 10
 	sem := make(chan struct{}, maxConcurrency)
 
 	client := &http.Client{
@@ -131,11 +133,11 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 					err = result.err
 				} else {
 					// Cache contained unexpected type, re-check the URL
-					status, err = checkURL(client, url, retryDelayMs, allowedStatuses)
+					status, err = checkURL(client, url, retryDelayMs, maxRetries, allowedStatuses)
 					urlCache.Store(url, cacheResult{status: status, err: err})
 				}
 			} else {
-				status, err = checkURL(client, url, retryDelayMs, allowedStatuses)
+				status, err = checkURL(client, url, retryDelayMs, maxRetries, allowedStatuses)
 				urlCache.Store(url, cacheResult{status: status, err: err})
 			}
 
@@ -158,9 +160,7 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 }
 
 // checkURL performs the URL check with retry logic.
-func checkURL(client *http.Client, url string, retryDelayMs int, allowedStatuses []int) (int, error) {
-	// maxRetries is the maximum number of retry attempts for failed requests
-	const maxRetries = 2
+func checkURL(client *http.Client, url string, retryDelayMs int, maxRetries int, allowedStatuses []int) (int, error) {
 	retryDelay := time.Duration(retryDelayMs) * time.Millisecond
 
 	var status int

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -35,11 +35,11 @@ const (
 	// DefaultMaxConcurrency is the default maximum number of concurrent HTTP requests
 	DefaultMaxConcurrency = 10
 	// MaxConcurrencyLimit is the maximum allowed value for maxConcurrency
-	MaxConcurrencyLimit = 10
+	MaxConcurrencyLimit = 15
 	// DefaultMaxRetries is the default maximum number of retry attempts for failed requests
 	DefaultMaxRetries = 2
 	// MaxRetriesLimit is the maximum allowed value for maxRetries
-	MaxRetriesLimit = 2
+	MaxRetriesLimit = 4
 
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -34,8 +34,12 @@ const (
 	DefaultRetryDelayMs = 1000
 	// DefaultMaxConcurrency is the default maximum number of concurrent HTTP requests
 	DefaultMaxConcurrency = 10
+	// MaxConcurrencyLimit is the maximum allowed value for maxConcurrency
+	MaxConcurrencyLimit = 10
 	// DefaultMaxRetries is the default maximum number of retry attempts for failed requests
 	DefaultMaxRetries = 2
+	// MaxRetriesLimit is the maximum allowed value for maxRetries
+	MaxRetriesLimit = 2
 
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )

--- a/internal/rule/external_link_internal_test.go
+++ b/internal/rule/external_link_internal_test.go
@@ -59,7 +59,7 @@ func Test_checkURL(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			status, err := checkURL(ts.Client(), ts.URL, 10, nil)
+			status, err := checkURL(ts.Client(), ts.URL, 10, DefaultMaxRetries, nil)
 			if tt.expectError && err == nil {
 				t.Errorf("expected error but got none")
 			}

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
@@ -42,7 +43,7 @@ func TestCheckExternalLinks_BasicSuccessFailure(t *testing.T) {
 
 	file := "mock.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(results))
@@ -70,7 +71,7 @@ func TestCheckExternalLinks_SkipPattern(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only non-localhost link should be checked), got %d", len(results))
@@ -89,7 +90,7 @@ func TestCheckExternalLinks_IgnoreCodeBlocks(t *testing.T) {
 	skip := []*regexp.Regexp{}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (code block link should be ignored), got %d", len(results))
 	}
@@ -119,7 +120,7 @@ Line 8 [link8](%s/fail8)
 
 	skip := []*regexp.Regexp{}
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 5 {
 		t.Fatalf("expected 5 errors, got %d", len(results))
@@ -151,9 +152,9 @@ func TestCheckExternalLinks_Deduplication(t *testing.T) {
 	lines, offset := toLines(markdown)
 
 	// First call - should trigger HTTP request
-	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
+	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
 	// Second call - should use cache
-	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
+	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
 
 	if requestCount != 1 {
 		t.Errorf("expected only 1 HTTP request due to caching, but got %d", requestCount)
@@ -167,7 +168,7 @@ func TestCheckExternalLinks_MultipleOccurrences(t *testing.T) {
 	markdown := fmt.Sprintf("[fail](%s/fail)\n[fail again](%s/fail)", ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	// Should report errors for each occurrence
 	if len(results) != 2 {
@@ -195,7 +196,7 @@ func TestCheckExternalLinks_AllLinksSucceed(t *testing.T) {
 [link3](%s/ok)`, ts.URL, ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors for all successful links, got %d", len(results))
@@ -217,7 +218,7 @@ func TestCheckExternalLinks_HTTPStatusBoundary(t *testing.T) {
 	fileName := "boundary.md"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only 400), got %d", len(results))
@@ -250,7 +251,7 @@ func TestCheckExternalLinks_MultipleSkipPatterns(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only httpstat.us), got %d", len(results))
@@ -275,7 +276,7 @@ func TestCheckExternalLinks_NetworkError(t *testing.T) {
 	unreachableURL := "http://invalid.test.localhost.invalid:9999/path"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error for network failure, got %d", len(results))
@@ -309,7 +310,7 @@ func TestCheckExternalLinks_DifferentHTTPStatusCodes(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)\n[server-error](%s/500)\n[unavailable](%s/503)", statusTs.URL, statusTs.URL, statusTs.URL)
 	fileName := "test.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 errors, got %d", len(results))
@@ -354,7 +355,7 @@ func TestCheckExternalLinks_RetrySuccess(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors due to successful retry, but got %d", len(results))
@@ -376,7 +377,7 @@ func TestCheckExternalLinks_NoRetryFor404(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	// For 404, there should be no retry; it should give up after a single request
 	if requestCount != 1 {
@@ -397,7 +398,7 @@ func TestCheckExternalLinks_ConcurrencyLimit(t *testing.T) {
 	markdown := strings.Join(links, "\n")
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors, got %d", len(results))
@@ -412,14 +413,14 @@ func TestCheckExternalLinks_CacheErrorState(t *testing.T) {
 
 	// First call - should trigger network error
 	lines, offset := toLines(markdown)
-	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, urlCache)
+	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
 
 	if len(results1) != 1 {
 		t.Fatalf("first call: expected 1 error for network failure, got %d", len(results1))
 	}
 
 	// Second call with same cache - should use cached error and report the same error
-	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, nil, urlCache)
+	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
 
 	if len(results2) != 1 {
 		t.Fatalf("second call: expected 1 error from cache, got %d", len(results2))
@@ -446,7 +447,7 @@ func TestCheckExternalLinks_CacheInvalidType(t *testing.T) {
 
 	// Call CheckExternalLinks - should detect invalid cache type and re-check
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, nil, urlCache)
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
 
 	// Should still get error because URL returns 404
 	if len(results) != 1 {
@@ -695,7 +696,7 @@ func TestCheckExternalLinks_GETFallback(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback should succeed), got: %v", results)
@@ -717,7 +718,7 @@ func TestCheckExternalLinks_GETFallback_On405(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 405 should succeed), got: %v", results)
@@ -739,7 +740,7 @@ func TestCheckExternalLinks_GETFallback_On403(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 403 should succeed), got: %v", results)
@@ -762,7 +763,7 @@ func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -782,7 +783,7 @@ func TestCheckExternalLinks_429NotFlagged(t *testing.T) {
 
 	markdown := fmt.Sprintf("[rate-limited](%s/429)", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if len(results) != 0 {
 		t.Errorf("expected no violations for 429 (rate limiting), got %d: %v", len(results), results)
@@ -803,13 +804,64 @@ func TestCheckExternalLinks_AllowedStatuses(t *testing.T) {
 	// 403 is in allowedStatuses → no violation; 500 is not → violation
 	markdown := fmt.Sprintf("[forbidden](%s/403)\n[server-error](%s/500)", ts.URL, ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, []int{403}, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, []int{403}, &sync.Map{})
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 violation (500 only), got %d: %v", len(results), results)
 	}
 	if !strings.Contains(results[0].Message, "/500") {
 		t.Errorf("expected violation for /500, got: %s", results[0].Message)
+	}
+}
+
+func TestCheckExternalLinks_ConfigurableMaxConcurrency(t *testing.T) {
+	var mu sync.Mutex
+	concurrent := 0
+	maxSeen := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		concurrent++
+		if concurrent > maxSeen {
+			maxSeen = concurrent
+		}
+		mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		mu.Lock()
+		concurrent--
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var links []string
+	for i := range 10 {
+		links = append(links, fmt.Sprintf("[L%d](%s/%d)", i, ts.URL, i))
+	}
+	lines, offset := toLines(strings.Join(links, "\n"))
+
+	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 2, rule.DefaultMaxRetries, nil, &sync.Map{})
+
+	if maxSeen > 2 {
+		t.Errorf("expected max concurrency of 2, but saw %d concurrent requests", maxSeen)
+	}
+}
+
+func TestCheckExternalLinks_ConfigurableMaxRetries(t *testing.T) {
+	requestCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
+	lines, offset := toLines(markdown)
+
+	_, _ = rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 5, 0, rule.DefaultMaxConcurrency, 0, nil, &sync.Map{})
+
+	if requestCount != 1 {
+		t.Errorf("maxRetries=0: expected 1 request, got %d", requestCount)
 	}
 }
 
@@ -823,7 +875,7 @@ func TestPerformCheck_UserAgentHeader(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)", ts.URL)
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
 
 	if !strings.Contains(gotUA, "gomarklint") {
 		t.Errorf("expected User-Agent to contain 'gomarklint', got %q", gotUA)


### PR DESCRIPTION
## Summary

- Expose `DefaultMaxConcurrency` (10) and `DefaultMaxRetries` (2) as exported constants in the `rule` package
- Add `maxConcurrency` and `maxRetries` as config options for the `external-link` rule, consistent with the existing `retryDelayMs`
- Update `CheckExternalLinks` and `checkURL` signatures to accept the new parameters; linter reads them via `externalLinkMaxConcurrency()` / `externalLinkMaxRetries()` helpers

**Config example:**
```json
{
  "rules": {
    "external-link": {
      "enabled": true,
      "maxConcurrency": 5,
      "maxRetries": 0
    }
  }
}
```

Closes #175

## Test plan

- [x] `make test` — all packages at 100% coverage
- [x] `make test-e2e` — all E2E cases pass
- [x] New tests: `TestCheckExternalLinks_ConfigurableMaxConcurrency` verifies concurrency cap is enforced; `TestCheckExternalLinks_ConfigurableMaxRetries` verifies `maxRetries=0` results in a single request
- [x] New linter tests: `TestExternalLink_ConfigurableMaxConcurrency`, `TestExternalLink_ConfigurableMaxRetries`, `TestExternalLink_MaxRetriesZeroIsValid`