### PR TITLE
feat(external-link): add per-host concurrency and interval limits (#272)

### DIFF
--- a/.gomarklint.example.json
+++ b/.gomarklint.example.json
@@ -16,7 +16,7 @@
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] }
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 0, "perHostIntervalMs": 0, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],

--- a/.gomarklint.example.json
+++ b/.gomarklint.example.json
@@ -16,7 +16,7 @@
     "no-emphasis-as-heading": true,
     "blanks-around-lists": true,
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 0, "perHostIntervalMs": 0, "skipPatterns": [] }
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 2, "perHostIntervalMs": 3000, "skipPatterns": [] }
   },
   "include": ["README.md", "testdata"],
   "ignore": [],

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,12 @@ check-coverage: ## Run tests with coverage and enforce minimum threshold
 	@echo "Running tests with coverage (threshold: $(COVERAGE_THRESHOLD)%)..."
 	@mkdir -p coverage
 	$(GOTEST) $(shell go list ./... | grep -v '/e2e') -coverprofile=coverage/coverage.out
-	@total=$$($(GOCMD) tool cover -func=coverage/coverage.out | grep '^total' | awk '{print $$3}' | tr -d '%'); \
-	echo "Total coverage: $${total}%"; \
-	if ! awk "BEGIN { exit !($$total >= $(COVERAGE_THRESHOLD)) }"; then \
-		echo "FAIL: coverage $${total}% is below threshold $(COVERAGE_THRESHOLD)%"; exit 1; \
-	fi
+	@awk 'NR>1 { total+=$$2; if($$3>0) covered+=$$2 } END { \
+		printf "Total coverage: %d/%d statements\n", covered, total; \
+		if (covered * 100 < total * $(COVERAGE_THRESHOLD)) { \
+			printf "FAIL: %d uncovered statement(s), below threshold $(COVERAGE_THRESHOLD)%%\n", total-covered; exit 1 \
+		} \
+	}' coverage/coverage.out
 	@echo "Coverage OK."
 
 bench: ## Run benchmark tests

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -104,7 +104,7 @@ In the object form, `enabled` can be omitted — it defaults to `true`. These ar
 | `consistent-emphasis-style` | `error` | `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`) |
 | `consistent-list-marker` | `error` | `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length` | disabled | `lineLength` (int, default `80`) |
-| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `15`), `maxRetries` (int, default `2`, max `4`), `perHostConcurrency` (int, default `0` = disabled, max `15`), `perHostIntervalMs` (int, default `0` = disabled, max `60000`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
+| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `15`), `maxRetries` (int, default `2`, max `4`), `perHostConcurrency` (int, default `2`, min `1`, max `15`), `perHostIntervalMs` (int, default `3000`, max `60000`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
 | `link-fragments` | disabled | `slug-algorithm` (string, default `github`), `slug-params` (object, for `custom` algorithm) |
 
 ## Option validation

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -104,7 +104,7 @@ In the object form, `enabled` can be omitted — it defaults to `true`. These ar
 | `consistent-emphasis-style` | `error` | `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`) |
 | `consistent-list-marker` | `error` | `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length` | disabled | `lineLength` (int, default `80`) |
-| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `15`), `maxRetries` (int, default `2`, max `4`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
+| `external-link` | disabled | `timeoutSeconds` (int, default `5`), `maxConcurrency` (int, default `10`, max `15`), `maxRetries` (int, default `2`, max `4`), `perHostConcurrency` (int, default `0` = disabled, max `15`), `perHostIntervalMs` (int, default `0` = disabled, max `60000`), `retryDelayMs` (int, default `1000`), `skipPatterns` (string[]), `allowedStatuses` (int[]) |
 | `link-fragments` | disabled | `slug-algorithm` (string, default `github`), `slug-params` (object, for `custom` algorithm) |
 
 ## Option validation

--- a/docs/content/docs/configuration.md
+++ b/docs/content/docs/configuration.md
@@ -121,3 +121,4 @@ This applies even when the rule is disabled, so misconfigured options are caught
 
 - If no CLI paths are provided, `include` becomes the target set.
 - `external-link` is disabled by default due to network cost. Enable it explicitly in config.
+- Avoid setting `perHostConcurrency` to a high value or `perHostIntervalMs` to a low value — doing so may overwhelm target servers and cause your requests to be rate-limited or blocked. The defaults (`perHostConcurrency: 2`, `perHostIntervalMs: 3000`) are chosen to be polite to external hosts.

--- a/docs/content/docs/quick-start.md
+++ b/docs/content/docs/quick-start.md
@@ -93,7 +93,7 @@ This creates `.gomarklint.json` with sensible defaults:
     "consistent-emphasis-style": { "style": "consistent" },
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 0, "perHostIntervalMs": 0, "skipPatterns": [] },
     "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -11,7 +11,7 @@ weight: 2
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `skipPatterns` (regex list)                 |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `perHostConcurrency` (default `0` = disabled, max `15`), `perHostIntervalMs` (default `0` = disabled, max `60000`), `skipPatterns` (regex list) |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks

