### PR TITLE
ci(zizmor): ignore adhoc-packages for verify-distribution workflow

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,3 +4,9 @@ rules:
       # setup-go uses cache: false and setup-node uses cache: "", so no
       # cache is read or written in this workflow — poisoning is not possible.
       - goreleaser.yml
+  adhoc-packages:
+    ignore:
+      # This workflow intentionally installs the published npm package
+      # globally to verify the released distribution works end-to-end;
+      # there is no lockfile to install from by design.
+      - verify-distribution.yml


### PR DESCRIPTION
## Overview

zizmor-action pulls zizmor at `latest`, now **v1.26.1**, which adds the new **`adhoc-packages`** audit. It flags this line in `verify-distribution.yml`:

```yaml
- name: Install via npm
  run: npm install -g @shinagawa-web/gomarklint
```

> verify-distribution.yml:79: ad-hoc installation of packages: installs a package outside of a lockfile

## Why ignore (not fix the workflow)

That install is **intentional**: the workflow verifies the *published npm distribution* works end-to-end, so it must install the released package ad-hoc — there is no lockfile to install from by design. The finding is a false positive for this use.

## Change

Add an `adhoc-packages` ignore scoped to `verify-distribution.yml` only, mirroring the existing `cache-poisoning` ignore style in `.github/zizmor.yml`.

## Context

This unblocks #329 (zizmor-action v0.5.6 → v0.5.7), which currently fails on this exact finding. More broadly, since zizmor runs at `latest`, **any** PR touching workflow files would now hit this — so this fixes main going forward, not just #329. Once this merges, #329 will rebase green and auto-merge under the Renovate config from #338.