### PR TITLE
feat(preprocess): add shared context pre-pass package (#337 Phase 1)

### DIFF
--- a/internal/preprocess/fenced_code.go
+++ b/internal/preprocess/fenced_code.go
@@ -1,0 +1,50 @@
+package preprocess
+
+import "strings"
+
+// openingFenceMarker returns the full fence marker (e.g. "```", "````", "~~~")
+// if trimmed is an opening code fence, or an empty string otherwise. The full
+// run of fence characters is captured so that closing fences of the same length
+// are correctly matched. trimmed must already have its leading indentation
+// removed by the caller; per CommonMark a fence is only valid at an indentation
+// of less than four columns, which Scan enforces before calling this.
+//
+// Modeled on internal/rule/fence.go; reimplemented here so the preprocess
+// package stays self-contained and has no dependency on the rule package.
+func openingFenceMarker(trimmed string) string {
+	if len(trimmed) < 3 {
+		return ""
+	}
+	ch := trimmed[0]
+	if (ch != '`' && ch != '~') || trimmed[1] != ch || trimmed[2] != ch {
+		return ""
+	}
+	n := 3
+	for n < len(trimmed) && trimmed[n] == ch {
+		n++
+	}
+	return trimmed[:n]
+}
+
+// isClosingFence reports whether trimmed is a valid closing fence for the given
+// opening fence marker. Per the CommonMark spec, a closing fence must:
+//  1. Use the same fence character as the opener (backtick or tilde)
+//  2. Have a run length >= the opener's length
+//  3. Contain only optional whitespace after the fence run
+func isClosingFence(trimmed, openMarker string) bool {
+	if len(trimmed) == 0 || len(openMarker) == 0 {
+		return false
+	}
+	ch := openMarker[0]
+	if trimmed[0] != ch {
+		return false
+	}
+	n := 0
+	for n < len(trimmed) && trimmed[n] == ch {
+		n++
+	}
+	if n < len(openMarker) {
+		return false
+	}
+	return strings.TrimSpace(trimmed[n:]) == ""
+}

--- a/internal/preprocess/fenced_code_test.go
+++ b/internal/preprocess/fenced_code_test.go
@@ -1,0 +1,55 @@
+package preprocess
+
+import "testing"
+
+func TestOpeningFenceMarker(t *testing.T) {
+	tests := []struct {
+		name    string
+		trimmed string
+		want    string
+	}{
+		{"triple backtick", "```", "```"},
+		{"backtick with info string", "```go", "```"},
+		{"longer backtick run", "````", "````"},
+		{"triple tilde", "~~~", "~~~"},
+		{"tilde with info string", "~~~ruby", "~~~"},
+		{"two backticks is not a fence", "``", ""},
+		{"single backtick", "`", ""},
+		{"not a fence", "plain text", ""},
+		{"empty", "", ""},
+		{"mixed run is not a fence", "`~`", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := openingFenceMarker(tt.trimmed); got != tt.want {
+				t.Errorf("openingFenceMarker(%q) = %q, want %q", tt.trimmed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsClosingFence(t *testing.T) {
+	tests := []struct {
+		name       string
+		trimmed    string
+		openMarker string
+		want       bool
+	}{
+		// CommonMark: a closing fence must use the same character and be at
+		// least as long as the opener.
+		{"exact match", "```", "```", true},
+		{"longer closer", "````", "```", true},
+		{"shorter closer does not close", "```", "````", false},
+		{"different char does not close", "~~~", "```", false},
+		{"trailing whitespace allowed", "```   ", "```", true},
+		{"trailing text does not close", "``` go", "```", false},
+		{"empty opener", "```", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isClosingFence(tt.trimmed, tt.openMarker); got != tt.want {
+				t.Errorf("isClosingFence(%q, %q) = %v, want %v", tt.trimmed, tt.openMarker, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/preprocess/html.go
+++ b/internal/preprocess/html.go
@@ -1,0 +1,191 @@
+package preprocess
+
+import "strings"
+
+// HTML comments (CommonMark §4.6 type 2) are handled by sanitizeInline and the
+// comment-continuation state in Scan, not here, so they can be tracked
+// independently of other HTML blocks and surfaced via LineContext.InHTMLComment.
+// The detectors below cover the remaining HTML block types 1 and 3–7.
+
+// htmlType1Names are the tag names whose blocks (type 1) end only when a
+// matching close tag appears, not on a blank line.
+var htmlType1Names = []string{"script", "pre", "style", "textarea"}
+
+// htmlType1CloseTags are the strings whose presence on any line closes a type 1
+// HTML block.
+var htmlType1CloseTags = []string{"</script>", "</style>", "</pre>", "</textarea>"}
+
+// htmlBlockTags is the set of tag names that start a type 6 HTML block
+// (CommonMark §4.6, condition 6). div is the load-bearing case for the audit.
+var htmlBlockTags = map[string]bool{
+	"address": true, "article": true, "aside": true, "base": true,
+	"basefont": true, "blockquote": true, "body": true, "caption": true,
+	"center": true, "col": true, "colgroup": true, "dd": true, "details": true,
+	"dialog": true, "dir": true, "div": true, "dl": true, "dt": true,
+	"fieldset": true, "figcaption": true, "figure": true, "footer": true,
+	"form": true, "frame": true, "frameset": true, "h1": true, "h2": true,
+	"h3": true, "h4": true, "h5": true, "h6": true, "head": true,
+	"header": true, "hr": true, "html": true, "iframe": true, "legend": true,
+	"li": true, "link": true, "main": true, "menu": true, "menuitem": true,
+	"nav": true, "noframes": true, "ol": true, "optgroup": true, "option": true,
+	"p": true, "param": true, "section": true, "summary": true, "table": true,
+	"tbody": true, "td": true, "tfoot": true, "th": true, "thead": true,
+	"title": true, "tr": true, "track": true, "ul": true,
+}
+
+func isASCIILetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isTagNameChar(c byte) bool {
+	return isASCIILetter(c) || (c >= '0' && c <= '9') || c == '-'
+}
+
+// htmlBlockStart reports the HTML block type (1, 3, 4, 5, 6, or 7) that line
+// opens, or 0 if it does not start an HTML block. line must already have its
+// leading indentation stripped (HTML blocks are only valid at an indentation of
+// less than four columns, which Scan enforces). Type 7 cannot interrupt a
+// paragraph, so inParagraph suppresses it.
+func htmlBlockStart(line string, inParagraph bool) int {
+	if len(line) < 2 || line[0] != '<' {
+		return 0
+	}
+	if matchType1(line) {
+		return 1
+	}
+	if strings.HasPrefix(line, "<?") {
+		return 3
+	}
+	if strings.HasPrefix(line, "<![CDATA[") {
+		return 5
+	}
+	if line[1] == '!' && len(line) >= 3 && isASCIILetter(line[2]) {
+		return 4
+	}
+	if matchType6(line) {
+		return 6
+	}
+	if !inParagraph && matchType7(line) {
+		return 7
+	}
+	return 0
+}
+
+// matchType1 reports whether line opens a type 1 HTML block: '<' followed by
+// script/pre/style/textarea (case-insensitive), then whitespace, '>', or
+// end-of-line.
+func matchType1(line string) bool {
+	for _, name := range htmlType1Names {
+		if len(line) < 1+len(name) {
+			continue
+		}
+		if !strings.EqualFold(line[1:1+len(name)], name) {
+			continue
+		}
+		rest := line[1+len(name):]
+		if rest == "" {
+			return true
+		}
+		switch rest[0] {
+		case ' ', '\t', '>':
+			return true
+		}
+	}
+	return false
+}
+
+// matchType6 reports whether line opens a type 6 HTML block: '<' or '</'
+// followed by a tag name in htmlBlockTags, then whitespace, end-of-line, '>',
+// or '/>'.
+func matchType6(line string) bool {
+	i := 1
+	if i < len(line) && line[i] == '/' {
+		i++
+	}
+	start := i
+	if start >= len(line) || !isASCIILetter(line[start]) {
+		return false
+	}
+	for i < len(line) && isTagNameChar(line[i]) {
+		i++
+	}
+	name := strings.ToLower(line[start:i])
+	if !htmlBlockTags[name] {
+		return false
+	}
+	if i >= len(line) {
+		return true
+	}
+	switch line[i] {
+	case ' ', '\t', '>':
+		return true
+	case '/':
+		return i+1 < len(line) && line[i+1] == '>'
+	}
+	return false
+}
+
+// matchType7 reports whether line is a single complete open or closing tag that
+// fills the whole line (only trailing whitespace allowed), with a tag name that
+// is not a type 1 tag. This is a pragmatic subset of CommonMark's full tag
+// grammar — sufficient for the standalone-tag case the audit cares about — and
+// deliberately conservative: anything it is unsure about returns false rather
+// than over-claiming an HTML block.
+func matchType7(line string) bool {
+	s := strings.TrimRight(line, " \t")
+	if len(s) < 3 || s[0] != '<' || s[len(s)-1] != '>' {
+		return false
+	}
+	inner := s[1 : len(s)-1]
+	closing := false
+	if strings.HasPrefix(inner, "/") {
+		closing = true
+		inner = inner[1:]
+	}
+	inner = strings.TrimSuffix(inner, "/")
+	// A second tag delimiter means this is not a single complete tag.
+	if strings.ContainsAny(inner, "<>") {
+		return false
+	}
+	if inner == "" || !isASCIILetter(inner[0]) {
+		return false
+	}
+	j := 0
+	for j < len(inner) && isTagNameChar(inner[j]) {
+		j++
+	}
+	name := strings.ToLower(inner[:j])
+	for _, t := range htmlType1Names {
+		if name == t {
+			return false
+		}
+	}
+	if closing {
+		// A closing tag has no attributes.
+		return strings.TrimSpace(inner[j:]) == ""
+	}
+	return true
+}
+
+// htmlBlockEndsOnLine reports whether a type 1–5 HTML block's end condition is
+// satisfied on line. Types 6 and 7 end on a blank line and are handled in Scan,
+// not here.
+func htmlBlockEndsOnLine(line string, blockType int) bool {
+	switch blockType {
+	case 1:
+		lower := strings.ToLower(line)
+		for _, close := range htmlType1CloseTags {
+			if strings.Contains(lower, close) {
+				return true
+			}
+		}
+		return false
+	case 3:
+		return strings.Contains(line, "?>")
+	case 4:
+		return strings.Contains(line, ">")
+	case 5:
+		return strings.Contains(line, "]]>")
+	}
+	return false
+}

--- a/internal/preprocess/html_test.go
+++ b/internal/preprocess/html_test.go
@@ -1,0 +1,127 @@
+package preprocess
+
+import "testing"
+
+func TestHTMLBlockStart(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		inParagraph bool
+		want        int
+	}{
+		// Type 1: script/pre/style/textarea.
+		{"type1 pre", "<pre>", false, 1},
+		{"type1 script with attr", "<script type=\"text/js\">", false, 1},
+		{"type1 style bare", "<style", false, 1},
+		{"type1 case insensitive", "<SCRIPT>", false, 1},
+		// Type 3: processing instruction.
+		{"type3", "<?php echo 1; ?>", false, 3},
+		// Type 4: declaration.
+		{"type4 doctype", "<!DOCTYPE html>", false, 4},
+		// Type 5: CDATA.
+		{"type5 cdata", "<![CDATA[stuff]]>", false, 5},
+		// Type 6: block-level tags. div is the load-bearing audit case.
+		{"type6 div open", "<div>", false, 6},
+		{"type6 div with attr", "<div class=\"x\">", false, 6},
+		{"type6 div bare eol", "<div", false, 6},
+		{"type6 closing div", "</div>", false, 6},
+		{"type6 self-closing hr", "<hr/>", false, 6},
+		{"type6 table", "<table>", false, 6},
+		{"type6 can interrupt paragraph", "<div>", true, 6},
+		// Type 7: a complete standalone tag that is not a type-1 tag.
+		{"type7 custom open tag", "<custom-element>", false, 7},
+		{"type7 custom closing tag", "</custom-element>", false, 7},
+		{"type7 cannot interrupt paragraph", "<custom-element>", true, 0},
+		// Non-starts.
+		{"plain text", "not html", false, 0},
+		{"inline tag mid-line is not type7", "see <span>x</span> here", false, 0},
+		{"tag name cannot start with a digit", "<1numeric>", false, 0},
+		{"comment is handled elsewhere", "<!-- comment -->", false, 0},
+		{"angle bracket only", "<", false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := htmlBlockStart(tt.line, tt.inParagraph); got != tt.want {
+				t.Errorf("htmlBlockStart(%q, inParagraph=%v) = %d, want %d",
+					tt.line, tt.inParagraph, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchType6(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"<div>", true},
+		{"<hr/>", true},
+		// A block tag name immediately followed by a character that is neither a
+		// delimiter (space/tab/>) nor part of the tag name is not a type 6 start.
+		{"<p=x>", false},
+		{"<div@>", false},
+		// Self-closing form must actually be "/>".
+		{"<div/x>", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			if got := matchType6(tt.line); got != tt.want {
+				t.Errorf("matchType6(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchType7(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"<custom-element>", true},
+		{"</custom-element>", true},
+		// Two tags on one line is not a single complete tag.
+		{"<a><b>", false},
+		// A type 1 tag name is excluded from type 7 (handled as type 1 instead).
+		{"<pre>", false},
+		{"<script>", false},
+		// A closing tag carries no attributes.
+		{"</div foo>", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			if got := matchType7(tt.line); got != tt.want {
+				t.Errorf("matchType7(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHTMLBlockEndsOnLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		blockType int
+		want      bool
+	}{
+		{"type1 closes on </pre>", "output</pre>", 1, true},
+		{"type1 closes on </script>", "</script>", 1, true},
+		{"type1 no close", "console.log(1)", 1, false},
+		{"type3 closes on ?>", "done ?>", 3, true},
+		{"type3 no close", "still going", 3, false},
+		{"type4 closes on >", "html>", 4, true},
+		{"type4 no close", "still declaring", 4, false},
+		{"type5 closes on ]]>", "data]]>", 5, true},
+		{"type5 no close", "more data", 5, false},
+		// Types 6 and 7 end on a blank line, never via this function.
+		{"type6 never ends here", "</div>", 6, false},
+		{"type7 never ends here", "</custom-element>", 7, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := htmlBlockEndsOnLine(tt.line, tt.blockType); got != tt.want {
+				t.Errorf("htmlBlockEndsOnLine(%q, %d) = %v, want %v",
+					tt.line, tt.blockType, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/preprocess/indented_code.go
+++ b/internal/preprocess/indented_code.go
@@ -1,0 +1,37 @@
+package preprocess
+
+// indentColumns returns the indentation of line measured in columns and the
+// byte index of the first non-whitespace character. A tab advances to the next
+// multiple of four columns, matching CommonMark's tab-stop handling. If the
+// line is empty or contains only whitespace, firstIdx equals len(line) and the
+// line should be treated as blank.
+//
+// Only spaces and tabs count as indentation here; a leading carriage return is
+// not expected because callers split on newlines.
+func indentColumns(line string) (cols, firstIdx int) {
+	col := 0
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case ' ':
+			col++
+		case '\t':
+			col += 4 - (col % 4)
+		default:
+			return col, i
+		}
+	}
+	return col, len(line)
+}
+
+// Indented code blocks (CommonMark §4.4) are detected in Scan rather than here,
+// because the rule is stateful: a line indented four or more columns is code
+// only when it does not continue an open paragraph (an indented code block
+// cannot interrupt a paragraph). The paragraph state is tracked across lines in
+// Scan.
+//
+// Known limitation (Phase 1): indentation is measured from the start of the
+// line, not relative to an enclosing list item or block quote. Inside a list,
+// continuation text is commonly indented several columns and is list content,
+// not an indented code block. Scan does not model container blocks, so such
+// lines may be mis-flagged as InIndentedCode. Downstream rules should not treat
+// InIndentedCode as authoritative inside list/blockquote contexts.

--- a/internal/preprocess/indented_code_test.go
+++ b/internal/preprocess/indented_code_test.go
@@ -1,0 +1,33 @@
+package preprocess
+
+import "testing"
+
+func TestIndentColumns(t *testing.T) {
+	tests := []struct {
+		name         string
+		line         string
+		wantCols     int
+		wantFirstIdx int
+	}{
+		{"no indent", "text", 0, 0},
+		{"three spaces", "   x", 3, 3},
+		{"four spaces", "    x", 4, 4},
+		// A tab advances to the next multiple of four columns (CommonMark tab
+		// stops), so a single leading tab is four columns of indentation.
+		{"single tab", "\tx", 4, 1},
+		{"two spaces then tab", "  \tx", 4, 3},
+		{"tab then text", "\t\tx", 8, 2},
+		{"blank line", "", 0, 0},
+		{"whitespace-only line", "   ", 3, 3},
+		{"tab-only line", "\t", 4, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cols, firstIdx := indentColumns(tt.line)
+			if cols != tt.wantCols || firstIdx != tt.wantFirstIdx {
+				t.Errorf("indentColumns(%q) = (%d, %d), want (%d, %d)",
+					tt.line, cols, firstIdx, tt.wantCols, tt.wantFirstIdx)
+			}
+		})
+	}
+}

--- a/internal/preprocess/inline.go
+++ b/internal/preprocess/inline.go
@@ -1,0 +1,112 @@
+package preprocess
+
+import "strings"
+
+// countBacktickRun returns the number of consecutive backticks starting at
+// position start in s.
+func countBacktickRun(s string, start int) int {
+	n := 0
+	for start+n < len(s) && s[start+n] == '`' {
+		n++
+	}
+	return n
+}
+
+// findClosingBacktickRun returns the start index of the next run of exactly
+// delimLen backticks at or after from, or -1 if there is none.
+func findClosingBacktickRun(s string, from, delimLen int) int {
+	j := from
+	for j < len(s) {
+		if s[j] != '`' {
+			j++
+			continue
+		}
+		runLen := countBacktickRun(s, j)
+		if runLen == delimLen {
+			return j
+		}
+		j += runLen
+	}
+	return -1
+}
+
+// sanitizeInline replaces inline code spans and inline HTML comments with
+// spaces so that downstream rules do not scan their contents. Length is
+// preserved (each blanked byte becomes a single space) so that column positions
+// in the sanitized string still line up with the original.
+//
+// Processing is a single left-to-right pass, so the construct that opens first
+// wins: a "<!--" inside a code span is treated as code (blanked as code, not a
+// comment), and a backtick inside a comment is treated as comment text. This is
+// consistent with CommonMark, where neither construct nests in the other.
+//
+// startInComment indicates the line begins inside an HTML comment that was
+// opened on a previous line. The returns are:
+//   - sanitized: the line with code spans and comments blanked
+//   - endedInComment: true if the line ends inside an unclosed comment
+//   - fullyComment: true if the line's only non-whitespace content was comment
+//     text (i.e. it is a standalone comment line, not prose with a trailing
+//     comment). Always false unless a comment was actually present.
+func sanitizeInline(line string, startInComment bool) (sanitized string, endedInComment, fullyComment bool) {
+	var b strings.Builder
+	b.Grow(len(line))
+
+	inComment := startInComment
+	hasComment := startInComment
+	hasOther := false
+
+	i := 0
+	for i < len(line) {
+		if inComment {
+			if i+3 <= len(line) && line[i:i+3] == "-->" {
+				b.WriteString("   ")
+				i += 3
+				inComment = false
+			} else {
+				b.WriteByte(' ')
+				i++
+			}
+			continue
+		}
+
+		// Opening of an inline HTML comment.
+		if i+4 <= len(line) && line[i:i+4] == "<!--" {
+			inComment = true
+			hasComment = true
+			b.WriteString("    ")
+			i += 4
+			continue
+		}
+
+		// Inline code span.
+		if line[i] == '`' {
+			delimLen := countBacktickRun(line, i)
+			closing := findClosingBacktickRun(line, i+delimLen, delimLen)
+			if closing == -1 {
+				// No matching closing run — emit the backticks literally.
+				for k := 0; k < delimLen; k++ {
+					b.WriteByte('`')
+				}
+				hasOther = true
+				i += delimLen
+				continue
+			}
+			spanLen := (closing + delimLen) - i
+			for k := 0; k < spanLen; k++ {
+				b.WriteByte(' ')
+			}
+			hasOther = true
+			i = closing + delimLen
+			continue
+		}
+
+		c := line[i]
+		if c != ' ' && c != '\t' && c != '\r' {
+			hasOther = true
+		}
+		b.WriteByte(c)
+		i++
+	}
+
+	return b.String(), inComment, hasComment && !hasOther
+}

--- a/internal/preprocess/inline_test.go
+++ b/internal/preprocess/inline_test.go
@@ -1,0 +1,99 @@
+package preprocess
+
+import (
+	"strings"
+	"testing"
+)
+
+// blanks returns a string of n spaces, matching how sanitizeInline blanks a
+// region of length n. Used to build expected output without hand-counting.
+func blanks(n int) string { return strings.Repeat(" ", n) }
+
+func TestSanitizeInline(t *testing.T) {
+	tests := []struct {
+		name           string
+		line           string
+		startInComment bool
+		wantSanitized  string
+		wantEnded      bool
+		wantFully      bool
+	}{
+		{
+			name:          "plain prose unchanged",
+			line:          "just some text",
+			wantSanitized: "just some text",
+		},
+		{
+			name:          "inline code span blanked, length preserved",
+			line:          "see `code` here",
+			wantSanitized: "see " + blanks(len("`code`")) + " here",
+		},
+		{
+			name:          "multi-backtick span closes on equal run",
+			line:          "a ``b`c`` d",
+			wantSanitized: "a " + blanks(len("``b`c``")) + " d",
+		},
+		{
+			name:          "unclosed backtick run is literal",
+			line:          "a `b c",
+			wantSanitized: "a `b c",
+		},
+		{
+			name:          "inline comment blanked, prose kept",
+			line:          "text <!-- note --> more",
+			wantSanitized: "text " + blanks(len("<!-- note -->")) + " more",
+		},
+		{
+			name:          "standalone comment is fully comment",
+			line:          "<!-- only a comment -->",
+			wantSanitized: blanks(len("<!-- only a comment -->")),
+			wantFully:     true,
+		},
+		{
+			name:          "unclosed comment carries state to next line",
+			line:          "text <!-- start",
+			wantSanitized: "text " + blanks(len("<!-- start")),
+			wantEnded:     true,
+		},
+		{
+			name:           "continuation line inside comment is fully comment",
+			line:           "still inside the comment",
+			startInComment: true,
+			wantSanitized:  blanks(len("still inside the comment")),
+			wantEnded:      true,
+			wantFully:      true,
+		},
+		{
+			name:           "comment closes mid-line, trailing prose kept",
+			line:           "end --> visible",
+			startInComment: true,
+			wantSanitized:  blanks(len("end -->")) + " visible",
+			wantEnded:      false,
+		},
+		{
+			// Left-to-right: "<!--" inside a code span is code, not a comment,
+			// so the line ends outside any comment.
+			name:          "comment delimiter inside code span is not a comment",
+			line:          "`<!--` text",
+			wantSanitized: blanks(len("`<!--`")) + " text",
+			wantEnded:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ended, fully := sanitizeInline(tt.line, tt.startInComment)
+			if got != tt.wantSanitized {
+				t.Errorf("sanitized = %q, want %q", got, tt.wantSanitized)
+			}
+			if len(got) != len(tt.line) {
+				t.Errorf("length not preserved: got %d, want %d", len(got), len(tt.line))
+			}
+			if ended != tt.wantEnded {
+				t.Errorf("endedInComment = %v, want %v", ended, tt.wantEnded)
+			}
+			if fully != tt.wantFully {
+				t.Errorf("fullyComment = %v, want %v", fully, tt.wantFully)
+			}
+		})
+	}
+}

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -1,0 +1,203 @@
+// Package preprocess provides a single shared pre-pass over a Markdown file's
+// lines, classifying each line by the context it lives in (fenced code,
+// indented code, HTML block, HTML comment) and producing a sanitized copy with
+// inline code spans and inline HTML comments blanked out.
+//
+// It exists to replace the per-rule "skip code blocks / HTML" machinery that
+// each rule currently re-implements, which the audit in issue #337 found to be
+// inconsistent and incomplete. Rules consume the result instead of re-deriving
+// context, so the three systematically missed contexts — indented code blocks,
+// HTML blocks, and HTML comments — are handled once, the same way, everywhere.
+//
+// The classification follows CommonMark's block structure but is intentionally
+// not a full parser: it does not model container blocks (lists, block quotes),
+// so indentation is measured from the start of the line. See the note in
+// indented_code.go for the consequences.
+package preprocess
+
+import "strings"
+
+// LineContext records, for one source line, which Markdown contexts it lives in
+// and a sanitized copy of its text.
+//
+// The boolean flags describe structural block membership and are mutually
+// exclusive: a line is in at most one of fenced code, indented code, an HTML
+// block, or an HTML comment. They are exposed individually rather than via a
+// single "skippable" convenience flag because different rules skip different
+// subsets — for example, rules implementing the markdownlint divergences in
+// issue #337 (max-line-length, no-hard-tabs) deliberately scan inside fenced
+// code blocks.
+//
+// Sanitized is an inline-level transformation only: inline code spans and inline
+// HTML comments are replaced by spaces (length-preserving), so a rule can scan
+// Sanitized without matching content that lives in those spans. Block-level code
+// (fenced and indented) is NOT blanked in Sanitized — it is left verbatim so
+// that rules which want to inspect code-block contents still can; use the flags
+// to skip block code instead. For lines flagged InHTMLComment, Sanitized is
+// fully blank because the entire line was comment text.
+type LineContext struct {
+	// Original is the line exactly as it appeared in the input.
+	Original string
+	// Sanitized is Original with inline code spans and inline HTML comments
+	// replaced by spaces. For block-code and HTML-block lines it equals
+	// Original; for fully-commented lines it is all whitespace.
+	Sanitized string
+
+	// InFencedCode is true for every line of a fenced code block, including the
+	// opening and closing fence lines. If a fence is never closed, every line
+	// from the opener to end of file is flagged, which prevents downstream rules
+	// from mispairing fences inside the unclosed region.
+	InFencedCode bool
+	// InIndentedCode is true for lines inside an indented code block
+	// (CommonMark §4.4). See the limitation noted in indented_code.go.
+	InIndentedCode bool
+	// InHTMLBlock is true for lines inside an HTML block of CommonMark types 1
+	// and 3–7 (e.g. <div>…</div>). HTML comments are reported via
+	// InHTMLComment, not this flag.
+	InHTMLBlock bool
+	// InHTMLComment is true for lines whose entire content is an HTML comment —
+	// a standalone <!-- … --> line or a continuation line of a multi-line
+	// comment. A prose line with a trailing inline comment is not flagged here;
+	// its comment is blanked in Sanitized instead.
+	InHTMLComment bool
+}
+
+// Scan classifies every line of a Markdown file in a single pass and returns one
+// LineContext per input line, in order. The input is expected to have already
+// had YAML front matter stripped by the caller (the linter does this centrally),
+// so Scan does not handle front matter.
+func Scan(lines []string) []LineContext {
+	result := make([]LineContext, len(lines))
+	var s scanner
+	for i, line := range lines {
+		result[i] = s.classify(line)
+	}
+	return result
+}
+
+// scanner holds the cross-line state needed to classify each line in context.
+type scanner struct {
+	inFence     bool
+	fenceMarker string
+
+	inHTMLBlock bool
+	htmlType    int
+
+	inComment   bool
+	inParagraph bool
+}
+
+// classify advances the scanner by one line and returns that line's context.
+func (s *scanner) classify(line string) LineContext {
+	cols, firstIdx := indentColumns(line)
+	isBlank := firstIdx == len(line)
+
+	if ctx, handled := s.continueOpenBlock(line, cols, isBlank); handled {
+		return ctx
+	}
+	return s.startLine(line, cols, isBlank)
+}
+
+// continueOpenBlock handles a line that lies inside a block opened on an earlier
+// line (fenced code, HTML comment, or HTML block). It returns handled=false when
+// no such block is open, or when a type 6/7 HTML block has just ended on this
+// blank line and the line should be classified afresh by startLine.
+func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (LineContext, bool) {
+	switch {
+	// Fences take precedence over every other context; a comment or HTML start
+	// inside a code block is literal.
+	case s.inFence:
+		if !isBlank && cols < 4 && isClosingFence(strings.TrimSpace(line), s.fenceMarker) {
+			s.inFence = false
+			s.fenceMarker = ""
+		}
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: line, InFencedCode: true}, true
+
+	// Multi-line HTML comment: track until the closing "-->".
+	case s.inComment:
+		sanitized, stillInComment, _ := sanitizeInline(line, true)
+		s.inComment = stillInComment
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: sanitized, InHTMLComment: true}, true
+
+	// Open HTML block. Types 1 and 3–5 end on a delimiter line; types 6 and 7
+	// end on a blank line, which is itself outside the block.
+	case s.inHTMLBlock:
+		if (s.htmlType == 6 || s.htmlType == 7) && isBlank {
+			s.inHTMLBlock = false
+			return LineContext{}, false
+		}
+		if s.htmlType >= 1 && s.htmlType <= 5 && htmlBlockEndsOnLine(line, s.htmlType) {
+			s.inHTMLBlock = false
+		}
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: line, InHTMLBlock: true}, true
+	}
+	return LineContext{}, false
+}
+
+// startLine classifies a line that does not continue an already-open block.
+func (s *scanner) startLine(line string, cols int, isBlank bool) LineContext {
+	// Blank line outside any block closes an open paragraph.
+	if isBlank {
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: line}
+	}
+
+	// Indented code block: four or more columns of indentation, but only when it
+	// does not continue an open paragraph (indented code cannot interrupt a
+	// paragraph). Checked before openers because an indented line can open
+	// neither a fence nor an HTML block.
+	if cols >= 4 && !s.inParagraph {
+		return LineContext{Original: line, Sanitized: line, InIndentedCode: true}
+	}
+
+	// Block openers are recognized only at an indentation below four columns.
+	if cols < 4 {
+		if ctx, opened := s.tryOpenBlock(line); opened {
+			return ctx
+		}
+	}
+
+	// Everything else is prose: paragraph text, headings, list items, lazy
+	// paragraph continuations, and standalone HTML comments. Inline code spans
+	// and inline comments are blanked in Sanitized.
+	sanitized, endedInComment, fullyComment := sanitizeInline(line, false)
+	s.inComment = endedInComment
+	ctx := LineContext{Original: line, Sanitized: sanitized}
+	if fullyComment {
+		// The line was nothing but comment text — a standalone comment line.
+		ctx.InHTMLComment = true
+		s.inParagraph = false
+	} else {
+		s.inParagraph = true
+	}
+	return ctx
+}
+
+// tryOpenBlock attempts to open a fenced code block or an HTML block on line
+// (which must be indented fewer than four columns). It returns opened=false when
+// the line is not a block opener.
+func (s *scanner) tryOpenBlock(line string) (LineContext, bool) {
+	trimmed := strings.TrimSpace(line)
+
+	if marker := openingFenceMarker(trimmed); marker != "" {
+		s.inFence = true
+		s.fenceMarker = marker
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: line, InFencedCode: true}, true
+	}
+
+	if t := htmlBlockStart(trimmed, s.inParagraph); t != 0 {
+		s.inHTMLBlock = true
+		s.htmlType = t
+		if t >= 1 && t <= 5 && htmlBlockEndsOnLine(trimmed, t) {
+			s.inHTMLBlock = false
+		}
+		s.inParagraph = false
+		return LineContext{Original: line, Sanitized: line, InHTMLBlock: true}, true
+	}
+
+	return LineContext{}, false
+}

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -114,12 +114,21 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (LineCo
 		s.inParagraph = false
 		return LineContext{Original: line, Sanitized: line, InFencedCode: true}, true
 
-	// Multi-line HTML comment: track until the closing "-->".
+	// Multi-line HTML comment: track until the closing "-->". The comment may
+	// close mid-line and leave trailing prose; in that case the line is not a
+	// pure comment line, so it is not flagged InHTMLComment and it reopens a
+	// paragraph — mirroring startLine's handling of a fresh comment line.
 	case s.inComment:
-		sanitized, stillInComment, _ := sanitizeInline(line, true)
+		sanitized, stillInComment, fullyComment := sanitizeInline(line, true)
 		s.inComment = stillInComment
-		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: sanitized, InHTMLComment: true}, true
+		ctx := LineContext{Original: line, Sanitized: sanitized}
+		if fullyComment {
+			ctx.InHTMLComment = true
+			s.inParagraph = false
+		} else {
+			s.inParagraph = true
+		}
+		return ctx, true
 
 	// Open HTML block. Types 1 and 3–5 end on a delimiter line; types 6 and 7
 	// end on a blank line, which is itself outside the block.

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -1,0 +1,240 @@
+package preprocess
+
+import (
+	"strings"
+	"testing"
+)
+
+// flags is a compact view of the four context booleans for one line, used to
+// assert Scan's output against the issue #337 audit matrix.
+type flags struct {
+	fenced, indented, htmlBlock, htmlComment bool
+}
+
+func flagsOf(c LineContext) flags {
+	return flags{c.InFencedCode, c.InIndentedCode, c.InHTMLBlock, c.InHTMLComment}
+}
+
+// runScan splits a multi-line literal and runs Scan. A leading newline in the
+// literal is dropped so test inputs can start on their own line.
+func runScan(t *testing.T, doc string) []LineContext {
+	t.Helper()
+	doc = strings.TrimPrefix(doc, "\n")
+	return Scan(strings.Split(doc, "\n"))
+}
+
+func TestScanContextFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want []flags
+	}{
+		{
+			// CommonMark §4.4 example 108: an indented code block cannot
+			// interrupt a paragraph, so the indented line is a lazy
+			// continuation of "Foo", not code.
+			name: "indented line does not interrupt paragraph",
+			doc: `
+Foo
+    bar`,
+			want: []flags{{}, {}},
+		},
+		{
+			// A four-space indented line after a blank line IS an indented
+			// code block. Audit: heading rules / link-fragments must skip the
+			// "# Fake" line instead of treating it as a real heading.
+			name: "indented code block after blank line",
+			doc: `
+text
+
+    # Fake heading`,
+			want: []flags{{}, {}, {indented: true}},
+		},
+		{
+			// Audit: a fenced code block opened at column >= 4 is indented code,
+			// not a fence. The two detectors must not fight.
+			name: "backtick fence indented four spaces is indented code",
+			doc: `
+text
+
+    ` + "```" + `
+    not a fence`,
+			want: []flags{{}, {}, {indented: true}, {indented: true}},
+		},
+		{
+			// Audit: a heading inside an HTML block (<div>) must not be parsed
+			// as a heading. The block runs to a blank line (or EOF).
+			name: "html block keeps inner heading in context",
+			doc: `
+<div>
+# Not a heading
+</div>`,
+			want: []flags{{htmlBlock: true}, {htmlBlock: true}, {htmlBlock: true}},
+		},
+		{
+			// A type-6 HTML block ends on a blank line; the blank line and what
+			// follows are outside the block.
+			name: "html block ends on blank line",
+			doc: `
+<div>
+content
+</div>
+
+after`,
+			want: []flags{
+				{htmlBlock: true}, {htmlBlock: true}, {htmlBlock: true},
+				{}, {},
+			},
+		},
+		{
+			// Audit: a multi-line HTML comment, including any "heading" inside
+			// it, is comment context, not headings.
+			name: "multi-line html comment",
+			doc: `
+<!--
+# commented heading
+-->
+text`,
+			want: []flags{
+				{htmlComment: true}, {htmlComment: true}, {htmlComment: true},
+				{},
+			},
+		},
+		{
+			// Audit worst offender: empty-alt-text fires inside fenced code.
+			// The image line must be flagged as fenced so the rule skips it.
+			name: "fenced code block covers delimiters and content",
+			doc: `
+` + "```" + `
+![](img.png)
+` + "```",
+			want: []flags{{fenced: true}, {fenced: true}, {fenced: true}},
+		},
+		{
+			// Audit item 5: an unclosed fence must mark every line to EOF as
+			// fenced, so downstream rules cannot mispair fences afterward.
+			name: "unclosed fence flags all lines to EOF",
+			doc: `
+text
+
+` + "```" + `
+code
+more code`,
+			want: []flags{
+				{}, {},
+				{fenced: true}, {fenced: true}, {fenced: true},
+			},
+		},
+		{
+			// A type 1 HTML block (<pre>) spans multiple lines and ends only on
+			// the line containing its matching close tag, not on a blank line.
+			name: "multi-line type 1 html block ends on close tag",
+			doc: `
+<pre>
+code
+</pre>
+after`,
+			want: []flags{
+				{htmlBlock: true}, {htmlBlock: true}, {htmlBlock: true},
+				{},
+			},
+		},
+		{
+			// A type 4 HTML block (declaration) opens and ends on the same line
+			// once its '>' delimiter is seen, so the following line is fresh.
+			name: "single-line type 4 html block",
+			doc: `
+<!DOCTYPE html>
+text`,
+			want: []flags{{htmlBlock: true}, {}},
+		},
+		{
+			// A backtick fence is not closed by a tilde fence of the same run
+			// length; only a matching-character fence closes it.
+			name: "tilde line does not close backtick fence",
+			doc: `
+` + "```" + `
+~~~
+still code
+` + "```",
+			want: []flags{
+				{fenced: true}, {fenced: true}, {fenced: true}, {fenced: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runScan(t, tt.doc)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d lines, want %d:\n%#v", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if g := flagsOf(got[i]); g != tt.want[i] {
+					t.Errorf("line %d (%q): flags = %+v, want %+v",
+						i, got[i].Original, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestScanSanitizedContract checks the inline-vs-block split of the Sanitized
+// field described in the LineContext docs.
+func TestScanSanitizedContract(t *testing.T) {
+	t.Run("inline code in prose is blanked", func(t *testing.T) {
+		ctx := runScan(t, "see `http://x.com` here")
+		if strings.Contains(ctx[0].Sanitized, "http://x.com") {
+			t.Errorf("inline code not blanked: %q", ctx[0].Sanitized)
+		}
+	})
+
+	t.Run("fenced code content is left verbatim", func(t *testing.T) {
+		doc := "```\n`backtick` text\n```"
+		ctx := Scan(strings.Split(doc, "\n"))
+		// Section B rules deliberately scan inside fenced code, so the content
+		// line's Sanitized must equal its Original (no inline stripping).
+		if ctx[1].Sanitized != ctx[1].Original {
+			t.Errorf("fenced content was sanitized: got %q, want %q",
+				ctx[1].Sanitized, ctx[1].Original)
+		}
+	})
+
+	t.Run("standalone comment line is fully blanked", func(t *testing.T) {
+		ctx := runScan(t, "<!-- a comment -->")
+		if strings.TrimSpace(ctx[0].Sanitized) != "" {
+			t.Errorf("comment line not blanked: %q", ctx[0].Sanitized)
+		}
+		if !ctx[0].InHTMLComment {
+			t.Errorf("standalone comment not flagged InHTMLComment")
+		}
+	})
+
+	t.Run("flags are mutually exclusive", func(t *testing.T) {
+		doc := "para\n\n```\ncode\n```\n\n<div>\nx\n</div>\n\n    indented\n\n<!-- c -->"
+		for i, c := range Scan(strings.Split(doc, "\n")) {
+			n := 0
+			for _, b := range []bool{c.InFencedCode, c.InIndentedCode, c.InHTMLBlock, c.InHTMLComment} {
+				if b {
+					n++
+				}
+			}
+			if n > 1 {
+				t.Errorf("line %d (%q) has %d context flags set, want <=1", i, c.Original, n)
+			}
+		}
+	})
+
+	t.Run("Original always preserved and Scan returns one ctx per line", func(t *testing.T) {
+		lines := []string{"a", "  b `c`", "```", "d", "```"}
+		ctx := Scan(lines)
+		if len(ctx) != len(lines) {
+			t.Fatalf("got %d contexts, want %d", len(ctx), len(lines))
+		}
+		for i := range lines {
+			if ctx[i].Original != lines[i] {
+				t.Errorf("line %d: Original = %q, want %q", i, ctx[i].Original, lines[i])
+			}
+		}
+	})
+}

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -101,6 +101,21 @@ text`,
 			},
 		},
 		{
+			// A multi-line comment can start mid-line after prose and close
+			// mid-line before more prose. The opening and closing lines carry
+			// real prose, so neither is a pure comment line; only the fully
+			// commented middle line is flagged. Without this, downstream rules
+			// would skip the trailing "visible prose".
+			name: "multi-line comment opened and closed mid-line keeps prose",
+			doc: `
+text <!-- start
+inside comment
+end --> visible prose`,
+			want: []flags{
+				{}, {htmlComment: true}, {},
+			},
+		},
+		{
 			// Audit worst offender: empty-alt-text fires inside fenced code.
 			// The image line must be flagged as fenced so the rule skips it.
 			name: "fenced code block covers delimiters and content",
@@ -207,6 +222,17 @@ func TestScanSanitizedContract(t *testing.T) {
 		}
 		if !ctx[0].InHTMLComment {
 			t.Errorf("standalone comment not flagged InHTMLComment")
+		}
+	})
+
+	t.Run("prose after a mid-line comment close is preserved", func(t *testing.T) {
+		ctx := runScan(t, "text <!-- start\nend --> visible prose")
+		last := ctx[len(ctx)-1]
+		if last.InHTMLComment {
+			t.Errorf("line with trailing prose flagged InHTMLComment: %q", last.Original)
+		}
+		if !strings.Contains(last.Sanitized, "visible prose") {
+			t.Errorf("trailing prose not preserved in Sanitized: %q", last.Sanitized)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #337: a new `internal/preprocess` package providing a single shared pre-pass over a Markdown file's lines.

`Scan(lines) []LineContext` classifies each line by the context it lives in (fenced code, indented code, HTML block, HTML comment) and produces an inline-sanitized copy. This closes the three systemic context-preprocessing gaps the audit found — **indented code blocks, HTML blocks, and HTML comments** — in one place rather than re-implementing "skip code / HTML" per rule.

Per the implementation plan, **Phase 1 is purely additive**: the package is not imported anywhere yet, so existing linter behavior is unchanged. Wiring into the linter and migrating rules happen in the follow-up phases (#340, #339, #341).

## Design

- **`LineContext`** exposes individual context flags (`InFencedCode`, `InIndentedCode`, `InHTMLBlock`, `InHTMLComment`) — no convenience `IsSkippable`, because rules skip different subsets (the Section B divergences deliberately scan inside fenced code).
- **`Sanitized`** is an inline-only transformation: inline code spans and inline `<!-- -->` comments are blanked (length-preserving). Block-level code (fenced/indented) is left **verbatim** so rules that want to inspect code contents still can; skipping block code is done via the flags.
- **Fence / HTML openers are recognized only at indentation < 4 columns**, so the fence detector and the indented-code detector don't fight.
- **Indented code uses a paragraph-aware state machine** (CommonMark §4.4: indented code cannot interrupt a paragraph). List/blockquote *relative* indentation is out of scope for Phase 1 and documented as a limitation so downstream rules don't over-trust the flag.
- **Unclosed fences flag every line to EOF** as `InFencedCode`, which structurally resolves the mispairing cascade in audit item 5.
- HTML blocks cover CommonMark types 1 and 3–7; comments (type 2) are tracked separately and surfaced as `InHTMLComment`.

## Tests

Tests trace to CommonMark semantics and the audit matrix cells (not to the implementation), e.g.:
- indented line cannot interrupt a paragraph (§4.4 ex. 108)
- `# Fake` inside an indented block → `InIndentedCode` (the link-fragments FN / heading-pollution fix)
- a backtick fence indented 4 spaces is indented code, not a fence
- `#` line inside `<div>` → `InHTMLBlock`
- `![](url)` inside fenced code → `InFencedCode` (empty-alt-text worst offender)
- unclosed fence flags all lines to EOF (cascade fix)

## Checklist (Phase 1)

- [x] Implement `preprocess.Scan` and per-detector functions
- [x] Per-detector unit tests (fenced / indented / HTML block / HTML comment / inline)
- [x] Integration tests asserting `LineContext` flags for matrix-derived multi-context inputs
- [x] `make test-all` clean
- [x] `make static-lint` clean, 100% coverage

Refs #337