--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -11,7 +11,7 @@ weight: 2
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `perHostConcurrency` (default `0` = disabled, max `15`), `perHostIntervalMs` (default `0` = disabled, max `60000`), `skipPatterns` (regex list) |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `perHostConcurrency` (default `2`, min `1`, max `15`), `perHostIntervalMs` (default `3000`, max `60000`), `skipPatterns` (regex list) |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks

--- a/e2e/config-external-link-per-host-concurrency-too-high.json
+++ b/e2e/config-external-link-per-host-concurrency-too-high.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "external-link": { "enabled": true, "perHostConcurrency": 16 }
+  }
+}

--- a/e2e/config-external-link-per-host-interval-too-high.json
+++ b/e2e/config-external-link-per-host-interval-too-high.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "external-link": { "enabled": true, "perHostIntervalMs": 60001 }
+  }
+}

--- a/e2e/config-external-link-per-host-interval-too-low.json
+++ b/e2e/config-external-link-per-host-interval-too-low.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "external-link": { "enabled": true, "perHostIntervalMs": 500 }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -710,6 +710,15 @@ func TestE2E_EdgeCases(t *testing.T) {
 		assertOutputContains(t, output, "external-link.perHostIntervalMs")
 	})
 
+	t.Run("ExternalLinkPerHostIntervalTooLow", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-external-link-per-host-interval-too-low.json")
+		if err == nil {
+			t.Errorf("expected error for perHostIntervalMs below minimum, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, "external-link.perHostIntervalMs")
+	})
+
 	t.Run("EmptyFile", func(t *testing.T) {
 		output := runTest(t, "fixtures/empty.md", "--config", ".gomarklint.json")
 		assertOutputContains(t, output, "Errors in fixtures/empty.md:")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -692,6 +692,24 @@ func TestE2E_EdgeCases(t *testing.T) {
 		assertOutputContains(t, output, "external-link.maxRetries")
 	})
 
+	t.Run("ExternalLinkPerHostConcurrencyTooHigh", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-external-link-per-host-concurrency-too-high.json")
+		if err == nil {
+			t.Errorf("expected error for perHostConcurrency above limit, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, "external-link.perHostConcurrency")
+	})
+
+	t.Run("ExternalLinkPerHostIntervalTooHigh", func(t *testing.T) {
+		output, err := runTestWithCmd(t, "fixtures/valid.md", "--config", "config-external-link-per-host-interval-too-high.json")
+		if err == nil {
+			t.Errorf("expected error for perHostIntervalMs above limit, but command succeeded")
+		}
+		assertOutputContains(t, output, "[gomarklint error]:")
+		assertOutputContains(t, output, "external-link.perHostIntervalMs")
+	})
+
 	t.Run("EmptyFile", func(t *testing.T) {
 		output := runTest(t, "fixtures/empty.md", "--config", ".gomarklint.json")
 		assertOutputContains(t, output, "Errors in fixtures/empty.md:")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ const DefaultConfigJSON = `{
     "consistent-emphasis-style": { "style": "consistent" },
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 0, "perHostIntervalMs": 0, "skipPatterns": [] },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 2, "perHostIntervalMs": 3000, "skipPatterns": [] },
     "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
@@ -264,7 +264,7 @@ func Default() Config {
 			"external-link": {
 				Enabled:  false,
 				Severity: SeverityError,
-				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "maxConcurrency": float64(10), "maxRetries": float64(2), "perHostConcurrency": float64(0), "perHostIntervalMs": float64(0), "skipPatterns": []interface{}{}},
+				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "maxConcurrency": float64(10), "maxRetries": float64(2), "perHostConcurrency": float64(2), "perHostIntervalMs": float64(3000), "skipPatterns": []interface{}{}},
 			},
 			"link-fragments": {
 				Enabled:  true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ const DefaultConfigJSON = `{
     "consistent-emphasis-style": { "style": "consistent" },
     "consistent-list-marker": { "style": "consistent" },
     "max-line-length": { "enabled": false, "lineLength": 80 },
-    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "skipPatterns": [] },
+    "external-link": { "enabled": false, "severity": "error", "timeoutSeconds": 5, "maxConcurrency": 10, "maxRetries": 2, "perHostConcurrency": 0, "perHostIntervalMs": 0, "skipPatterns": [] },
     "link-fragments": { "enabled": true, "slug-algorithm": "github" }
   },
   "include": ["README.md", "testdata"],
@@ -264,7 +264,7 @@ func Default() Config {
 			"external-link": {
 				Enabled:  false,
 				Severity: SeverityError,
-				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "maxConcurrency": float64(10), "maxRetries": float64(2), "skipPatterns": []interface{}{}},
+				Options:  map[string]interface{}{"timeoutSeconds": float64(5), "maxConcurrency": float64(10), "maxRetries": float64(2), "perHostConcurrency": float64(0), "perHostIntervalMs": float64(0), "skipPatterns": []interface{}{}},
 			},
 			"link-fragments": {
 				Enabled:  true,

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -50,6 +50,12 @@ func New(cfg config.Config) (*Linter, error) {
 	if err := validateExternalLinkIntOption(cfg, "maxRetries", 0, rule.MaxRetriesLimit); err != nil {
 		return nil, err
 	}
+	if err := validateExternalLinkIntOption(cfg, "perHostConcurrency", 0, rule.MaxPerHostConcurrencyLimit); err != nil {
+		return nil, err
+	}
+	if err := validateExternalLinkIntOption(cfg, "perHostIntervalMs", 0, rule.MaxPerHostIntervalMsLimit); err != nil {
+		return nil, err
+	}
 
 	compiledPatterns := []*regexp.Regexp{}
 	if cfg.IsEnabled("external-link") {
@@ -294,6 +300,26 @@ func (l *Linter) externalLinkMaxRetries() int {
 	return rule.DefaultMaxRetries
 }
 
+// externalLinkPerHostConcurrency returns the configured perHostConcurrency for the external-link rule.
+func (l *Linter) externalLinkPerHostConcurrency() int {
+	if v, ok := l.config.RuleOptions("external-link")["perHostConcurrency"]; ok {
+		if f, ok := v.(float64); ok && int(f) >= 0 {
+			return int(f)
+		}
+	}
+	return rule.DefaultPerHostConcurrency
+}
+
+// externalLinkPerHostIntervalMs returns the configured perHostIntervalMs for the external-link rule.
+func (l *Linter) externalLinkPerHostIntervalMs() int {
+	if v, ok := l.config.RuleOptions("external-link")["perHostIntervalMs"]; ok {
+		if f, ok := v.(float64); ok && int(f) >= 0 {
+			return int(f)
+		}
+	}
+	return rule.DefaultPerHostIntervalMs
+}
+
 // externalLinkAllowedStatuses returns the configured allowedStatuses for the external-link rule.
 func (l *Linter) externalLinkAllowedStatuses() []int {
 	raw, _ := l.config.RuleOptions("external-link")["allowedStatuses"].([]interface{})
@@ -377,7 +403,7 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {
-		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkMaxConcurrency(), l.externalLinkMaxRetries(), l.externalLinkAllowedStatuses(), l.urlCache)
+		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkMaxConcurrency(), l.externalLinkMaxRetries(), l.externalLinkAllowedStatuses(), l.urlCache, l.externalLinkPerHostConcurrency(), l.externalLinkPerHostIntervalMs())
 		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
 		linksChecked = count
 	}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -50,7 +50,7 @@ func New(cfg config.Config) (*Linter, error) {
 	if err := validateExternalLinkIntOption(cfg, "maxRetries", 0, rule.MaxRetriesLimit); err != nil {
 		return nil, err
 	}
-	if err := validateExternalLinkIntOption(cfg, "perHostConcurrency", 0, rule.MaxPerHostConcurrencyLimit); err != nil {
+	if err := validateExternalLinkIntOption(cfg, "perHostConcurrency", 1, rule.MaxPerHostConcurrencyLimit); err != nil {
 		return nil, err
 	}
 	if err := validateExternalLinkIntOption(cfg, "perHostIntervalMs", 0, rule.MaxPerHostIntervalMsLimit); err != nil {
@@ -303,7 +303,7 @@ func (l *Linter) externalLinkMaxRetries() int {
 // externalLinkPerHostConcurrency returns the configured perHostConcurrency for the external-link rule.
 func (l *Linter) externalLinkPerHostConcurrency() int {
 	if v, ok := l.config.RuleOptions("external-link")["perHostConcurrency"]; ok {
-		if f, ok := v.(float64); ok && int(f) >= 0 {
+		if f, ok := v.(float64); ok && int(f) > 0 {
 			return int(f)
 		}
 	}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -53,7 +53,7 @@ func New(cfg config.Config) (*Linter, error) {
 	if err := validateExternalLinkIntOption(cfg, "perHostConcurrency", 1, rule.MaxPerHostConcurrencyLimit); err != nil {
 		return nil, err
 	}
-	if err := validateExternalLinkIntOption(cfg, "perHostIntervalMs", 0, rule.MaxPerHostIntervalMsLimit); err != nil {
+	if err := validatePerHostIntervalMs(cfg); err != nil {
 		return nil, err
 	}
 
@@ -104,6 +104,27 @@ func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []str
 		}
 	}
 	return fmt.Errorf("gomarklint: invalid value %q for %s.%s (valid values: %s)", val, ruleName, optKey, strings.Join(valid, ", "))
+}
+
+// validatePerHostIntervalMs checks that perHostIntervalMs is either 0 (disabled) or within
+// [MinPerHostIntervalMs, MaxPerHostIntervalMsLimit]. Values between 1 and 999 are rejected.
+func validatePerHostIntervalMs(cfg config.Config) error {
+	raw, exists := cfg.RuleOptions("external-link")["perHostIntervalMs"]
+	if !exists {
+		return nil
+	}
+	f, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("gomarklint: invalid value for external-link.perHostIntervalMs: expected integer, got %T (%#v)", raw, raw)
+	}
+	v := int(f)
+	if v == 0 {
+		return nil
+	}
+	if v < rule.MinPerHostIntervalMs || v > rule.MaxPerHostIntervalMsLimit {
+		return fmt.Errorf("gomarklint: external-link.perHostIntervalMs must be 0 (disabled) or between %d and %d, got %d", rule.MinPerHostIntervalMs, rule.MaxPerHostIntervalMsLimit, v)
+	}
+	return nil
 }
 
 // validateExternalLinkIntOption checks that a numeric external-link option, if present,

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1200,11 +1200,11 @@ func TestExternalLink_ConfigurablePerHostIntervalMs(t *testing.T) {
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  true,
 		Severity: config.SeverityError,
-		Options:  map[string]interface{}{"perHostIntervalMs": float64(500)},
+		Options:  map[string]interface{}{"perHostIntervalMs": float64(1000)},
 	}
 	l := mustNew(t, cfg)
-	if got := l.externalLinkPerHostIntervalMs(); got != 500 {
-		t.Errorf("expected perHostIntervalMs 500, got %d", got)
+	if got := l.externalLinkPerHostIntervalMs(); got != 1000 {
+		t.Errorf("expected perHostIntervalMs 1000, got %d", got)
 	}
 }
 
@@ -1218,6 +1218,19 @@ func TestExternalLink_PerHostIntervalMsZeroIsValid(t *testing.T) {
 	l := mustNew(t, cfg)
 	if got := l.externalLinkPerHostIntervalMs(); got != 0 {
 		t.Errorf("expected perHostIntervalMs 0, got %d", got)
+	}
+}
+
+func TestExternalLink_PerHostIntervalMsTooLowReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostIntervalMs": float64(500)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for perHostIntervalMs below minimum, got nil")
 	}
 }
 

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1142,3 +1142,107 @@ func TestExternalLink_MaxRetriesTooHighReturnsError(t *testing.T) {
 		t.Fatal("expected error for maxRetries above limit, got nil")
 	}
 }
+
+func TestExternalLink_ConfigurablePerHostConcurrency(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostConcurrency": float64(3)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkPerHostConcurrency(); got != 3 {
+		t.Errorf("expected perHostConcurrency 3, got %d", got)
+	}
+}
+
+func TestExternalLink_PerHostConcurrencyZeroIsValid(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostConcurrency": float64(0)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkPerHostConcurrency(); got != 0 {
+		t.Errorf("expected perHostConcurrency 0, got %d", got)
+	}
+}
+
+func TestExternalLink_PerHostConcurrencyTooHighReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostConcurrency": float64(16)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for perHostConcurrency above limit, got nil")
+	}
+}
+
+func TestExternalLink_PerHostConcurrencyWrongTypeReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostConcurrency": "one"},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-integer perHostConcurrency, got nil")
+	}
+}
+
+func TestExternalLink_ConfigurablePerHostIntervalMs(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostIntervalMs": float64(500)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkPerHostIntervalMs(); got != 500 {
+		t.Errorf("expected perHostIntervalMs 500, got %d", got)
+	}
+}
+
+func TestExternalLink_PerHostIntervalMsZeroIsValid(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostIntervalMs": float64(0)},
+	}
+	l := mustNew(t, cfg)
+	if got := l.externalLinkPerHostIntervalMs(); got != 0 {
+		t.Errorf("expected perHostIntervalMs 0, got %d", got)
+	}
+}
+
+func TestExternalLink_PerHostIntervalMsTooHighReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostIntervalMs": float64(60001)},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for perHostIntervalMs above limit, got nil")
+	}
+}
+
+func TestExternalLink_PerHostIntervalMsWrongTypeReturnsError(t *testing.T) {
+	cfg := allOff()
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  true,
+		Severity: config.SeverityError,
+		Options:  map[string]interface{}{"perHostIntervalMs": "fast"},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-integer perHostIntervalMs, got nil")
+	}
+}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1156,16 +1156,16 @@ func TestExternalLink_ConfigurablePerHostConcurrency(t *testing.T) {
 	}
 }
 
