### PR TITLE
fix(ci): re-inject GITHUB_TOKEN for git push in update-major-tag job

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -78,7 +78,13 @@ jobs:
           persist-credentials: false
 
       - name: Update floating major version tag
+        # persist-credentials: false removes auth after checkout, so we must
+        # re-inject GITHUB_TOKEN into the remote URL before pushing.
+        # Do not remove this env block or the git remote set-url line.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           MAJOR=$(echo "${GITHUB_REF_NAME}" | cut -d. -f1)
           git tag -f "${MAJOR}" "${GITHUB_SHA}"
           git push origin "${MAJOR}" --force


### PR DESCRIPTION
## Summary

- Fixes `update-major-tag` job failure introduced in #292
- `persist-credentials: false` removes auth after checkout; explicitly re-injects `GITHUB_TOKEN` into the remote URL before `git push`

## Root cause

PR #292 added `persist-credentials: false` to all `actions/checkout` steps (ghalint requirement). The `update-major-tag` job does `git push origin "${MAJOR}" --force` after checkout, but with credentials removed there's nothing to authenticate with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

v3.2.0 succeeded because it ran before #292 was merged.

## Fix

Keep `persist-credentials: false` and manually set the remote URL with `GITHUB_TOKEN` before pushing. A comment is included to prevent the env block or `git remote set-url` line from being accidentally removed.

Closes #310