### PR TITLE
fix: add directory: Formula to goreleaser brews config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,7 @@ brews:
       owner: shinagawa-web
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
     homepage: "https://github.com/shinagawa-web/gomarklint"
     description: "A fast, extensible Markdown linter written in Go"
     license: "MIT"


### PR DESCRIPTION
## Summary

- Adds `directory: Formula` to the `brews` entry in `.goreleaser.yaml`
- Without this, GoReleaser writes `gomarklint.rb` to the root of `shinagawa-web/homebrew-tap` instead of `Formula/`
- `brew install shinagawa-web/tap/gomarklint` requires the formula to be under `Formula/`

The companion fix that moves the existing formula file lives in [shinagawa-web/homebrew-tap#2](https://github.com/shinagawa-web/homebrew-tap/pull/2).

Closes #315

## Test plan

- [ ] Pre-push hook passed (static lint + unit tests at 100% coverage)
- [ ] Verify next GoReleaser run writes to `Formula/gomarklint.rb` in homebrew-tap