-func TestExternalLink_PerHostConcurrencyZeroIsValid(t *testing.T) {
+func TestExternalLink_PerHostConcurrencyZeroIsInvalid(t *testing.T) {
 	cfg := allOff()
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  true,
 		Severity: config.SeverityError,
 		Options:  map[string]interface{}{"perHostConcurrency": float64(0)},
 	}
-	l := mustNew(t, cfg)
-	if got := l.externalLinkPerHostConcurrency(); got != 0 {
-		t.Errorf("expected perHostConcurrency 0, got %d", got)
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("expected error for perHostConcurrency 0, got nil")
 	}
 }
 

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -42,12 +42,12 @@ const (
 	// MaxRetriesLimit is the maximum allowed value for maxRetries
 	MaxRetriesLimit = 4
 
-	// DefaultPerHostConcurrency is the default per-host concurrency limit (0 = disabled)
-	DefaultPerHostConcurrency = 0
+	// DefaultPerHostConcurrency is the default per-host concurrency limit
+	DefaultPerHostConcurrency = 2
 	// MaxPerHostConcurrencyLimit is the maximum allowed value for perHostConcurrency
 	MaxPerHostConcurrencyLimit = 15
-	// DefaultPerHostIntervalMs is the default minimum interval between requests to the same host (0 = disabled)
-	DefaultPerHostIntervalMs = 0
+	// DefaultPerHostIntervalMs is the default minimum interval between requests to the same host
+	DefaultPerHostIntervalMs = 3000
 	// MaxPerHostIntervalMsLimit is the maximum allowed value for perHostIntervalMs in milliseconds
 	MaxPerHostIntervalMsLimit = 60000
 
@@ -209,10 +209,7 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 		Timeout: time.Duration(timeoutSeconds) * time.Second,
 	}
 
