### PR TITLE
ci: harden GitHub Actions token permissions and pin Dockerfile base images

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   auto-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -6,13 +6,15 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      checks: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -26,7 +26,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      checks: write
       pull-requests: write
     steps:
       - name: Checkout code
@@ -37,7 +36,7 @@ jobs:
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
+          reporter: github-pr-review
           fail_level: error
 
   zizmor:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ RUN go mod download
 COPY . .
 RUN go build -o gomarklint .
 
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 RUN apk --no-cache add ca-certificates curl jq
 
 COPY --from=builder /app/gomarklint /usr/local/bin/gomarklint


### PR DESCRIPTION
## Summary

Addresses OpenSSF Scorecard alerts to improve supply-chain security posture.

- **golangci.yml** (#49): move `checks: write` from top-level to job-level permissions
- **lint-actions.yml** (#48): drop `checks: write`, switch actionlint reporter from `github-pr-check` to `github-pr-review` (which only requires `pull-requests: write`)
- **auto-label.yml** (#41): add top-level `permissions: contents: read` (jobs already had explicit job-level permissions)
- **Dockerfile** (#39, #47): pin `golang:1.26-alpine` and `alpine:latest` to SHA digests

## Related alerts

Closes Scorecard alerts: #39, #41, #47, #48, #49