### PR TITLE
chore(renovate): self-merge automerge for digest and github-actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
       "automerge": true
     },
     {
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest", "major"],
       "automerge": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,27 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "automerge": false,
+  "platformAutomerge": false,
   "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "requiredStatusChecks": ["Test / test"]
+      "automerge": true
     },
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "requiredStatusChecks": ["Test / test"]
+      "matchUpdateTypes": ["minor", "patch", "digest", "major"],
+      "automerge": true
     },
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["digest"],
-      "enabled": false
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Overview

Make Renovate auto-merge low-risk dependency PRs that previously piled up (docker digests, github-actions updates), using Renovate **self-merge** rather than GitHub native auto-merge.

## Why self-merge (`platformAutomerge: false`)

Native GitHub auto-merge does not gate correctly on this repo:

- **main has no branch protection** → no required status checks, so native auto-merge cannot wait for CI (it would merge immediately or refuse to enable).
- **Some checks are conditional** → action-lint checks (`zizmor`, `actionlint`, `ghalint`, `pinact`) only run on PRs touching workflow/action files. There is no fixed required-checks list that both gates action PRs and lets docker/gomod PRs through:
  - require them → docker/gomod PRs hang on checks that never run
  - don't require them → a PR failing *because of* `zizmor` (e.g. #329) becomes auto-mergeable

Renovate self-merge gates on the branch's aggregate status — every check that actually ran must be green — so docker PRs merge on `test`/`golangci` green, and action PRs that fail `zizmor` are correctly held back. No repository settings change required.

## Changes

- `platformAutomerge: false` — Renovate self-merges.
- Add **docker digest** and **github-actions digest/major** to automerge (previously docker digest had no rule and github-actions digest was disabled).
- `gomod` **major stays manual** (breaking changes need review).
- Modernize: `config:base` → `config:recommended`; drop deprecated `automergeType` / `requiredStatusChecks`.