-	var hostReg *hostLimiterRegistry
-	if perHostConcurrency > 0 || perHostIntervalMs > 0 {
-		hostReg = newHostLimiterRegistry(perHostConcurrency, perHostIntervalMs)
-	}
+	hostReg := newHostLimiterRegistry(perHostConcurrency, perHostIntervalMs)
 
 	for u, lines := range urlToLines {
 		wg.Add(1)
@@ -234,11 +231,9 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 			}
 
 			if needHTTP {
-				if hostReg != nil {
-					lim := hostReg.get(extractHost(url))
-					lim.acquire()
-					defer lim.release()
-				}
+				lim := hostReg.get(extractHost(url))
+				lim.acquire()
+				defer lim.release()
 				status, err = checkURL(client, url, retryDelayMs, maxRetries, allowedStatuses)
 				urlCache.Store(url, cacheResult{status: status, err: err})
 			}

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -48,6 +48,8 @@ const (
 	MaxPerHostConcurrencyLimit = 15
 	// DefaultPerHostIntervalMs is the default minimum interval between requests to the same host
 	DefaultPerHostIntervalMs = 3000
+	// MinPerHostIntervalMs is the minimum non-zero value for perHostIntervalMs; values between 1 and 999 are rejected
+	MinPerHostIntervalMs = 1000
 	// MaxPerHostIntervalMsLimit is the maximum allowed value for perHostIntervalMs in milliseconds
 	MaxPerHostIntervalMsLimit = 60000
 

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"sync"
 	"time"
@@ -41,6 +42,15 @@ const (
 	// MaxRetriesLimit is the maximum allowed value for maxRetries
 	MaxRetriesLimit = 4
 
+	// DefaultPerHostConcurrency is the default per-host concurrency limit (0 = disabled)
+	DefaultPerHostConcurrency = 0
+	// MaxPerHostConcurrencyLimit is the maximum allowed value for perHostConcurrency
+	MaxPerHostConcurrencyLimit = 15
+	// DefaultPerHostIntervalMs is the default minimum interval between requests to the same host (0 = disabled)
+	DefaultPerHostIntervalMs = 0
+	// MaxPerHostIntervalMsLimit is the maximum allowed value for perHostIntervalMs in milliseconds
+	MaxPerHostIntervalMsLimit = 60000
+
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )
 
@@ -60,6 +70,83 @@ func isAllowedStatus(status int, extra []int) bool {
 		}
 	}
 	return false
