### PR TITLE
feat(external-link): switch retry backoff from linear to exponential (#176)

### DIFF
--- a/docs/content/docs/rules.md
+++ b/docs/content/docs/rules.md
@@ -11,7 +11,7 @@ weight: 2
 
 | Rule key                       | What it detects                                                         | Notes / Options                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `perHostConcurrency` (default `2`, min `1`, max `15`), `perHostIntervalMs` (default `3000`, max `60000`), `skipPatterns` (regex list) |
+| `external-link`                | External links that fail HTTP validation                                | Default **off**. Options: `timeoutSeconds` (default `5`), `maxConcurrency` (default `10`, max `15`), `maxRetries` (default `2`, max `4`), `retryDelayMs` (default `1000`), `perHostConcurrency` (default `2`, min `1`, max `15`), `perHostIntervalMs` (default `3000`, min `1000`, max `60000`; `0` = disabled), `skipPatterns` (regex list), `allowedStatuses` (int[]) |
 | `link-fragments`               | Internal fragment links (`#section`) that do not resolve to a heading  | Default **on**. Options: `slug-algorithm` (default `github`), `slug-params` (for `custom` algorithm) |
 
 ## Structure and formatting checks
@@ -39,6 +39,28 @@ weight: 2
 | `consistent-emphasis-style`    | Inconsistent emphasis marker (`*text*` vs `_text_`)                     | Default **on**. Option: `style` (`consistent` \| `asterisk` \| `underscore`, default `consistent`)   |
 | `consistent-list-marker`       | Inconsistent unordered list marker (`-` vs `*` vs `+`)                 | Default **on**. Option: `style` (`consistent` \| `dash` \| `asterisk` \| `plus`, default `consistent`) |
 | `max-line-length`              | Lines exceeding the configured maximum length                           | Default **off**. Option: `lineLength` (default `80`)                                                  |
+
+## external-link
+
+`external-link` performs HTTP validation of every external link in the document. It is disabled by default due to network cost.
+
+### Retry behavior
+
+On transient failures (5xx, network errors), gomarklint retries up to `maxRetries` times using **exponential backoff**: the wait before each retry doubles relative to the previous one.
+
+With the default `retryDelayMs: 1000` and `maxRetries: 2`:
+
+| Attempt | Wait before request |
+| --- | --- |
+| 1st (initial) | — |
+| 2nd (retry 1) | 1000 ms |
+| 3rd (retry 2) | 2000 ms |
+
+Permanent failures (404, 401) are not retried.
+
+### Per-host rate limiting
+
+`perHostConcurrency` and `perHostIntervalMs` limit how aggressively gomarklint hits any single host. The defaults (`perHostConcurrency: 2`, `perHostIntervalMs: 3000`) are intentionally conservative — avoid raising them to prevent your requests from being rate-limited or blocked. Set `perHostIntervalMs: 0` to disable the interval limit entirely.
 
 ## link-fragments
 

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -267,8 +267,7 @@ func checkURL(client *http.Client, url string, retryDelayMs int, maxRetries int,
 
 	for i := 0; i <= maxRetries; i++ {
 		if i > 0 {
-			// Wait a bit before retrying (simple backoff)
-			time.Sleep(retryDelay * time.Duration(i))
+			time.Sleep(retryDelay * time.Duration(1<<uint(i-1)))
 		}
 
 		status, err = performCheck(client, url)

--- a/internal/rule/external_link_internal_test.go
+++ b/internal/rule/external_link_internal_test.go
@@ -88,20 +88,23 @@ func Test_checkURL_ExponentialBackoff(t *testing.T) {
 	defer ts.Close()
 
 	// retryDelayMs=100, maxRetries=3 → delays: 100ms, 200ms, 400ms
+	// linear would give: 100ms, 200ms, 300ms — gap2/gap1 ≈ 1.5×
+	// exponential gives: 100ms, 200ms, 400ms — gap2/gap1 ≈ 2×
 	_, _ = checkURL(ts.Client(), ts.URL, 100, 3, nil)
 
 	mu.Lock()
 	times := requestTimes
 	mu.Unlock()
 
-	if len(times) < 3 {
-		t.Fatalf("expected at least 3 requests, got %d", len(times))
+	if len(times) < 4 {
+		t.Fatalf("expected 4 requests (initial + 3 retries), got %d", len(times))
 	}
-	gap0 := times[1].Sub(times[0])
 	gap1 := times[2].Sub(times[1])
-	// second gap should be roughly double the first
-	if gap1 < gap0 {
-		t.Errorf("expected exponential backoff: gap1 (%v) should be >= gap0 (%v)", gap1, gap0)
+	gap2 := times[3].Sub(times[2])
+	// exponential: gap2 ≈ 2× gap1; linear: gap2 ≈ 1.5× gap1
+	// require gap2 >= gap1 * 1.8 to distinguish the two
+	if gap2 < time.Duration(float64(gap1)*1.8) {
+		t.Errorf("expected exponential backoff: gap2 (%v) should be >= 1.8× gap1 (%v)", gap2, gap1)
 	}
 }
 

--- a/internal/rule/external_link_internal_test.go
+++ b/internal/rule/external_link_internal_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func Test_checkURL(t *testing.T) {
@@ -70,6 +72,36 @@ func Test_checkURL(t *testing.T) {
 				t.Errorf("expected status %d, got %d", tt.expectedStatus, status)
 			}
 		})
+	}
+}
+
+func Test_checkURL_ExponentialBackoff(t *testing.T) {
+	var mu sync.Mutex
+	var requestTimes []time.Time
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestTimes = append(requestTimes, time.Now())
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	// retryDelayMs=100, maxRetries=3 → delays: 100ms, 200ms, 400ms
+	_, _ = checkURL(ts.Client(), ts.URL, 100, 3, nil)
+
+	mu.Lock()
+	times := requestTimes
+	mu.Unlock()
+
+	if len(times) < 3 {
+		t.Fatalf("expected at least 3 requests, got %d", len(times))
+	}
+	gap0 := times[1].Sub(times[0])
+	gap1 := times[2].Sub(times[1])
+	// second gap should be roughly double the first
+	if gap1 < gap0 {
+		t.Errorf("expected exponential backoff: gap1 (%v) should be >= gap0 (%v)", gap1, gap0)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Changes the retry wait from linear (`retryDelay × i`) to exponential (`retryDelay × 2^(i-1)`)
- Delays now follow 1×, 2×, 4×, 8× the base `retryDelayMs` instead of 1×, 2×, 3×, 4×
- No change to public API or config options

## Test plan

- [x] `Test_checkURL_ExponentialBackoff`: verifies that the gap between retries grows with each attempt
- [x] Existing retry tests still pass

Closes #176