### PR TITLE
fix(blanks-around-fences): treat single-line HTML comments as transparent

### DIFF
--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -22,8 +22,15 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 		if !inBlock && (inHTMLComment || strings.IndexByte(line, '<') >= 0) {
 			skip, stillInComment := stepHTMLComment(strings.TrimSpace(line), inHTMLComment)
 			if skip {
+				// Single-line HTML comments (<!-- ... --> on one line) are invisible
+				// in rendered output; preserve prevBlank so they don't break a
+				// blank-line chain established before the comment.
+				// Multi-line comment lines (opening, body, or closing) are not
+				// transparent and do reset the blank-line state.
+				if inHTMLComment || stillInComment {
+					prevBlank = false
+				}
 				inHTMLComment = stillInComment
-				prevBlank = false
 				continue
 			}
 		}
@@ -76,8 +83,11 @@ func stepHTMLComment(trimmed string, inComment bool) (bool, bool) {
 		}
 		return true, true
 	}
-	if strings.Contains(trimmed, "<!--") && !strings.Contains(trimmed, "-->") {
-		return true, true
+	if strings.Contains(trimmed, "<!--") {
+		if strings.Contains(trimmed, "-->") {
+			return true, false // single-line comment: <!-- ... -->
+		}
+		return true, true // opening of multi-line comment
 	}
 	return false, false
 }

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -20,14 +20,9 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 		// `<!--`-like content inside a fenced block is just code and must not
 		// interfere with detecting the closing fence.
 		if !inBlock && (inHTMLComment || strings.IndexByte(line, '<') >= 0) {
-			skip, stillInComment := stepHTMLComment(strings.TrimSpace(line), inHTMLComment)
+			skip, stillInComment, resetPrevBlank := stepHTMLComment(strings.TrimSpace(line), inHTMLComment)
 			if skip {
-				// Single-line HTML comments (<!-- ... --> on one line) are invisible
-				// in rendered output; preserve prevBlank so they don't break a
-				// blank-line chain established before the comment.
-				// Multi-line comment lines (opening, body, or closing) are not
-				// transparent and do reset the blank-line state.
-				if inHTMLComment || stillInComment {
+				if resetPrevBlank {
 					prevBlank = false
 				}
 				inHTMLComment = stillInComment
@@ -78,20 +73,26 @@ func appendMissingTrailingBlank(errs []LintError, filename string, lines []strin
 }
 
 // stepHTMLComment advances the HTML-comment state machine for one line.
-// It returns (skip, inComment) where skip indicates the caller should
-// `continue` past this line, and inComment is the updated state.
-func stepHTMLComment(trimmed string, inComment bool) (bool, bool) {
+// It returns (skip, newInComment, resetPrevBlank).
+// skip: caller should continue past this line.
+// newInComment: updated multi-line comment state.
+// resetPrevBlank: true when the line contains visible content and prevBlank
+// must be cleared; false for standalone single-line comments (<!-- ... -->)
+// that are invisible in rendered output and should not break a blank-line chain.
+func stepHTMLComment(trimmed string, inComment bool) (skip, newInComment, resetPrevBlank bool) {
 	if inComment {
 		if strings.Contains(trimmed, "-->") {
-			return true, false
+			return true, false, true
 		}
-		return true, true
+		return true, true, true
 	}
 	if strings.Contains(trimmed, "<!--") {
 		if strings.Contains(trimmed, "-->") {
-			return true, false // single-line comment: <!-- ... -->
+			// Standalone single-line comment is transparent; mixed lines like
+			// "text <!-- note -->" are not (HasPrefix distinguishes them).
+			return true, false, !strings.HasPrefix(trimmed, "<!--")
 		}
-		return true, true // opening of multi-line comment
+		return true, true, true
 	}
-	return false, false
+	return false, false, false
 }

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -39,14 +39,7 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
 				inBlock = false
 				fenceMarker = ""
-				// closing fence: check the next line
-				if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
-					errs = append(errs, LintError{
-						File:    filename,
-						Line:    offset + i + 1,
-						Message: "blanks-around-fences: fenced code block must be followed by a blank line",
-					})
-				}
+				errs = appendMissingTrailingBlank(errs, filename, lines, i, offset)
 			}
 			prevBlank = false
 			continue
@@ -70,6 +63,17 @@ func CheckBlanksAroundFences(filename string, lines []string, offset int) []Lint
 		prevBlank = isBlank
 	}
 
+	return errs
+}
+
+func appendMissingTrailingBlank(errs []LintError, filename string, lines []string, i, offset int) []LintError {
+	if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
+		return append(errs, LintError{
+			File:    filename,
+			Line:    offset + i + 1,
+			Message: "blanks-around-fences: fenced code block must be followed by a blank line",
+		})
+	}
 	return errs
 }
 

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -121,6 +121,28 @@ func TestCheckBlanksAroundFences(t *testing.T) {
 			content:  "Use <br> for line breaks.\n\n```go\nfmt.Println()\n```\n\nDone.\n",
 			wantErrs: nil,
 		},
+		{
+			name:     "valid: single-line HTML comment preceded by blank is transparent",
+			content:  "Some text\n\n<!-- comment -->\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:    "invalid: single-line HTML comment preceded by non-blank still triggers violation",
+			content: "Some text\n<!-- comment -->\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 3, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+			},
+		},
+		{
+			name:     "valid: gomarklint disable-next-line comment preceded by blank is transparent",
+			content:  "Some text\n\n<!-- gomarklint-disable-next-line -->\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
+		{
+			name:     "valid: multiple single-line HTML comments preceded by blank are all transparent",
+			content:  "Some text\n\n<!-- a -->\n<!-- b -->\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -143,6 +143,13 @@ func TestCheckBlanksAroundFences(t *testing.T) {
 			content:  "Some text\n\n<!-- a -->\n<!-- b -->\n```go\ncode\n```\n\nMore text\n",
 			wantErrs: nil,
 		},
+		{
+			name:    "invalid: line with visible text and inline comment before fence triggers violation",
+			content: "Some text\n\ntext <!-- comment -->\n```go\ncode\n```\n\nMore text\n",
+			wantErrs: []LintError{
+				{File: "test.md", Line: 4, Message: "blanks-around-fences: fenced code block must be preceded by a blank line"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `stepHTMLComment` did not recognize single-line HTML comments (`<!-- ... -->` on one line), returning `skip=false` and letting `prevBlank` fall to `false`
- This caused a false-positive "must be preceded by a blank line" on a fence immediately after a `<!-- gomarklint-disable-next-line -->` directive, making the directive and the rule mutually exclusive
- Fix: `stepHTMLComment` now returns `(true, false)` for single-line comments; `CheckBlanksAroundFences` preserves `prevBlank` when skipping them (multi-line comment lines still reset it as before)
- Also extracted `appendMissingTrailingBlank` helper to keep cyclomatic complexity within the lint threshold

Closes #331

## Test plan

- [ ] New unit tests in `blanks_around_fences_test.go`: single-line comment preceded by blank → no violation; preceded by non-blank → violation; `disable-next-line` preceded by blank → no violation; multiple single-line comments → all transparent
- [ ] Existing tests unchanged: multi-line HTML comment blocks still require a blank line before the fence
- [ ] `make test-all` passes (lint, unit, e2e, benchmark comparison)