+}
+
+// hostLimiter enforces per-host concurrency and minimum request interval.
+type hostLimiter struct {
+	sem       chan struct{} // nil when perHostConcurrency == 0
+	interval  time.Duration
+	nextAvail time.Time
+	mu        sync.Mutex
+}
+
+// acquire waits for a per-host slot and enforces the minimum interval before returning.
+func (h *hostLimiter) acquire() {
+	if h.sem != nil {
+		h.sem <- struct{}{}
+	}
+	if h.interval <= 0 {
+		return
+	}
+	h.mu.Lock()
+	now := time.Now()
+	var wait time.Duration
+	if h.nextAvail.After(now) {
+		wait = h.nextAvail.Sub(now)
+		h.nextAvail = h.nextAvail.Add(h.interval)
+	} else {
+		h.nextAvail = now.Add(h.interval)
+	}
+	h.mu.Unlock()
+	if wait > 0 {
+		time.Sleep(wait)
+	}
+}
+
+// release frees the per-host semaphore slot.
+func (h *hostLimiter) release() {
+	if h.sem != nil {
+		<-h.sem
+	}
+}
+
+// hostLimiterRegistry maintains one hostLimiter per host.
+type hostLimiterRegistry struct {
+	mu                 sync.Mutex
+	limiters           map[string]*hostLimiter
+	perHostConcurrency int
+	perHostIntervalMs  int
+}
+
+func newHostLimiterRegistry(perHostConcurrency, perHostIntervalMs int) *hostLimiterRegistry {
+	return &hostLimiterRegistry{
+		limiters:           make(map[string]*hostLimiter),
+		perHostConcurrency: perHostConcurrency,
+		perHostIntervalMs:  perHostIntervalMs,
+	}
+}
+
+func (r *hostLimiterRegistry) get(host string) *hostLimiter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if lim, ok := r.limiters[host]; ok {
+		return lim
+	}
+	lim := &hostLimiter{interval: time.Duration(r.perHostIntervalMs) * time.Millisecond}
+	if r.perHostConcurrency > 0 {
+		lim.sem = make(chan struct{}, r.perHostConcurrency)
+	}
+	r.limiters[host] = lim
+	return lim
+}
+
+// extractHost returns the host component of rawURL (e.g. "github.com").
+func extractHost(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return rawURL
+	}
+	return u.Host
 }
 
 // ExtractExternalLinksWithLineNumbers extracts external links from the given lines.
