### PR TITLE
docs: sync website homepage with README badges and fix demo GIF rendering

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,6 +9,8 @@ title: "gomarklint"
 [![Go Report Card](https://goreportcard.com/badge/github.com/shinagawa-web/gomarklint)](https://goreportcard.com/report/github.com/shinagawa-web/gomarklint)
 [![Go Reference](https://pkg.go.dev/badge/github.com/shinagawa-web/gomarklint.svg)](https://pkg.go.dev/github.com/shinagawa-web/gomarklint)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/shinagawa-web/gomarklint/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/shinagawa-web/gomarklint/badge)](https://securityscorecards.dev/viewer/?uri=github.com/shinagawa-web/gomarklint)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12970/badge)](https://www.bestpractices.dev/projects/12970)
 
 <a href="https://gyazo.com/a5f8265a0865e5a37dc83733ca61069a"><img src="https://i.gyazo.com/a5f8265a0865e5a37dc83733ca61069a.gif" width="800" alt="Demo"></a>
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -3,6 +3,9 @@ languageCode = "en-us"
 title = "gomarklint"
 theme = "hugo-book"
 
+[markup.goldmark.renderer]
+  unsafe = true
+
 [params]
   BookToC = true
   BookRepo = "https://github.com/shinagawa-web/gomarklint"


### PR DESCRIPTION
## Summary

- Add missing OpenSSF Scorecard and OpenSSF Best Practices badges to the docs site homepage (`docs/content/_index.md`)
- Enable `unsafe = true` in Hugo's Goldmark renderer (`docs/hugo.toml`) so the raw HTML demo GIF embed is rendered correctly — it was silently stripped before this fix

## Test plan

- [ ] Verify demo GIF appears on the homepage after deploy
- [ ] Verify all 7 badges appear (Test, codecov, Go Report Card, Go Reference, License, OpenSSF Scorecard, OpenSSF Best Practices)