### PR TITLE
refactor(preprocess): compact, accessor-based Context API (#337 Phase 1.5)

### DIFF
--- a/internal/preprocess/html.go
+++ b/internal/preprocess/html.go
@@ -4,7 +4,7 @@ import "strings"
 
 // HTML comments (CommonMark §4.6 type 2) are handled by sanitizeInline and the
 // comment-continuation state in Scan, not here, so they can be tracked
-// independently of other HTML blocks and surfaced via LineContext.InHTMLComment.
+// independently of other HTML blocks and surfaced via Context.InHTMLComment.
 // The detectors below cover the remaining HTML block types 1 and 3–7.
 
 // htmlType1Names are the tag names whose blocks (type 1) end only when a

--- a/internal/preprocess/inline.go
+++ b/internal/preprocess/inline.go
@@ -30,6 +30,28 @@ func findClosingBacktickRun(s string, from, delimLen int) int {
 	return -1
 }
 
+// writeBlankedCodeSpan handles an inline code span whose opening backtick run
+// begins at index start (line[start] == '`'). If the run has a matching closing
+// run, the whole span (delimiters and content) is written to b as spaces;
+// otherwise the unmatched backticks are written literally. It returns the index
+// in line immediately after what it consumed.
+func writeBlankedCodeSpan(b *strings.Builder, line string, start int) int {
+	delimLen := countBacktickRun(line, start)
+	closing := findClosingBacktickRun(line, start+delimLen, delimLen)
+	if closing == -1 {
+		// No matching closing run — emit the backticks literally.
+		for k := 0; k < delimLen; k++ {
+			b.WriteByte('`')
+		}
+		return start + delimLen
+	}
+	spanLen := (closing + delimLen) - start
+	for k := 0; k < spanLen; k++ {
+		b.WriteByte(' ')
+	}
+	return closing + delimLen
+}
+
 // sanitizeInline replaces inline code spans and inline HTML comments with
 // spaces so that downstream rules do not scan their contents. Length is
 // preserved (each blanked byte becomes a single space) so that column positions
@@ -48,6 +70,17 @@ func findClosingBacktickRun(s string, from, delimLen int) int {
 //     text (i.e. it is a standalone comment line, not prose with a trailing
 //     comment). Always false unless a comment was actually present.
 func sanitizeInline(line string, startInComment bool) (sanitized string, endedInComment, fullyComment bool) {
+	// Fast path: a line outside any open comment with no inline code span or
+	// comment opener has nothing to blank, so it is returned verbatim with no
+	// allocation. Returning the input string unchanged also lets Scan detect via
+	// identity that the line needs no entry in its sparse sanitized map. This is
+	// the common case once the linter runs Scan on every file.
+	if !startInComment &&
+		strings.IndexByte(line, '`') < 0 &&
+		!strings.Contains(line, "<!--") {
+		return line, false, false
+	}
+
 	var b strings.Builder
 	b.Grow(len(line))
 
@@ -80,23 +113,8 @@ func sanitizeInline(line string, startInComment bool) (sanitized string, endedIn
 
 		// Inline code span.
 		if line[i] == '`' {
-			delimLen := countBacktickRun(line, i)
-			closing := findClosingBacktickRun(line, i+delimLen, delimLen)
-			if closing == -1 {
-				// No matching closing run — emit the backticks literally.
-				for k := 0; k < delimLen; k++ {
-					b.WriteByte('`')
-				}
-				hasOther = true
-				i += delimLen
-				continue
-			}
-			spanLen := (closing + delimLen) - i
-			for k := 0; k < spanLen; k++ {
-				b.WriteByte(' ')
-			}
+			i = writeBlankedCodeSpan(&b, line, i)
 			hasOther = true
-			i = closing + delimLen
 			continue
 		}
 

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -1,7 +1,7 @@
 // Package preprocess provides a single shared pre-pass over a Markdown file's
 // lines, classifying each line by the context it lives in (fenced code,
-// indented code, HTML block, HTML comment) and producing a sanitized copy with
-// inline code spans and inline HTML comments blanked out.
+// indented code, HTML block, HTML comment) and exposing an inline-sanitized
+// view with inline code spans and inline HTML comments blanked out.
 //
 // It exists to replace the per-rule "skip code blocks / HTML" machinery that
 // each rule currently re-implements, which the audit in issue #337 found to be
@@ -13,66 +13,128 @@
 // not a full parser: it does not model container blocks (lists, block quotes),
 // so indentation is measured from the start of the line. See the note in
 // indented_code.go for the consequences.
+//
+// The result is stored compactly: context flags are packed one byte per line and
+// the sanitized text is materialized only for the lines that actually differ
+// from the original (those carrying an inline code span or comment). The
+// original lines are borrowed, not copied. This keeps the per-line overhead near
+// one byte rather than two string headers plus four bools, which matters because
+// the linter runs Scan over every file. Access the result through the Context
+// methods rather than touching the fields.
 package preprocess
 
 import "strings"
 
-// LineContext records, for one source line, which Markdown contexts it lives in
-// and a sanitized copy of its text.
+// Context is the result of Scan: the per-line Markdown classification of a file,
+// queried by line index through its methods.
 //
-// The boolean flags describe structural block membership and are mutually
-// exclusive: a line is in at most one of fenced code, indented code, an HTML
-// block, or an HTML comment. They are exposed individually rather than via a
-// single "skippable" convenience flag because different rules skip different
-// subsets — for example, rules implementing the markdownlint divergences in
-// issue #337 (max-line-length, no-hard-tabs) deliberately scan inside fenced
-// code blocks.
+// The four context predicates (InFencedCode, InIndentedCode, InHTMLBlock,
+// InHTMLComment) describe structural block membership and are mutually
+// exclusive: a line is in at most one of them. They are exposed individually
+// rather than via a single "skippable" convenience predicate because different
+// rules skip different subsets — for example, rules implementing the markdownlint
+// divergences in issue #337 (max-line-length, no-hard-tabs) deliberately scan
+// inside fenced code blocks.
 //
-// Sanitized is an inline-level transformation only: inline code spans and inline
-// HTML comments are replaced by spaces (length-preserving), so a rule can scan
-// Sanitized without matching content that lives in those spans. Block-level code
-// (fenced and indented) is NOT blanked in Sanitized — it is left verbatim so
-// that rules which want to inspect code-block contents still can; use the flags
-// to skip block code instead. For lines flagged InHTMLComment, Sanitized is
-// fully blank because the entire line was comment text.
-type LineContext struct {
-	// Original is the line exactly as it appeared in the input.
-	Original string
-	// Sanitized is Original with inline code spans and inline HTML comments
-	// replaced by spaces. For block-code and HTML-block lines it equals
-	// Original; for fully-commented lines it is all whitespace.
-	Sanitized string
-
-	// InFencedCode is true for every line of a fenced code block, including the
-	// opening and closing fence lines. If a fence is never closed, every line
-	// from the opener to end of file is flagged, which prevents downstream rules
-	// from mispairing fences inside the unclosed region.
-	InFencedCode bool
-	// InIndentedCode is true for lines inside an indented code block
-	// (CommonMark §4.4). See the limitation noted in indented_code.go.
-	InIndentedCode bool
-	// InHTMLBlock is true for lines inside an HTML block of CommonMark types 1
-	// and 3–7 (e.g. <div>…</div>). HTML comments are reported via
-	// InHTMLComment, not this flag.
-	InHTMLBlock bool
-	// InHTMLComment is true for lines whose entire content is an HTML comment —
-	// a standalone <!-- … --> line or a continuation line of a multi-line
-	// comment. A prose line with a trailing inline comment is not flagged here;
-	// its comment is blanked in Sanitized instead.
-	InHTMLComment bool
+// Sanitized returns an inline-level transformation only: inline code spans and
+// inline HTML comments are replaced by spaces (length-preserving), so a rule can
+// scan it without matching content that lives in those spans. Block-level code
+// (fenced and indented) is NOT blanked — it is returned verbatim so that rules
+// which want to inspect code-block contents still can; use the predicates to skip
+// block code instead. For lines reported by InHTMLComment, Sanitized is fully
+// blank because the entire line was comment text.
+type Context struct {
+	// lines is the borrowed input slice. The caller must not mutate it for the
+	// lifetime of the Context, since Line and Sanitized read from it directly.
+	lines []string
+	// flags holds the packed context bits for each line, parallel to lines.
+	flags []uint8
+	// sanitized holds the inline-sanitized text only for the lines that differ
+	// from their original (those with an inline code span or comment). Lines
+	// absent from the map are their own sanitized form. nil until the first such
+	// line is seen.
+	sanitized map[int]string
 }
 
-// Scan classifies every line of a Markdown file in a single pass and returns one
-// LineContext per input line, in order. The input is expected to have already
-// had YAML front matter stripped by the caller (the linter does this centrally),
-// so Scan does not handle front matter.
-func Scan(lines []string) []LineContext {
-	result := make([]LineContext, len(lines))
+// Context flag bits, packed one set per line in Context.flags.
+const (
+	flagFencedCode uint8 = 1 << iota
+	flagIndentedCode
+	flagHTMLBlock
+	flagHTMLComment
+)
+
+// Len returns the number of lines classified (equal to len(input)).
+func (c *Context) Len() int { return len(c.lines) }
+
+// Line returns the original text of line i, exactly as it appeared in the input.
+func (c *Context) Line(i int) string { return c.lines[i] }
+
+// Sanitized returns line i with inline code spans and inline HTML comments
+// replaced by spaces. For block-code and HTML-block lines it equals Line(i); for
+// fully-commented lines it is all whitespace.
+func (c *Context) Sanitized(i int) string {
+	if s, ok := c.sanitized[i]; ok {
+		return s
+	}
+	return c.lines[i]
+}
+
+// InFencedCode reports whether line i is part of a fenced code block, including
+// the opening and closing fence lines. If a fence is never closed, every line
+// from the opener to end of file is flagged, which prevents downstream rules from
+// mispairing fences inside the unclosed region.
+func (c *Context) InFencedCode(i int) bool { return c.flags[i]&flagFencedCode != 0 }
+
+// InIndentedCode reports whether line i is inside an indented code block
+// (CommonMark §4.4). See the limitation noted in indented_code.go.
+func (c *Context) InIndentedCode(i int) bool { return c.flags[i]&flagIndentedCode != 0 }
+
+// InHTMLBlock reports whether line i is inside an HTML block of CommonMark types
+// 1 and 3–7 (e.g. <div>…</div>). HTML comments are reported via InHTMLComment,
+// not this predicate.
+func (c *Context) InHTMLBlock(i int) bool { return c.flags[i]&flagHTMLBlock != 0 }
+
+// InHTMLComment reports whether line i is a line whose entire content is an HTML
+// comment — a standalone <!-- … --> line or a continuation line of a multi-line
+// comment. A prose line with a trailing inline comment is not reported here; its
+// comment is blanked in Sanitized instead.
+func (c *Context) InHTMLComment(i int) bool { return c.flags[i]&flagHTMLComment != 0 }
+
+// Scan classifies every line of a Markdown file in a single pass and returns a
+// Context to query by line index. The input slice is borrowed, not copied, and
+// must not be mutated while the Context is in use. The input is expected to have
+// already had YAML front matter stripped by the caller (the linter does this
+// centrally), so Scan does not handle front matter.
+func Scan(lines []string) *Context {
+	c := &Context{
+		lines: lines,
+		flags: make([]uint8, len(lines)),
+	}
 	var s scanner
 	for i, line := range lines {
-		result[i] = s.classify(line)
+		lc := s.classify(line)
+		c.flags[i] = lc.flags
+		// Store the sanitized text only when it actually differs from the
+		// original. The fast path in sanitizeInline returns the original string
+		// unchanged for ordinary lines, so this comparison is a cheap identity
+		// check for the common case.
+		if lc.sanitized != line {
+			if c.sanitized == nil {
+				c.sanitized = make(map[int]string)
+			}
+			c.sanitized[i] = lc.sanitized
+		}
 	}
-	return result
+	return c
+}
+
+// lineClass is the per-line classification produced by the scanner: the packed
+// context flags and the inline-sanitized text (which equals the original line
+// unless an inline code span or comment was blanked).
+type lineClass struct {
+	flags     uint8
+	sanitized string
 }
 
 // scanner holds the cross-line state needed to classify each line in context.
@@ -87,13 +149,13 @@ type scanner struct {
 	inParagraph bool
 }
 
-// classify advances the scanner by one line and returns that line's context.
-func (s *scanner) classify(line string) LineContext {
+// classify advances the scanner by one line and returns that line's class.
+func (s *scanner) classify(line string) lineClass {
 	cols, firstIdx := indentColumns(line)
 	isBlank := firstIdx == len(line)
 
-	if ctx, handled := s.continueOpenBlock(line, cols, isBlank); handled {
-		return ctx
+	if lc, handled := s.continueOpenBlock(line, cols, isBlank); handled {
+		return lc
 	}
 	return s.startLine(line, cols, isBlank)
 }
@@ -102,7 +164,7 @@ func (s *scanner) classify(line string) LineContext {
 // line (fenced code, HTML comment, or HTML block). It returns handled=false when
 // no such block is open, or when a type 6/7 HTML block has just ended on this
 // blank line and the line should be classified afresh by startLine.
-func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (LineContext, bool) {
+func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (lineClass, bool) {
 	switch {
 	// Fences take precedence over every other context; a comment or HTML start
 	// inside a code block is literal.
@@ -112,7 +174,7 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (LineCo
 			s.fenceMarker = ""
 		}
 		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: line, InFencedCode: true}, true
+		return lineClass{flags: flagFencedCode, sanitized: line}, true
 
 	// Multi-line HTML comment: track until the closing "-->". The comment may
 	// close mid-line and leave trailing prose; in that case the line is not a
@@ -121,37 +183,37 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (LineCo
 	case s.inComment:
 		sanitized, stillInComment, fullyComment := sanitizeInline(line, true)
 		s.inComment = stillInComment
-		ctx := LineContext{Original: line, Sanitized: sanitized}
+		lc := lineClass{sanitized: sanitized}
 		if fullyComment {
-			ctx.InHTMLComment = true
+			lc.flags = flagHTMLComment
 			s.inParagraph = false
 		} else {
 			s.inParagraph = true
 		}
-		return ctx, true
+		return lc, true
 
 	// Open HTML block. Types 1 and 3–5 end on a delimiter line; types 6 and 7
 	// end on a blank line, which is itself outside the block.
 	case s.inHTMLBlock:
 		if (s.htmlType == 6 || s.htmlType == 7) && isBlank {
 			s.inHTMLBlock = false
-			return LineContext{}, false
+			return lineClass{}, false
 		}
 		if s.htmlType >= 1 && s.htmlType <= 5 && htmlBlockEndsOnLine(line, s.htmlType) {
 			s.inHTMLBlock = false
 		}
 		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: line, InHTMLBlock: true}, true
+		return lineClass{flags: flagHTMLBlock, sanitized: line}, true
 	}
-	return LineContext{}, false
+	return lineClass{}, false
 }
 
 // startLine classifies a line that does not continue an already-open block.
-func (s *scanner) startLine(line string, cols int, isBlank bool) LineContext {
+func (s *scanner) startLine(line string, cols int, isBlank bool) lineClass {
 	// Blank line outside any block closes an open paragraph.
 	if isBlank {
 		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: line}
+		return lineClass{sanitized: line}
 	}
 
 	// Indented code block: four or more columns of indentation, but only when it
@@ -159,43 +221,43 @@ func (s *scanner) startLine(line string, cols int, isBlank bool) LineContext {
 	// paragraph). Checked before openers because an indented line can open
 	// neither a fence nor an HTML block.
 	if cols >= 4 && !s.inParagraph {
-		return LineContext{Original: line, Sanitized: line, InIndentedCode: true}
+		return lineClass{flags: flagIndentedCode, sanitized: line}
 	}
 
 	// Block openers are recognized only at an indentation below four columns.
 	if cols < 4 {
-		if ctx, opened := s.tryOpenBlock(line); opened {
-			return ctx
+		if lc, opened := s.tryOpenBlock(line); opened {
+			return lc
 		}
 	}
 
 	// Everything else is prose: paragraph text, headings, list items, lazy
 	// paragraph continuations, and standalone HTML comments. Inline code spans
-	// and inline comments are blanked in Sanitized.
+	// and inline comments are blanked in the sanitized text.
 	sanitized, endedInComment, fullyComment := sanitizeInline(line, false)
 	s.inComment = endedInComment
-	ctx := LineContext{Original: line, Sanitized: sanitized}
+	lc := lineClass{sanitized: sanitized}
 	if fullyComment {
 		// The line was nothing but comment text — a standalone comment line.
-		ctx.InHTMLComment = true
+		lc.flags = flagHTMLComment
 		s.inParagraph = false
 	} else {
 		s.inParagraph = true
 	}
-	return ctx
+	return lc
 }
 
 // tryOpenBlock attempts to open a fenced code block or an HTML block on line
 // (which must be indented fewer than four columns). It returns opened=false when
 // the line is not a block opener.
-func (s *scanner) tryOpenBlock(line string) (LineContext, bool) {
+func (s *scanner) tryOpenBlock(line string) (lineClass, bool) {
 	trimmed := strings.TrimSpace(line)
 
 	if marker := openingFenceMarker(trimmed); marker != "" {
 		s.inFence = true
 		s.fenceMarker = marker
 		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: line, InFencedCode: true}, true
+		return lineClass{flags: flagFencedCode, sanitized: line}, true
 	}
 
 	if t := htmlBlockStart(trimmed, s.inParagraph); t != 0 {
@@ -205,8 +267,8 @@ func (s *scanner) tryOpenBlock(line string) (LineContext, bool) {
 			s.inHTMLBlock = false
 		}
 		s.inParagraph = false
-		return LineContext{Original: line, Sanitized: line, InHTMLBlock: true}, true
+		return lineClass{flags: flagHTMLBlock, sanitized: line}, true
 	}
 
-	return LineContext{}, false
+	return lineClass{}, false
 }

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -11,13 +11,13 @@ type flags struct {
 	fenced, indented, htmlBlock, htmlComment bool
 }
 
-func flagsOf(c LineContext) flags {
-	return flags{c.InFencedCode, c.InIndentedCode, c.InHTMLBlock, c.InHTMLComment}
+func flagsOf(c *Context, i int) flags {
+	return flags{c.InFencedCode(i), c.InIndentedCode(i), c.InHTMLBlock(i), c.InHTMLComment(i)}
 }
 
 // runScan splits a multi-line literal and runs Scan. A leading newline in the
 // literal is dropped so test inputs can start on their own line.
-func runScan(t *testing.T, doc string) []LineContext {
+func runScan(t *testing.T, doc string) *Context {
 	t.Helper()
 	doc = strings.TrimPrefix(doc, "\n")
 	return Scan(strings.Split(doc, "\n"))
@@ -181,13 +181,13 @@ still code
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := runScan(t, tt.doc)
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %d lines, want %d:\n%#v", len(got), len(tt.want), got)
+			if got.Len() != len(tt.want) {
+				t.Fatalf("got %d lines, want %d", got.Len(), len(tt.want))
 			}
 			for i := range tt.want {
-				if g := flagsOf(got[i]); g != tt.want[i] {
+				if g := flagsOf(got, i); g != tt.want[i] {
 					t.Errorf("line %d (%q): flags = %+v, want %+v",
-						i, got[i].Original, g, tt.want[i])
+						i, got.Line(i), g, tt.want[i])
 				}
 			}
 		})
@@ -195,12 +195,12 @@ still code
 }
 
 // TestScanSanitizedContract checks the inline-vs-block split of the Sanitized
-// field described in the LineContext docs.
+// view described in the Context docs.
 func TestScanSanitizedContract(t *testing.T) {
 	t.Run("inline code in prose is blanked", func(t *testing.T) {
 		ctx := runScan(t, "see `http://x.com` here")
-		if strings.Contains(ctx[0].Sanitized, "http://x.com") {
-			t.Errorf("inline code not blanked: %q", ctx[0].Sanitized)
+		if strings.Contains(ctx.Sanitized(0), "http://x.com") {
+			t.Errorf("inline code not blanked: %q", ctx.Sanitized(0))
 		}
 	})
 
@@ -208,59 +208,93 @@ func TestScanSanitizedContract(t *testing.T) {
 		doc := "```\n`backtick` text\n```"
 		ctx := Scan(strings.Split(doc, "\n"))
 		// Section B rules deliberately scan inside fenced code, so the content
-		// line's Sanitized must equal its Original (no inline stripping).
-		if ctx[1].Sanitized != ctx[1].Original {
+		// line's Sanitized must equal its Line (no inline stripping).
+		if ctx.Sanitized(1) != ctx.Line(1) {
 			t.Errorf("fenced content was sanitized: got %q, want %q",
-				ctx[1].Sanitized, ctx[1].Original)
+				ctx.Sanitized(1), ctx.Line(1))
 		}
 	})
 
 	t.Run("standalone comment line is fully blanked", func(t *testing.T) {
 		ctx := runScan(t, "<!-- a comment -->")
-		if strings.TrimSpace(ctx[0].Sanitized) != "" {
-			t.Errorf("comment line not blanked: %q", ctx[0].Sanitized)
+		if strings.TrimSpace(ctx.Sanitized(0)) != "" {
+			t.Errorf("comment line not blanked: %q", ctx.Sanitized(0))
 		}
-		if !ctx[0].InHTMLComment {
+		if !ctx.InHTMLComment(0) {
 			t.Errorf("standalone comment not flagged InHTMLComment")
 		}
 	})
 
 	t.Run("prose after a mid-line comment close is preserved", func(t *testing.T) {
 		ctx := runScan(t, "text <!-- start\nend --> visible prose")
-		last := ctx[len(ctx)-1]
-		if last.InHTMLComment {
-			t.Errorf("line with trailing prose flagged InHTMLComment: %q", last.Original)
+		last := ctx.Len() - 1
+		if ctx.InHTMLComment(last) {
+			t.Errorf("line with trailing prose flagged InHTMLComment: %q", ctx.Line(last))
 		}
-		if !strings.Contains(last.Sanitized, "visible prose") {
-			t.Errorf("trailing prose not preserved in Sanitized: %q", last.Sanitized)
+		if !strings.Contains(ctx.Sanitized(last), "visible prose") {
+			t.Errorf("trailing prose not preserved in Sanitized: %q", ctx.Sanitized(last))
 		}
 	})
 
 	t.Run("flags are mutually exclusive", func(t *testing.T) {
 		doc := "para\n\n```\ncode\n```\n\n<div>\nx\n</div>\n\n    indented\n\n<!-- c -->"
-		for i, c := range Scan(strings.Split(doc, "\n")) {
+		ctx := Scan(strings.Split(doc, "\n"))
+		for i := 0; i < ctx.Len(); i++ {
 			n := 0
-			for _, b := range []bool{c.InFencedCode, c.InIndentedCode, c.InHTMLBlock, c.InHTMLComment} {
+			for _, b := range []bool{ctx.InFencedCode(i), ctx.InIndentedCode(i), ctx.InHTMLBlock(i), ctx.InHTMLComment(i)} {
 				if b {
 					n++
 				}
 			}
 			if n > 1 {
-				t.Errorf("line %d (%q) has %d context flags set, want <=1", i, c.Original, n)
+				t.Errorf("line %d (%q) has %d context flags set, want <=1", i, ctx.Line(i), n)
 			}
 		}
 	})
 
-	t.Run("Original always preserved and Scan returns one ctx per line", func(t *testing.T) {
+	t.Run("Line preserves input and Scan covers every line", func(t *testing.T) {
 		lines := []string{"a", "  b `c`", "```", "d", "```"}
 		ctx := Scan(lines)
-		if len(ctx) != len(lines) {
-			t.Fatalf("got %d contexts, want %d", len(ctx), len(lines))
+		if ctx.Len() != len(lines) {
+			t.Fatalf("got %d lines, want %d", ctx.Len(), len(lines))
 		}
 		for i := range lines {
-			if ctx[i].Original != lines[i] {
-				t.Errorf("line %d: Original = %q, want %q", i, ctx[i].Original, lines[i])
+			if ctx.Line(i) != lines[i] {
+				t.Errorf("line %d: Line = %q, want %q", i, ctx.Line(i), lines[i])
 			}
 		}
 	})
+}
+
+// TestScanSanitizedIsSparse locks the compact-storage contract: the sanitized
+// map holds an entry only for lines whose sanitized form differs from the
+// original (those carrying an inline code span or comment). Verbatim lines —
+// blank, prose without inline code, block code, HTML blocks — are absent and
+// fall through to the original via Sanitized.
+func TestScanSanitizedIsSparse(t *testing.T) {
+	lines := []string{
+		"plain prose line",        // verbatim
+		"",                        // blank, verbatim
+		"text with `code` span",   // differs -> stored
+		"```",                     // fence open, verbatim
+		"code `not blanked` here", // inside fence, verbatim
+		"```",                     // fence close, verbatim
+		"<!-- standalone -->",     // fully comment -> stored
+	}
+	ctx := Scan(lines)
+
+	differs := map[int]bool{2: true, 6: true}
+	for i := range lines {
+		_, stored := ctx.sanitized[i]
+		if stored != differs[i] {
+			t.Errorf("line %d (%q): stored=%v, want %v", i, lines[i], stored, differs[i])
+		}
+		// Regardless of storage, Sanitized must round-trip verbatim lines.
+		if !differs[i] && ctx.Sanitized(i) != lines[i] {
+			t.Errorf("line %d (%q): Sanitized=%q, want verbatim", i, lines[i], ctx.Sanitized(i))
+		}
+	}
+	if len(ctx.sanitized) != 2 {
+		t.Errorf("sanitized map has %d entries, want 2 (only differing lines)", len(ctx.sanitized))
+	}
 }


### PR DESCRIPTION
## Summary

A small **"Phase 1.5"** before wiring the preprocess layer into the linter (#340).

While prototyping Phase 2 (wiring `preprocess.Scan` into `collectLineErrors`), the benchmark gate surfaced a **structural** problem with the Phase 1 API: `Scan` returned `[]LineContext`, a struct of two `string` fields (`Original`, `Sanitized`) + 4 bools ≈ **40 bytes/line, materialized eagerly for every line**.

On a large document that array alone is roughly the size of the entire baseline lint footprint, so simply wiring `Scan` in **~doubled memory** — and that cost is **permanent**, not transient: later phases remove redundant *CPU passes*, but the shared array stays. Measured on `FullLinting_ExtraLarge` (~96k-line synthetic doc):

| | memory | note |
|---|---|---|
| main baseline | 3.84 MB | the lint itself is allocation-frugal |
| `Scan` array alone | +3.83 MB | ≈ baseline → +100% |

## Change

Replace `[]LineContext` with a compact `*Context` queried by line index:

```go
ctx := preprocess.Scan(lines)   // *Context, borrows lines (must not be mutated)
ctx.Len()
ctx.Line(i)                      // original text, zero-copy
ctx.Sanitized(i)                 // inline code/comments blanked; verbatim otherwise
ctx.InFencedCode(i)              // + InIndentedCode / InHTMLBlock / InHTMLComment
```

- **Flags** packed one byte per line (bitset).
- **Sanitized** materialized only for the lines that actually differ from the original (those carrying an inline code span or comment), kept in a sparse map; verbatim lines fall through to the borrowed original.
- **Original** never duplicated — `Line(i)` reads the borrowed input slice.

Per-line overhead drops from ~40 bytes to ~1 byte, so the shared pre-pass will add only a few percent once wired in (Phase 2), instead of doubling memory.

A fast path in `sanitizeInline` returns ordinary prose lines verbatim, which also lets `Scan` detect by string identity that a line needs no sanitized-map entry.

## Scope / safety

Phase 1 was purely additive and **nothing imports `internal/preprocess` yet**, so this is an API change with **zero consumers to update** — the cheapest possible moment to make it. Behavior (the classification semantics and the sanitized contract) is unchanged; only the result representation and access shape change.

## Tests

- All existing classification + sanitized-contract tests ported to the accessor API.
- New `TestScanSanitizedIsSparse` locks the compact-storage contract: the sanitized map holds an entry only for lines whose sanitized form differs from the original.
- `make test-all` clean, `make static-lint` clean, 100% coverage, `make bench-compare` ✅ (unchanged — still no consumers).

Refs #337. Unblocks #340 (Phase 2).