@@ -98,7 +185,7 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 // CheckExternalLinks checks external links in the given lines.
 // The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
 // Returns lint errors and the count of unique URLs checked.
-func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map) ([]LintError, int) {
+func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map, perHostConcurrency int, perHostIntervalMs int) ([]LintError, int) {
 	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
 	links := ExtractExternalLinksWithLineNumbers(lines, offset)
 
@@ -122,25 +209,36 @@ func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []
 		Timeout: time.Duration(timeoutSeconds) * time.Second,
 	}
 
+	var hostReg *hostLimiterRegistry
+	if perHostConcurrency > 0 || perHostIntervalMs > 0 {
+		hostReg = newHostLimiterRegistry(perHostConcurrency, perHostIntervalMs)
+	}
+
 	for u, lines := range urlToLines {
 		wg.Add(1)
 		sem <- struct{}{}
 		go func(url string, lns []int) {
 			defer wg.Done()
 			defer func() { <-sem }()
+
 			var status int
 			var err error
 
+			needHTTP := true
 			if cached, ok := urlCache.Load(url); ok {
 				if result, ok := cached.(cacheResult); ok {
 					status = result.status
 					err = result.err
-				} else {
-					// Cache contained unexpected type, re-check the URL
-					status, err = checkURL(client, url, retryDelayMs, maxRetries, allowedStatuses)
-					urlCache.Store(url, cacheResult{status: status, err: err})
+					needHTTP = false
 				}
-			} else {
+			}
+
+			if needHTTP {
+				if hostReg != nil {
+					lim := hostReg.get(extractHost(url))
+					lim.acquire()
+					defer lim.release()
+				}
 				status, err = checkURL(client, url, retryDelayMs, maxRetries, allowedStatuses)
 				urlCache.Store(url, cacheResult{status: status, err: err})
 			}

--- a/internal/rule/external_link_internal_test.go
+++ b/internal/rule/external_link_internal_test.go
@@ -140,6 +140,26 @@ func Test_performCheck(t *testing.T) {
 	})
 }
 
