### PR TITLE
test: add FuzzLintContent and fix index-out-of-range panic in no-emphasis-as-heading

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -38,6 +38,9 @@ jobs:
             if (title.startsWith('refactor:') || title.startsWith('refactor(')) {
               labels.push('refactor');
             }
+            if (title.startsWith('test:') || title.startsWith('test(')) {
+              labels.push('test');
+            }
             if (title.startsWith('deps:') || title.startsWith('deps(') || title.includes('dependencies')) {
               labels.push('dependencies');
             }
@@ -68,5 +71,5 @@ jobs:
       - name: Check for labels
         uses: docker://agilepathway/pull-request-label-checker@sha256:65e57fd98ba3ab6ca4fcbc5a0aef288dd984ee4ab988f124d83424d19b55b801
         with:
-          one_of: bug,documentation,duplicate,enhancement,help wanted,good first issue,invalid,question,wontfix,breaking-change,dependencies,chore,refactor
+          one_of: bug,documentation,duplicate,enhancement,help wanted,good first issue,invalid,question,wontfix,breaking-change,dependencies,chore,refactor,test
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/internal/linter/fuzz_test.go
+++ b/internal/linter/fuzz_test.go
@@ -15,7 +15,7 @@ func FuzzLintContent(f *testing.F) {
 		"[link text](https://example.com)\n",
 		"![alt text](image.png)\n",
 		"| col1 | col2 |\n|------|------|\n| a    | b    |\n",
-		"    code with hard tab\n",
+		"\tcode with hard tab\n",
 		"Line that is intentionally very long and exceeds the default maximum line length limit set by the linter configuration.\n",
 		"",
 		"---\ntitle: frontmatter\n---\n\n# Body\n",
@@ -30,7 +30,8 @@ func FuzzLintContent(f *testing.F) {
 	}
 
 	cfg := config.Default()
-	// Disable external-link to avoid network calls during fuzzing.
+	// Explicitly keep external-link disabled as a safeguard against network calls
+	// during fuzzing, even though config.Default() already disables it.
 	cfg.Rules["external-link"] = &config.RuleConfig{
 		Enabled:  false,
 		Severity: config.SeverityOff,

--- a/internal/linter/fuzz_test.go
+++ b/internal/linter/fuzz_test.go
@@ -1,0 +1,48 @@
+package linter
+
+import (
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/config"
+)
+
+func FuzzLintContent(f *testing.F) {
+	seeds := []string{
+		"# Hello\n\nWorld\n",
+		"## Section\n\nSome text with **bold** and _italic_.\n",
+		"```go\nfmt.Println(\"hello\")\n```\n",
+		"- item one\n- item two\n- item three\n",
+		"[link text](https://example.com)\n",
+		"![alt text](image.png)\n",
+		"| col1 | col2 |\n|------|------|\n| a    | b    |\n",
+		"    code with hard tab\n",
+		"Line that is intentionally very long and exceeds the default maximum line length limit set by the linter configuration.\n",
+		"",
+		"---\ntitle: frontmatter\n---\n\n# Body\n",
+		"# H1\n\n## H2\n\n### H3\n\n#### H4\n",
+		"https://bare-url.example.com\n",
+		"> blockquote\n",
+		"* [ ] task\n* [x] done\n",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	cfg := config.Default()
+	// Disable external-link to avoid network calls during fuzzing.
+	cfg.Rules["external-link"] = &config.RuleConfig{
+		Enabled:  false,
+		Severity: config.SeverityOff,
+		Options:  map[string]interface{}{},
+	}
+
+	l, err := New(cfg)
+	if err != nil {
+		f.Fatalf("failed to create linter: %v", err)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		l.LintContent("fuzz.md", data)
+	})
+}

--- a/internal/linter/testdata/fuzz/FuzzLintContent/b8f1c06291379309
+++ b/internal/linter/testdata/fuzz/FuzzLintContent/b8f1c06291379309
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("_*_")

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -76,8 +76,10 @@ var punctuationChars = map[rune]struct{}{
 
 // endsWithPunctuation reports whether s ends with sentence-ending punctuation.
 // When true, the emphasis is likely inline prose, not a heading.
-// s is always non-empty when called from CheckNoEmphasisAsHeading.
 func endsWithPunctuation(s string) bool {
+	if s == "" {
+		return false
+	}
 	runes := []rune(s)
 	_, ok := punctuationChars[runes[len(runes)-1]]
 	return ok

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -243,6 +243,13 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 			content:  "_under_score_\n",
 			wantErrs: nil,
 		},
+		{
+			name:    "violation: delimiter-only inner content does not panic",
+			content: "_*_\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 1, Message: "no-emphasis-as-heading: emphasis used as heading, use ATX heading instead: _*_"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Adds `FuzzLintContent` in `internal/linter/fuzz_test.go` targeting `linter.LintContent` — satisfies the OpenSSF Scorecard Fuzzing check (closes alert #46).
- The fuzzer immediately found a real panic: `_*_` input caused an index-out-of-range in `endsWithPunctuation` because `strings.TrimRight("*", "*_")` yields `""`, and the function blindly indexed `runes[len(runes)-1]`.
- Fixed by adding an empty-string guard in `endsWithPunctuation`.
- Added a regression test for the `_*_` case in `no_emphasis_as_heading_test.go`.
- Fuzz corpus entry `testdata/fuzz/FuzzLintContent/b8f1c06291379309` committed so future runs replay the crash input automatically.

## Test plan

- [x] `make test` passes (100% coverage maintained)
- [x] `go test -run=FuzzLintContent/b8f1c06291379309 ./internal/linter/` passes (was panicking before fix)
- [x] `go test -fuzz=FuzzLintContent -fuzztime=30s ./internal/linter/` ran ~4M executions with no panics

Closes #304