### PR TITLE
fix(duplicate-heading): skip fenced code blocks and use strict ATX heading detection

### DIFF
--- a/internal/rule/duplicate_headings.go
+++ b/internal/rule/duplicate_headings.go
@@ -26,9 +26,13 @@ func CheckDuplicateHeadings(filename string, lines []string, offset int) []LintE
 	fenceMarker := ""
 
 	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 
 		if inBlock {
+			if first != fenceMarker[0] {
+				continue
+			}
+			trimmed := strings.TrimSpace(line)
 			if IsClosingFence(trimmed, fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
@@ -36,13 +40,19 @@ func CheckDuplicateHeadings(filename string, lines []string, offset int) []LintE
 			continue
 		}
 
+		if first != '#' && first != '`' && first != '~' {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+
 		if marker := openingFenceMarker(trimmed); marker != "" {
 			inBlock = true
 			fenceMarker = marker
 			continue
 		}
 
-		if !isATXHeading(trimmed) {
+		if first != '#' || !isATXHeading(trimmed) {
 			continue
 		}
 

--- a/internal/rule/duplicate_headings.go
+++ b/internal/rule/duplicate_headings.go
@@ -22,13 +22,31 @@ import (
 func CheckDuplicateHeadings(filename string, lines []string, offset int) []LintError {
 	var errs []LintError
 	seen := make(map[string]struct{}, len(lines)/10)
+	inBlock := false
+	fenceMarker := ""
 
 	for i, line := range lines {
-		if firstNonSpaceByte(line) != '#' {
+		trimmed := strings.TrimSpace(line)
+
+		if inBlock {
+			if IsClosingFence(trimmed, fenceMarker) {
+				inBlock = false
+				fenceMarker = ""
+			}
 			continue
 		}
-		line = strings.TrimSpace(line)
-		heading := strings.TrimSpace(strings.TrimLeft(line, "#"))
+
+		if marker := openingFenceMarker(trimmed); marker != "" {
+			inBlock = true
+			fenceMarker = marker
+			continue
+		}
+
+		if !isATXHeading(trimmed) {
+			continue
+		}
+
+		heading := strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
 		normalized := strings.ToLower(heading)
 
 		if _, ok := seen[normalized]; ok {

--- a/internal/rule/duplicate_headings_test.go
+++ b/internal/rule/duplicate_headings_test.go
@@ -54,6 +54,21 @@ func TestCheckDuplicateHeadings(t *testing.T) {
 				{File: "test.md", Line: 5, Message: `duplicate heading: "intro"`},
 			},
 		},
+		{
+			name: "hash inside fenced code block is ignored",
+			content: "## Full source\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```\n\n## Closer look\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```",
+			wantErrs: nil,
+		},
+		{
+			name: "hash inside tilde fenced code block is ignored",
+			content: "## Section A\n\n~~~python\n# comment\n~~~\n\n## Section B\n\n~~~python\n# comment\n~~~",
+			wantErrs: nil,
+		},
+		{
+			name:     "non-ATX hash (no space after #) is not a heading",
+			content:  "#hashtag\nSome text\n#hashtag",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/duplicate_headings_test.go
+++ b/internal/rule/duplicate_headings_test.go
@@ -55,13 +55,13 @@ func TestCheckDuplicateHeadings(t *testing.T) {
 			},
 		},
 		{
-			name: "hash inside fenced code block is ignored",
-			content: "## Full source\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```\n\n## Closer look\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```",
+			name:     "hash inside fenced code block is ignored",
+			content:  "## Full source\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```\n\n## Closer look\n\n```rust\n#[tokio::main]\nasync fn main() {}\n```",
 			wantErrs: nil,
 		},
 		{
-			name: "hash inside tilde fenced code block is ignored",
-			content: "## Section A\n\n~~~python\n# comment\n~~~\n\n## Section B\n\n~~~python\n# comment\n~~~",
+			name:     "hash inside tilde fenced code block is ignored",
+			content:  "## Section A\n\n~~~python\n# comment\n~~~\n\n## Section B\n\n~~~python\n# comment\n~~~",
 			wantErrs: nil,
 		},
 		{


### PR DESCRIPTION
## Summary

- `CheckDuplicateHeadings` now skips lines inside fenced code blocks (both backtick and tilde), matching the pattern already used by `single-h1`, `heading-level`, and `blanks-around-headings`.
- Replaced the permissive `firstNonSpaceByte(line) != '#'` check with `isATXHeading()`, which requires a space or end-of-line after the `#` markers — so `#[tokio::main]` and `#hashtag` are no longer misidentified as headings.

Fixes #330.

## Test plan

- [ ] `TestCheckDuplicateHeadings/hash_inside_fenced_code_block_is_ignored` — `#[tokio::main]` in two separate backtick blocks produces no errors
- [ ] `TestCheckDuplicateHeadings/hash_inside_tilde_fenced_code_block_is_ignored` — same for tilde fences
- [ ] `TestCheckDuplicateHeadings/non-ATX_hash_(no_space_after_#)_is_not_a_heading` — `#hashtag` repeated is not flagged
- [ ] All existing duplicate-heading tests continue to pass
- [ ] `make test-all` passes (unit + E2E + benchmark comparison)