### PR TITLE
feat(linter): wire preprocess.Scan into the linter and migrate no-bare-urls (#337 Phase 2)

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 	"github.com/shinagawa-web/gomarklint/v3/internal/file"
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
@@ -353,8 +354,10 @@ func (l *Linter) externalLinkAllowedStatuses() []int {
 	return statuses
 }
 
-// simpleRules lists rules whose check function takes only (path, lines, offset).
-// Rules that require additional options are handled separately below.
+// simpleRules lists rules whose check function takes only (path, lines, offset)
+// and have not yet been migrated to the preprocess context. Rules that require
+// additional options, or that consume the shared *preprocess.Context, are
+// handled separately below.
 var simpleRules = []struct {
 	name string
 	fn   func(string, []string, int) []rule.LintError
@@ -368,7 +371,6 @@ var simpleRules = []struct {
 	{"no-setext-headings", rule.CheckNoSetextHeadings},
 	{"single-h1", rule.CheckSingleH1},
 	{"blanks-around-headings", rule.CheckBlanksAroundHeadings},
-	{"no-bare-urls", rule.CheckNoBareURLs},
 	{"no-empty-links", rule.CheckNoEmptyLinks},
 	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
@@ -377,13 +379,20 @@ var simpleRules = []struct {
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.
-func (l *Linter) collectLineErrors(path string, lines []string, offset int) []rule.LintError {
+// ctx is the shared per-line context produced once by preprocess.Scan; rules
+// that have migrated to consume it receive ctx, while the rest continue to read
+// the raw lines slice (which Scan borrows, so no copy is made).
+func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.Context, offset int) []rule.LintError {
 	var errs []rule.LintError
 
 	for _, r := range simpleRules {
 		if l.config.IsEnabled(r.name) {
 			errs = append(errs, l.withSeverity(r.fn(path, lines, offset), r.name)...)
 		}
+	}
+
+	if l.config.IsEnabled("no-bare-urls") {
+		errs = append(errs, l.withSeverity(rule.CheckNoBareURLs(path, ctx, offset), "no-bare-urls")...)
 	}
 
 	if l.config.IsEnabled("heading-level") {
@@ -420,7 +429,9 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 		disabled = parseDisableComments(lines, offset)
 	}
 
-	allErrors := l.collectLineErrors(path, lines, offset)
+	ctx := preprocess.Scan(lines)
+
+	allErrors := l.collectLineErrors(path, lines, ctx, offset)
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {

--- a/internal/rule/inline_strip.go
+++ b/internal/rule/inline_strip.go
@@ -22,9 +22,9 @@ func countBacktickRun(s string, start int) int {
 
 // stripInlineCode replaces content inside backtick spans (including the
 // delimiters) with spaces so that URLs within inline code are not scanned.
-// Handles both single-backtick (` " `) and multi-backtick (` " `) spans per
-// CommonMark: a code span opens with a run of N backticks and closes with the
-// next run of exactly N backticks.
+// Handles single- and multi-backtick code spans (e.g. `code`) per CommonMark:
+// a code span opens with a run of N backticks and closes with the next run of
+// exactly N backticks, so a longer run can contain shorter ones.
 func stripInlineCode(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))

--- a/internal/rule/inline_strip.go
+++ b/internal/rule/inline_strip.go
@@ -1,0 +1,103 @@
+package rule
+
+import "strings"
+
+// This file holds inline-sanitization helpers shared by several rules that have
+// not yet been migrated to the preprocess context (#337 Phase 3): no-empty-links,
+// link-fragments, consistent-emphasis-style, no-hard-tabs, and
+// fenced-code-language. They duplicate logic now centralized in
+// internal/preprocess (see Context.Sanitized) and are removed once their last
+// consumer migrates. no-bare-urls, the Phase 2 reference adoption, no longer
+// uses them.
+
+// countBacktickRun returns the number of consecutive backticks starting at
+// position start in s.
+func countBacktickRun(s string, start int) int {
+	n := 0
+	for start+n < len(s) && s[start+n] == '`' {
+		n++
+	}
+	return n
+}
+
+// stripInlineCode replaces content inside backtick spans (including the
+// delimiters) with spaces so that URLs within inline code are not scanned.
+// Handles both single-backtick (` " `) and multi-backtick (` " `) spans per
+// CommonMark: a code span opens with a run of N backticks and closes with the
+// next run of exactly N backticks.
+func stripInlineCode(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		if s[i] != '`' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		delimLen := countBacktickRun(s, i)
+		closing := -1
+		j := i + delimLen
+		for j < len(s) {
+			if s[j] != '`' {
+				j++
+				continue
+			}
+			runLen := countBacktickRun(s, j)
+			if runLen == delimLen {
+				closing = j
+				break
+			}
+			j += runLen
+		}
+
+		if closing == -1 {
+			// No matching closing run — emit backticks as-is.
+			for k := 0; k < delimLen; k++ {
+				b.WriteByte('`')
+			}
+			i += delimLen
+			continue
+		}
+
+		// Replace the entire span (delimiters + content) with spaces.
+		spanLen := (closing + delimLen) - i
+		for k := 0; k < spanLen; k++ {
+			b.WriteByte(' ')
+		}
+		i = closing + delimLen
+	}
+
+	return b.String()
+}
+
+// stripHTMLComments replaces content inside <!-- ... --> spans (including the
+// delimiters) with spaces so that URLs within HTML comments are not scanned.
+// It handles multiple comment spans on a single line. The second return value
+// reports whether the line ended inside an unclosed comment.
+func stripHTMLComments(s string) (string, bool) {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+4 <= len(s) && s[i:i+4] == "<!--" {
+			end := strings.Index(s[i+4:], "-->")
+			if end == -1 {
+				// Unclosed comment — blank the rest of the line.
+				for k := i; k < len(s); k++ {
+					b.WriteByte(' ')
+				}
+				return b.String(), true
+			}
+			spanLen := 4 + end + 3
+			for k := 0; k < spanLen; k++ {
+				b.WriteByte(' ')
+			}
+			i += spanLen
+		} else {
+			b.WriteByte(s[i])
+			i++
+		}
+	}
+	return b.String(), false
+}

--- a/internal/rule/inline_strip_test.go
+++ b/internal/rule/inline_strip_test.go
@@ -1,0 +1,38 @@
+package rule
+
+import "testing"
+
+// TestStripInlineCode covers the shared helper directly. The unclosed-backtick
+// branch in particular is no longer exercised transitively by no-bare-urls,
+// which migrated to the preprocess context (#337 Phase 2).
+func TestStripInlineCode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no backticks", "plain text", "plain text"},
+		{"single span blanked", "a `code` b", "a        b"},
+		{"multi-backtick span blanked", "a ``c`d`` e", "a         e"},
+		{
+			// Unclosed run: the backticks have no matching closing run, so they
+			// are emitted literally and the rest of the line is left intact.
+			name: "unclosed backtick emitted literally",
+			in:   "see `http://x.com here",
+			want: "see `http://x.com here",
+		},
+		{
+			// A longer unclosed run is also emitted verbatim.
+			name: "unclosed double backtick emitted literally",
+			in:   "``unterminated",
+			want: "``unterminated",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripInlineCode(tt.in); got != tt.want {
+				t.Errorf("stripInlineCode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -3,69 +3,9 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
-
-// countBacktickRun returns the number of consecutive backticks starting at
-// position start in s.
-func countBacktickRun(s string, start int) int {
-	n := 0
-	for start+n < len(s) && s[start+n] == '`' {
-		n++
-	}
-	return n
-}
-
-// stripInlineCode replaces content inside backtick spans (including the
-// delimiters) with spaces so that URLs within inline code are not scanned.
-// Handles both single-backtick (` " `) and multi-backtick (` " `) spans per
-// CommonMark: a code span opens with a run of N backticks and closes with the
-// next run of exactly N backticks.
-func stripInlineCode(s string) string {
-	var b strings.Builder
-	b.Grow(len(s))
-
-	for i := 0; i < len(s); {
-		if s[i] != '`' {
-			b.WriteByte(s[i])
-			i++
-			continue
-		}
-
-		delimLen := countBacktickRun(s, i)
-		closing := -1
-		j := i + delimLen
-		for j < len(s) {
-			if s[j] != '`' {
-				j++
-				continue
-			}
-			runLen := countBacktickRun(s, j)
-			if runLen == delimLen {
-				closing = j
-				break
-			}
-			j += runLen
-		}
-
-		if closing == -1 {
-			// No matching closing run — emit backticks as-is.
-			for k := 0; k < delimLen; k++ {
-				b.WriteByte('`')
-			}
-			i += delimLen
-			continue
-		}
-
-		// Replace the entire span (delimiters + content) with spaces.
-		spanLen := (closing + delimLen) - i
-		for k := 0; k < spanLen; k++ {
-			b.WriteByte(' ')
-		}
-		i = closing + delimLen
-	}
-
-	return b.String()
-}
 
 // isURLBodyChar returns true for characters allowed in a URL body
 // (everything except whitespace, <>, ()[], and quotes).
@@ -93,36 +33,6 @@ func isWrappedURL(line string, start int) bool {
 		return i >= 0 && line[i] == '='
 	}
 	return false
-}
-
-// stripHTMLComments replaces content inside <!-- ... --> spans (including the
-// delimiters) with spaces so that URLs within HTML comments are not scanned.
-// It handles multiple comment spans on a single line. The second return value
-// reports whether the line ended inside an unclosed comment.
-func stripHTMLComments(s string) (string, bool) {
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); {
-		if i+4 <= len(s) && s[i:i+4] == "<!--" {
-			end := strings.Index(s[i+4:], "-->")
-			if end == -1 {
-				// Unclosed comment — blank the rest of the line.
-				for k := i; k < len(s); k++ {
-					b.WriteByte(' ')
-				}
-				return b.String(), true
-			}
-			spanLen := 4 + end + 3
-			for k := 0; k < spanLen; k++ {
-				b.WriteByte(' ')
-			}
-			i += spanLen
-		} else {
-			b.WriteByte(s[i])
-			i++
-		}
-	}
-	return b.String(), false
 }
 
 // scanURLEnd returns the end index of the URL body starting at bodyStart.
@@ -171,39 +81,14 @@ func findBareURLs(line string) []string {
 	return urls
 }
 
-// advanceComment advances a line that is currently inside a multi-line HTML
-// comment. It returns the (possibly modified) line and the updated inComment
-// state. If "-->" is found, inComment becomes false and the remainder of the
-// line after "-->" is returned for further processing.
-func advanceComment(line string) (string, bool) {
-	idx := strings.Index(line, "-->")
-	if idx == -1 {
-		return line, true
-	}
-	return strings.Repeat(" ", idx+3) + line[idx+3:], false
-}
-
-// prepareScanned strips inline code and HTML comments from line, returning the
-// sanitized string and whether the line ended inside an unclosed comment.
-func prepareScanned(line string) (string, bool) {
-	scanned := line
-	if strings.ContainsRune(scanned, '`') {
-		scanned = stripInlineCode(scanned)
-	}
-	if strings.Contains(scanned, "<!--") {
-		var endedInComment bool
-		scanned, endedInComment = stripHTMLComments(scanned)
-		return scanned, endedInComment
-	}
-	return scanned, false
-}
-
 // isLinkCard reports whether line i is a standalone link-card URL: the
 // trimmed line is a single http/https URL with no surrounding prose, preceded
 // and followed by a blank line (or the file boundary). Such lines are
 // intentionally placed by the author to trigger renderer-level link card
-// previews (GitHub, Zenn, etc.) and must not be flagged.
-func isLinkCard(lines []string, i int, trimmed string) bool {
+// previews (GitHub, Zenn, etc.) and must not be flagged. The trimmed argument
+// is derived from the original line so that inline code or comment markers on
+// the line disqualify it from being a bare link card.
+func isLinkCard(ctx *preprocess.Context, i int, trimmed string) bool {
 	if !strings.HasPrefix(trimmed, "http://") && !strings.HasPrefix(trimmed, "https://") {
 		return false
 	}
@@ -211,71 +96,47 @@ func isLinkCard(lines []string, i int, trimmed string) bool {
 	if len(urls) != 1 || trimmed != urls[0] {
 		return false
 	}
-	prevBlank := i == 0 || strings.TrimSpace(lines[i-1]) == ""
-	nextBlank := i >= len(lines)-1 || strings.TrimSpace(lines[i+1]) == ""
+	prevBlank := i == 0 || strings.TrimSpace(ctx.Line(i-1)) == ""
+	nextBlank := i >= ctx.Len()-1 || strings.TrimSpace(ctx.Line(i+1)) == ""
 	return prevBlank && nextBlank
 }
 
 // CheckNoBareURLs flags HTTP/HTTPS URLs that appear as bare text rather than
 // being wrapped in angle brackets or used inside a Markdown link or image.
-// URLs inside fenced code blocks, inline code spans, HTML comments, and HTML
-// attribute values are ignored. A URL that stands alone on its own line
-// surrounded by blank lines is treated as a link card and not flagged.
-func CheckNoBareURLs(filename string, lines []string, offset int) []LintError {
+// URLs inside fenced code blocks, indented code blocks, HTML blocks, HTML
+// comments, inline code spans, and HTML attribute values are ignored. A URL
+// that stands alone on its own line surrounded by blank lines is treated as a
+// link card and not flagged.
+//
+// This rule is the reference adoption of the shared preprocess pass (#337
+// Phase 2): rather than re-deriving code/comment context, it skips lines the
+// scanner already classified as code or HTML and scans the inline-sanitized
+// text (code spans and inline comments blanked) for the remaining lines.
+func CheckNoBareURLs(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
-	inComment := false
 
-	for i, line := range lines {
-		// Multi-line HTML comment tracking takes priority: fences inside
-		// comments are not treated as code block delimiters.
-		if inComment {
-			var stillInComment bool
-			line, stillInComment = advanceComment(line)
-			if stillInComment {
-				continue
-			}
-			inComment = false
-			// Fall through to process the remainder of the line.
-		}
-
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		// Skip every block context the scanner already identified. This closes
+		// the indented-code and HTML-block gaps the previous bespoke fence/
+		// comment tracking missed.
+		if ctx.InFencedCode(i) || ctx.InIndentedCode(i) || ctx.InHTMLBlock(i) || ctx.InHTMLComment(i) {
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				continue
-			}
-		}
-
-		if !strings.Contains(line, "http") {
-			if strings.Contains(line, "<!--") {
-				_, inComment = stripHTMLComments(line)
-			}
+		// Sanitized has inline code spans and inline comments blanked, so URLs
+		// living inside them are not seen here.
+		sanitized := ctx.Sanitized(i)
+		if !strings.Contains(sanitized, "http") {
 			continue
 		}
 
-		trimmed := strings.TrimSpace(line)
-		if isLinkCard(lines, i, trimmed) {
+		// The link-card test uses the original text: a line carrying anything
+		// besides the URL (e.g. an inline code span) is not a bare link card.
+		if isLinkCard(ctx, i, strings.TrimSpace(ctx.Line(i))) {
 			continue
 		}
 
-		scanned, endedInComment := prepareScanned(line)
-		if endedInComment {
-			inComment = true
-		}
-
-		for _, url := range findBareURLs(scanned) {
+		for _, url := range findBareURLs(sanitized) {
 			errs = append(errs, LintError{
 				File:    filename,
 				Line:    offset + i + 1,

--- a/internal/rule/no_bare_urls_test.go
+++ b/internal/rule/no_bare_urls_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoBareURLs(t *testing.T) {
@@ -267,7 +269,7 @@ func TestCheckNoBareURLs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoBareURLs("test.md", lines, tt.offset)
+			got := CheckNoBareURLs("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)


### PR DESCRIPTION
## Summary

Phase 2 of #337 (#340): run the shared pre-pass once per file and have the first rule consume it.

- `linter.collectErrors` now calls `preprocess.Scan(lines)` once per file and passes the resulting `*preprocess.Context` to rules that consume it.
- **`no-bare-urls`** is migrated as the reference adoption: it drops its own fence/comment state machine and instead skips lines the scanner classified as fenced code, indented code, HTML block, or HTML comment, scanning the inline-sanitized text for the rest.

Depends on #345 (Phase 1.5, the compact `Context` API).

## Wiring approach — and a deviation from the original plan

The implementation plan (#337) called for changing **all 23 rule signatures** to take the context in one mechanical pass, with un-migrated rules bridging back to `[]string`. I prototyped that and it **fails the benchmark gate**: reconstructing the lines slice per rule allocates ~16 bytes/line × 22 rules, which on the large benchmark doc is +942% memory.

Instead, this PR keeps un-migrated rules on the raw `lines` slice (which `Scan` **borrows**, so there is no copy) and passes the `*Context` only to the rule that actually consumes it. Each remaining rule will change its signature **together with** its body when it migrates in Phase 3. `no-bare-urls` is therefore lifted out of the `simpleRules` table and called explicitly.

Result on `FullLinting_ExtraLarge` (~96k-line synthetic doc): **memory +2.75%, time +4.78%, allocs +0.06%** — all within the +10% gate. (The residual time is the one extra Scan pass; Phase 3 reclaims it as rules stop running their own fence-tracking passes.)

## Behavior change (intended)

Migrating `no-bare-urls` to the shared context also **closes two audit gaps** it previously had (#337 matrix): bare URLs inside **indented code blocks** and **HTML blocks** are no longer flagged. All existing `no-bare-urls` tests still pass, including the inline-code, HTML-attribute, link-card, and multi-line-comment cases.

## Note on the helper relocation

The issue's checklist says to delete `stripInlineCode` / `stripHTMLComments` / `countBacktickRun` from `no_bare_urls.go`. Those helpers are **shared** — `no-empty-links`, `link-fragments`, `consistent-emphasis-style`, `no-hard-tabs`, and `fenced-code-language` still use them until Phase 3 — so rather than delete them they are **moved** to `internal/rule/inline_strip.go` with a note. `no-bare-urls` no longer references them.

## Tests

- All existing `no-bare-urls` tests pass against the new signature (wrapped through `preprocess.Scan`).
- Added `TestStripInlineCode` covering the relocated helpers' unclosed-backtick branch, which `no-bare-urls` no longer exercises transitively.
- `make test-all` clean, `make static-lint` clean, 100% coverage, `make bench-compare` ✅.

Refs #337. Closes #340.