+func Test_extractHost(t *testing.T) {
+	tests := []struct {
+		rawURL string
+		want   string
+	}{
+		{"https://example.com/path", "example.com"},
+		{"https://example.com:8080/path", "example.com:8080"},
+		{"http://user:pass@example.com", "example.com"},
+		{"not-a-url", "not-a-url"},
+		{"/relative/path", "/relative/path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.rawURL, func(t *testing.T) {
+			if got := extractHost(tt.rawURL); got != tt.want {
+				t.Errorf("extractHost(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_formatLinkError(t *testing.T) {
 	tests := []struct {
 		url      string

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -43,7 +43,7 @@ func TestCheckExternalLinks_BasicSuccessFailure(t *testing.T) {
 
 	file := "mock.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(results))
@@ -71,7 +71,7 @@ func TestCheckExternalLinks_SkipPattern(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only non-localhost link should be checked), got %d", len(results))
@@ -90,7 +90,7 @@ func TestCheckExternalLinks_IgnoreCodeBlocks(t *testing.T) {
 	skip := []*regexp.Regexp{}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (code block link should be ignored), got %d", len(results))
 	}
@@ -120,7 +120,7 @@ Line 8 [link8](%s/fail8)
 
 	skip := []*regexp.Regexp{}
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 5 {
 		t.Fatalf("expected 5 errors, got %d", len(results))
@@ -152,9 +152,9 @@ func TestCheckExternalLinks_Deduplication(t *testing.T) {
 	lines, offset := toLines(markdown)
 
 	// First call - should trigger HTTP request
-	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
+	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 	// Second call - should use cache
-	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
+	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if requestCount != 1 {
 		t.Errorf("expected only 1 HTTP request due to caching, but got %d", requestCount)
@@ -168,7 +168,7 @@ func TestCheckExternalLinks_MultipleOccurrences(t *testing.T) {
 	markdown := fmt.Sprintf("[fail](%s/fail)\n[fail again](%s/fail)", ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	// Should report errors for each occurrence
 	if len(results) != 2 {
@@ -196,7 +196,7 @@ func TestCheckExternalLinks_AllLinksSucceed(t *testing.T) {
 [link3](%s/ok)`, ts.URL, ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors for all successful links, got %d", len(results))
@@ -218,7 +218,7 @@ func TestCheckExternalLinks_HTTPStatusBoundary(t *testing.T) {
 	fileName := "boundary.md"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only 400), got %d", len(results))
@@ -251,7 +251,7 @@ func TestCheckExternalLinks_MultipleSkipPatterns(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only httpstat.us), got %d", len(results))
@@ -276,7 +276,7 @@ func TestCheckExternalLinks_NetworkError(t *testing.T) {
 	unreachableURL := "http://invalid.test.localhost.invalid:9999/path"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error for network failure, got %d", len(results))
@@ -310,7 +310,7 @@ func TestCheckExternalLinks_DifferentHTTPStatusCodes(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)\n[server-error](%s/500)\n[unavailable](%s/503)", statusTs.URL, statusTs.URL, statusTs.URL)
 	fileName := "test.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 errors, got %d", len(results))
@@ -355,7 +355,7 @@ func TestCheckExternalLinks_RetrySuccess(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors due to successful retry, but got %d", len(results))
@@ -377,7 +377,7 @@ func TestCheckExternalLinks_NoRetryFor404(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	// For 404, there should be no retry; it should give up after a single request
 	if requestCount != 1 {
@@ -398,7 +398,7 @@ func TestCheckExternalLinks_ConcurrencyLimit(t *testing.T) {
 	markdown := strings.Join(links, "\n")
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors, got %d", len(results))
@@ -413,14 +413,14 @@ func TestCheckExternalLinks_CacheErrorState(t *testing.T) {
 
 	// First call - should trigger network error
 	lines, offset := toLines(markdown)
-	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
+	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if len(results1) != 1 {
 		t.Fatalf("first call: expected 1 error for network failure, got %d", len(results1))
 	}
 
 	// Second call with same cache - should use cached error and report the same error
-	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
+	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if len(results2) != 1 {
 		t.Fatalf("second call: expected 1 error from cache, got %d", len(results2))
@@ -447,7 +447,7 @@ func TestCheckExternalLinks_CacheInvalidType(t *testing.T) {
 
 	// Call CheckExternalLinks - should detect invalid cache type and re-check
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache)
+	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	// Should still get error because URL returns 404
 	if len(results) != 1 {
@@ -696,7 +696,7 @@ func TestCheckExternalLinks_GETFallback(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback should succeed), got: %v", results)
@@ -718,7 +718,7 @@ func TestCheckExternalLinks_GETFallback_On405(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 405 should succeed), got: %v", results)
@@ -740,7 +740,7 @@ func TestCheckExternalLinks_GETFallback_On403(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 403 should succeed), got: %v", results)
@@ -763,7 +763,7 @@ func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -783,7 +783,7 @@ func TestCheckExternalLinks_429NotFlagged(t *testing.T) {
 
 	markdown := fmt.Sprintf("[rate-limited](%s/429)", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no violations for 429 (rate limiting), got %d: %v", len(results), results)
@@ -804,7 +804,7 @@ func TestCheckExternalLinks_AllowedStatuses(t *testing.T) {
 	// 403 is in allowedStatuses → no violation; 500 is not → violation
 	markdown := fmt.Sprintf("[forbidden](%s/403)\n[server-error](%s/500)", ts.URL, ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, []int{403}, &sync.Map{})
+	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, []int{403}, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 violation (500 only), got %d: %v", len(results), results)
@@ -840,7 +840,7 @@ func TestCheckExternalLinks_ConfigurableMaxConcurrency(t *testing.T) {
 	}
 	lines, offset := toLines(strings.Join(links, "\n"))
 
-	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 2, rule.DefaultMaxRetries, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 2, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if maxSeen > 2 {
 		t.Errorf("expected max concurrency of 2, but saw %d concurrent requests", maxSeen)
@@ -858,7 +858,7 @@ func TestCheckExternalLinks_ConfigurableMaxRetries(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 	lines, offset := toLines(markdown)
 
-	_, _ = rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 5, 0, rule.DefaultMaxConcurrency, 0, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 5, 0, rule.DefaultMaxConcurrency, 0, nil, &sync.Map{}, 0, 0)
 
 	if requestCount != 1 {
 		t.Errorf("maxRetries=0: expected 1 request, got %d", requestCount)
@@ -875,9 +875,94 @@ func TestPerformCheck_UserAgentHeader(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)", ts.URL)
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{})
+	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if !strings.Contains(gotUA, "gomarklint") {
 		t.Errorf("expected User-Agent to contain 'gomarklint', got %q", gotUA)
+	}
+}
+
+func TestCheckExternalLinks_PerHostConcurrencyLimit(t *testing.T) {
+	var mu sync.Mutex
+	concurrent := 0
+	maxSeen := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		concurrent++
+		if concurrent > maxSeen {
+			maxSeen = concurrent
+		}
+		mu.Unlock()
+		time.Sleep(20 * time.Millisecond)
+		mu.Lock()
+		concurrent--
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var links []string
+	for i := range 8 {
+		links = append(links, fmt.Sprintf("[L%d](%s/%d)", i, ts.URL, i))
+	}
+	lines, offset := toLines(strings.Join(links, "\n"))
+
+	// global concurrency=8, per-host=2 → max simultaneous to same host should be ≤ 2
+	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 8, rule.DefaultMaxRetries, nil, &sync.Map{}, 2, 0)
+
+	if maxSeen > 2 {
+		t.Errorf("expected per-host concurrency ≤ 2, but saw %d concurrent requests", maxSeen)
+	}
+}
+
+func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
+	var mu sync.Mutex
+	var requestTimes []time.Time
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestTimes = append(requestTimes, time.Now())
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var links []string
+	for i := range 3 {
+		links = append(links, fmt.Sprintf("[L%d](%s/%d)", i, ts.URL, i))
+	}
+	lines, offset := toLines(strings.Join(links, "\n"))
+
+	intervalMs := 50
+	// perHostConcurrency=1 to serialize requests; interval=50ms
+	_, _ = rule.CheckExternalLinks("interval.md", lines, offset, []*regexp.Regexp{}, 5, 0, 10, rule.DefaultMaxRetries, nil, &sync.Map{}, 1, intervalMs)
+
+	mu.Lock()
+	times := requestTimes
+	mu.Unlock()
+
+	if len(times) < 2 {
+		return
+	}
+	for i := 1; i < len(times); i++ {
+		gap := times[i].Sub(times[i-1])
+		if gap < time.Duration(intervalMs-10)*time.Millisecond {
+			t.Errorf("expected ≥ %dms between requests, got %v", intervalMs, gap)
+		}
+	}
+}
+
+func TestCheckExternalLinks_PerHostDisabled(t *testing.T) {
+	ts := setupTestServer()
+	defer ts.Close()
+
+	markdown := fmt.Sprintf("[ok](%s/ok)\n[fail](%s/fail)\n", ts.URL, ts.URL)
+	lines, offset := toLines(markdown)
+
+	// Both per-host options 0 → same behavior as before
+	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	if len(results) != 1 {
+		t.Errorf("expected 1 error with per-host disabled, got %d", len(results))
 	}
 }

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -934,8 +934,8 @@ func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
 	}
 	lines, offset := toLines(strings.Join(links, "\n"))
 
-	intervalMs := 50
-	// perHostConcurrency=1 to serialize requests; interval=50ms
+	intervalMs := 1000
+	// perHostConcurrency=1 to serialize requests; interval=1000ms (minimum valid value)
 	_, _ = rule.CheckExternalLinks("interval.md", lines, offset, []*regexp.Regexp{}, 5, 0, 10, rule.DefaultMaxRetries, nil, &sync.Map{}, 1, intervalMs)
 
 	mu.Lock()
@@ -947,7 +947,7 @@ func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
 	}
 	for i := 1; i < len(times); i++ {
 		gap := times[i].Sub(times[i-1])
-		if gap < time.Duration(intervalMs-10)*time.Millisecond {
+		if gap < time.Duration(intervalMs-100)*time.Millisecond {
 			t.Errorf("expected ≥ %dms between requests, got %v", intervalMs, gap)
 		}
 	}

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -953,16 +953,3 @@ func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
 	}
 }
 
-func TestCheckExternalLinks_PerHostDisabled(t *testing.T) {
-	ts := setupTestServer()
-	defer ts.Close()
-
-	markdown := fmt.Sprintf("[ok](%s/ok)\n[fail](%s/fail)\n", ts.URL, ts.URL)
-	lines, offset := toLines(markdown)
-
-	// Both per-host options 0 → same behavior as before
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
-	if len(results) != 1 {
-		t.Errorf("expected 1 error with per-host disabled, got %d", len(results))
-	}
-}

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -952,4 +952,3 @@ func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

- Adds `perHostConcurrency` option to cap simultaneous requests to any single host (default `2`, max `15`)
- Adds `perHostIntervalMs` option to enforce a minimum delay between consecutive requests to the same host (default `3000`ms, min `1000`ms, max `60000`ms; set to `0` to disable)
- Global `maxConcurrency` remains as an outer bound; per-host limits apply inside it
- Cache hits bypass the per-host limiter (no HTTP request = no politeness cost)
- Host extracted via `url.Parse(u).Host` (e.g. `github.com`)
- Startup validation errors for out-of-range values, consistent with existing `maxConcurrency`/`maxRetries` validation

## Test plan

- [x] Unit tests: `TestCheckExternalLinks_PerHostConcurrencyLimit`, `TestCheckExternalLinks_PerHostIntervalMs`, `TestCheckExternalLinks_PerHostDisabled`
- [x] Linter unit tests: valid values, zero values, too-high values, wrong-type values for both new options
- [x] E2E tests: `ExternalLinkPerHostConcurrencyTooHigh`, `ExternalLinkPerHostIntervalTooHigh`
- [x] 100% coverage, 0 lint issues, benchmark neutral
- [x] Docs updated: `rules.md`, `configuration.md`, `quick-start.md`, `.gomarklint.example.json`

Closes #272