### PR TITLE
feat(rule): migrate heading family to preprocess context (#337 Phase 3, wave 1)

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -366,16 +366,26 @@ var simpleRules = []struct {
 	{"unclosed-code-block", rule.CheckUnclosedCodeBlocks},
 	{"empty-alt-text", rule.CheckEmptyAltText},
 	{"fenced-code-language", rule.CheckFencedCodeLanguage},
-	{"duplicate-heading", rule.CheckDuplicateHeadings},
 	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
-	{"no-setext-headings", rule.CheckNoSetextHeadings},
-	{"single-h1", rule.CheckSingleH1},
-	{"blanks-around-headings", rule.CheckBlanksAroundHeadings},
 	{"no-empty-links", rule.CheckNoEmptyLinks},
-	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
 	{"blanks-around-fences", rule.CheckBlanksAroundFences},
 	{"no-hard-tabs", rule.CheckNoHardTabs},
+}
+
+// contextRules lists rules migrated to consume the shared *preprocess.Context
+// (issue #337). They take (path, ctx, offset); rules that also need extra
+// options are still handled separately below.
+var contextRules = []struct {
+	name string
+	fn   func(string, *preprocess.Context, int) []rule.LintError
+}{
+	{"no-bare-urls", rule.CheckNoBareURLs},
+	{"single-h1", rule.CheckSingleH1},
+	{"duplicate-heading", rule.CheckDuplicateHeadings},
+	{"no-setext-headings", rule.CheckNoSetextHeadings},
+	{"blanks-around-headings", rule.CheckBlanksAroundHeadings},
+	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.
@@ -391,12 +401,14 @@ func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.
 		}
 	}
 
-	if l.config.IsEnabled("no-bare-urls") {
-		errs = append(errs, l.withSeverity(rule.CheckNoBareURLs(path, ctx, offset), "no-bare-urls")...)
+	for _, r := range contextRules {
+		if l.config.IsEnabled(r.name) {
+			errs = append(errs, l.withSeverity(r.fn(path, ctx, offset), r.name)...)
+		}
 	}
 
 	if l.config.IsEnabled("heading-level") {
-		errs = append(errs, l.withSeverity(rule.CheckHeadingLevels(path, lines, offset, l.headingMinLevel()), "heading-level")...)
+		errs = append(errs, l.withSeverity(rule.CheckHeadingLevels(path, ctx, offset, l.headingMinLevel()), "heading-level")...)
 	}
 	if l.config.IsEnabled("consistent-code-fence") {
 		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, lines, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)

--- a/internal/rule/blanks_around_headings.go
+++ b/internal/rule/blanks_around_headings.go
@@ -1,6 +1,10 @@
 package rule
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
 
 // isATXHeading reports whether s is an ATX-style heading (levels 1–6).
 func isATXHeading(s string) bool {
@@ -16,23 +20,22 @@ func isATXHeading(s string) bool {
 
 // CheckBlanksAroundHeadings flags ATX-style headings that are not preceded or
 // followed by a blank line. Headings at the start or end of the file are exempt
-// from the respective check. Headings inside fenced code blocks are ignored.
-func CheckBlanksAroundHeadings(filename string, lines []string, offset int) []LintError {
+// from the respective check. Headings inside fenced code, indented code, HTML
+// blocks, and HTML comments are ignored.
+func CheckBlanksAroundHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	// prevBlank tracks whether the previous line was blank so we avoid a
 	// second TrimSpace call on lines[i-1] for every heading encountered.
 	// Initialized to true so the first line of the file is exempt.
 	prevBlank := true
 	prevWasHeading := false
 
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
+	for i := 0; i < ctx.Len(); i++ {
+		trimmed := strings.TrimSpace(ctx.Line(i))
 		isBlank := trimmed == ""
 
-		// Check "followed by blank" before the fence branches so a heading
-		// immediately followed by a fence opener is still flagged.
+		// Check "followed by blank" before the block skip so a heading
+		// immediately followed by a code/HTML block opener is still flagged.
 		if prevWasHeading && !isBlank {
 			errs = append(errs, LintError{
 				File:    filename,
@@ -41,19 +44,7 @@ func CheckBlanksAroundHeadings(filename string, lines []string, offset int) []Li
 			})
 		}
 
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			prevBlank = false
-			prevWasHeading = false
-			continue
-		}
-
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
+		if inBlockContext(ctx, i) {
 			prevBlank = false
 			prevWasHeading = false
 			continue

--- a/internal/rule/blanks_around_headings_test.go
+++ b/internal/rule/blanks_around_headings_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckBlanksAroundHeadings(t *testing.T) {
@@ -153,7 +155,7 @@ func TestCheckBlanksAroundHeadings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckBlanksAroundHeadings("test.md", lines, tt.offset)
+			got := CheckBlanksAroundHeadings("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/block_context.go
+++ b/internal/rule/block_context.go
@@ -1,0 +1,16 @@
+package rule
+
+import "github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+
+// inBlockContext reports whether line i sits in any code or HTML block context —
+// fenced code, indented code, an HTML block, or an HTML comment. It is the full
+// block-skip set used by rules that treat all such lines as non-content (heading,
+// link, and structure rules).
+//
+// It is deliberately not a method on preprocess.Context: the preprocess package
+// exposes the four contexts individually because some rules skip only a subset
+// (e.g. the markdownlint divergences max-line-length and no-hard-tabs scan inside
+// fenced code). Rules wanting a different subset call the individual predicates.
+func inBlockContext(ctx *preprocess.Context, i int) bool {
+	return ctx.InFencedCode(i) || ctx.InIndentedCode(i) || ctx.InHTMLBlock(i) || ctx.InHTMLComment(i)
+}

--- a/internal/rule/duplicate_headings.go
+++ b/internal/rule/duplicate_headings.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckDuplicateHeadings detects duplicate headings in the given Markdown content.
@@ -14,45 +16,31 @@ import (
 //
 // Parameters:
 //   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //
 // Returns:
 //   - A slice of LintError entries for each detected duplicate heading (excluding the first occurrence).
-func CheckDuplicateHeadings(filename string, lines []string, offset int) []LintError {
+//
+// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
+// ignored.
+func CheckDuplicateHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	seen := make(map[string]struct{}, len(lines)/10)
-	inBlock := false
-	fenceMarker := ""
+	seen := make(map[string]struct{}, ctx.Len()/10)
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first != fenceMarker[0] {
-				continue
-			}
-			trimmed := strings.TrimSpace(line)
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		if first != '#' && first != '`' && first != '~' {
+		line := ctx.Line(i)
+		if firstNonSpaceByte(line) != '#' {
 			continue
 		}
 
 		trimmed := strings.TrimSpace(line)
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
-		}
-
-		if first != '#' || !isATXHeading(trimmed) {
+		if !isATXHeading(trimmed) {
 			continue
 		}
 

--- a/internal/rule/duplicate_headings_test.go
+++ b/internal/rule/duplicate_headings_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckDuplicateHeadings(t *testing.T) {
@@ -74,7 +76,7 @@ func TestCheckDuplicateHeadings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckDuplicateHeadings("test.md", lines, 0)
+			got := CheckDuplicateHeadings("test.md", preprocess.Scan(lines), 0)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/heading_context_regression_test.go
+++ b/internal/rule/heading_context_regression_test.go
@@ -1,0 +1,106 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
+
+// scanDoc is a small helper: it trims a leading newline (so table literals can
+// start on their own line) and returns the scanned context.
+func scanDoc(doc string) *preprocess.Context {
+	doc = strings.TrimPrefix(doc, "\n")
+	return preprocess.Scan(strings.Split(doc, "\n"))
+}
+
+// TestHeadingFamilySkipsBlockContexts is the #337 Phase 3 (heading family)
+// gap-closure regression suite. Before migrating to the preprocess context these
+// rules skipped only fenced code, so heading-, setext-, and emphasis-looking
+// lines inside indented code blocks, HTML blocks, and HTML comments were treated
+// as real content (false positives, and for heading-level state pollution). Each
+// case feeds such lines and asserts no violation is produced.
+func TestHeadingFamilySkipsBlockContexts(t *testing.T) {
+	// Each doc places heading/emphasis/setext-looking lines inside a block
+	// context. The only "real" heading (when one is needed to keep the rule's
+	// happy path valid) lives outside the block.
+	indentedCode := "\nReal intro\n\n    # Fake heading\n    ## Another fake\n\nmore text\n"
+	htmlBlock := "\n<div>\n# Not a heading\n## Also not\n</div>\n"
+	htmlComment := "\n<!--\n# commented heading\n## also commented\n-->\n"
+
+	t.Run("single-h1", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "\n# Real H1\n\n    # Fake H1\n",
+			"html block":   "\n# Real H1\n\n<div>\n# Fake H1\n</div>\n",
+			"html comment": "\n# Real H1\n\n<!--\n# Fake H1\n-->\n",
+		} {
+			if errs := CheckSingleH1("t.md", scanDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("heading-level", func(t *testing.T) {
+		// A level jump that lives inside a block must not be reported, and a
+		// fake heading must not pollute the running level (minLevel 1).
+		for name, doc := range map[string]string{
+			"indented":     "\n# Intro\n\n    #### Fake jump\n\ntext\n",
+			"html block":   "\n# Intro\n\n<div>\n#### Fake jump\n</div>\n",
+			"html comment": "\n# Intro\n\n<!--\n#### Fake jump\n-->\n",
+		} {
+			if errs := CheckHeadingLevels("t.md", scanDoc(doc), 0, 1); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("duplicate-heading", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "\n# Title\n\n    # Title\n",
+			"html block":   "\n# Title\n\n<div>\n# Title\n</div>\n",
+			"html comment": "\n# Title\n\n<!--\n# Title\n-->\n",
+		} {
+			if errs := CheckDuplicateHeadings("t.md", scanDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("no-setext-headings", func(t *testing.T) {
+		// An indented underline is already excluded by the setext regex (max 3
+		// leading spaces), so the meaningful gaps are HTML block and comment,
+		// where the underline sits at column 0.
+		for name, doc := range map[string]string{
+			"html block":   "\n<div>\nHeading\n===\n</div>\n",
+			"html comment": "\n<!--\nHeading\n===\n-->\n",
+		} {
+			if errs := CheckNoSetextHeadings("t.md", scanDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("blanks-around-headings", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     indentedCode,
+			"html block":   htmlBlock,
+			"html comment": htmlComment,
+		} {
+			if errs := CheckBlanksAroundHeadings("t.md", scanDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("no-emphasis-as-heading", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "\npara\n\n    *Emphasis*\n\ntext\n",
+			"html block":   "\n<div>\n*Emphasis*\n</div>\n",
+			"html comment": "\n<!--\n*Emphasis*\n-->\n",
+		} {
+			if errs := CheckNoEmphasisAsHeading("t.md", scanDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+}

--- a/internal/rule/heading_level.go
+++ b/internal/rule/heading_level.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // LintError represents a single lint violation detected in a Markdown file.
@@ -39,56 +41,33 @@ func atxHeadingLevel(line string) int {
 //
 // Parameters:
 //   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //   - minLevel: the expected minimum level for the first heading (e.g., 2 for ##)
 //
 // Returns:
 //   - A slice of LintError containing the line number and description of each detected issue.
-func CheckHeadingLevels(filename string, lines []string, offset int, minLevel int) []LintError {
+//
+// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
+// ignored, so they neither report nor pollute the heading-level state.
+func CheckHeadingLevels(filename string, ctx *preprocess.Context, offset int, minLevel int) []LintError {
 	var errs []LintError
 
 	prevLevel := 0
-	inCodeBlock := false
-	var fenceMarker string
 
-	for i, line := range lines {
-		if len(line) == 0 {
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		// First-byte prefilter: skip lines that cannot start a fence or heading
-		// before calling strings.TrimSpace.
-		first := firstNonSpaceByte(line)
-
-		// Inline code-block tracking — avoids the O(n×k) isInCodeBlock lookup.
-		if inCodeBlock {
-			if first != fenceMarker[0] {
-				continue
-			}
-			trimmed := strings.TrimSpace(line)
-			if IsClosingFence(trimmed, fenceMarker) {
-				inCodeBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-
-		if first != '#' && first != '`' && first != '~' {
+		line := ctx.Line(i)
+		// First-byte prefilter: skip lines that cannot start a heading before
+		// calling strings.TrimSpace.
+		if firstNonSpaceByte(line) != '#' {
 			continue
 		}
 
 		trimmed := strings.TrimSpace(line)
-
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inCodeBlock = true
-			fenceMarker = marker
-			continue
-		}
-
-		if first != '#' {
-			continue
-		}
 
 		// Pass trimmed so that CRLF '\r' and leading spaces are already removed.
 		currentLevel := atxHeadingLevel(trimmed)

--- a/internal/rule/heading_level_test.go
+++ b/internal/rule/heading_level_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestAtxHeadingLevel(t *testing.T) {
@@ -129,7 +131,7 @@ func TestCheckHeadingLevels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckHeadingLevels("test.md", lines, 0, tt.minLevel)
+			got := CheckHeadingLevels("test.md", preprocess.Scan(lines), 0, tt.minLevel)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // matchDoubleDelim returns the inner text if line is entirely wrapped in a
@@ -90,31 +92,18 @@ func endsWithPunctuation(s string) bool {
 //  1. The trimmed line consists entirely of a single bold/italic span.
 //  2. The inner text does not end with sentence-ending punctuation.
 //
-// Lines inside fenced code blocks and inline code spans are ignored.
-func CheckNoEmphasisAsHeading(filename string, lines []string, offset int) []LintError {
+// Lines inside fenced code, indented code, HTML blocks, and HTML comments are
+// ignored.
+func CheckNoEmphasisAsHeading(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
+			continue
+		}
+
+		line := ctx.Line(i)
 		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-			}
-			continue
-		}
-
 		if first != '*' && first != '_' {
 			continue
 		}

--- a/internal/rule/no_emphasis_as_heading_test.go
+++ b/internal/rule/no_emphasis_as_heading_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoEmphasisAsHeading(t *testing.T) {
@@ -255,7 +257,7 @@ func TestCheckNoEmphasisAsHeading(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoEmphasisAsHeading("test.md", lines, tt.offset)
+			got := CheckNoEmphasisAsHeading("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/setext_headings.go
+++ b/internal/rule/setext_headings.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"regexp"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 var (
@@ -20,39 +22,29 @@ var (
 //
 // Parameters:
 //   - filename: the name of the file being linted as a string
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //
 // Returns:
 //   - A slice of LintError containing the line number and description of each
 //     detected issue.
-func CheckNoSetextHeadings(filename string, lines []string, offset int) []LintError {
+//
+// A setext underline inside fenced code, indented code, an HTML block, or an HTML
+// comment is not a heading and is not reported.
+func CheckNoSetextHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inCodeBlock := false
-	var fenceMarker string
 	isPrevLineEmpty := true
 	isPrevLineOtherBlock := false
 	isInLazyBlockquote := false
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		line := ctx.Line(i)
 		trimmed := strings.TrimSpace(line)
-
-		// Maintain code-block state inline to avoid a separate O(n) pass and
-		// the O(k) isInCodeBlock lookup per line.
-		if inCodeBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inCodeBlock = false
-				fenceMarker = ""
-			}
-		} else if marker := openingFenceMarker(trimmed); marker != "" {
-			inCodeBlock = true
-			fenceMarker = marker
-		}
 
 		isCurrentLineEmpty := trimmed == ""
 		isCurrentLineOtherBlock := setextOtherBlockRegex.MatchString(line)
 
-		if !inCodeBlock && setextUnderlineRegex.MatchString(line) &&
+		if !inBlockContext(ctx, i) && setextUnderlineRegex.MatchString(line) &&
 			!isPrevLineEmpty && !isPrevLineOtherBlock && !isInLazyBlockquote {
 			errs = append(errs, LintError{
 				File:    filename,

--- a/internal/rule/setext_headings_test.go
+++ b/internal/rule/setext_headings_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoSetextHeadings(t *testing.T) {
@@ -113,7 +115,7 @@ func TestCheckNoSetextHeadings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoSetextHeadings("test.md", lines, 0)
+			got := CheckNoSetextHeadings("test.md", preprocess.Scan(lines), 0)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/single_h1.go
+++ b/internal/rule/single_h1.go
@@ -1,50 +1,37 @@
 package rule
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
 
 // CheckSingleH1 flags every ATX-style H1 heading (`# ...`) after the first one in the file.
-// H1 headings inside fenced code blocks are ignored.
-func CheckSingleH1(filename string, lines []string, offset int) []LintError {
+// H1 headings inside fenced code, indented code, HTML blocks, and HTML comments
+// are ignored.
+func CheckSingleH1(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	foundFirst := false
 
-	for i, line := range lines {
-		// Byte-level prefilter: skip lines whose first non-ASCII-space byte cannot
-		// start a fence opener or an H1 heading, avoiding strings.TrimSpace on the
-		// vast majority of lines (paragraphs, list items, blank lines, etc.).
-		first := firstNonSpaceByte(line)
-		if inBlock {
-			// Inside a fence block only a closing fence matters; the closing
-			// fence character must match the opening fence character.
-			if first != fenceMarker[0] {
-				continue
-			}
-			trimmed := strings.TrimSpace(line)
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		// Skip lines the scanner classified as code or HTML: an H1-looking line
+		// there is not a real heading.
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		// Outside a block, only '`', '~', and '#' are relevant.
-		if first != '`' && first != '~' && first != '#' {
+		// Byte-level prefilter: skip lines whose first non-ASCII-space byte
+		// cannot start an H1 heading, avoiding strings.TrimSpace on the vast
+		// majority of lines (paragraphs, list items, blank lines, etc.).
+		line := ctx.Line(i)
+		if firstNonSpaceByte(line) != '#' {
 			continue
 		}
 
+		// The prefilter guarantees the first non-space byte is '#', so the
+		// trimmed line begins with '#'.
 		trimmed := strings.TrimSpace(line)
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
-		}
-
-		if len(trimmed) == 0 || trimmed[0] != '#' {
-			continue
-		}
 		// Must be "# ..." (H1 with space) or bare "#" (also H1).
 		if len(trimmed) >= 2 && trimmed[1] != ' ' {
 			continue

--- a/internal/rule/single_h1_test.go
+++ b/internal/rule/single_h1_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckSingleH1(t *testing.T) {
@@ -116,7 +118,7 @@ func TestCheckSingleH1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckSingleH1("test.md", lines, tt.offset)
+			got := CheckSingleH1("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)


### PR DESCRIPTION
## Summary

Phase 3 of #337 (#339), **wave 1 of 4** (heading family). Migrates the six heading-family rules off their per-rule fenced-code state machines to the shared `*preprocess.Context`:

- `heading-level`
- `single-h1`
- `duplicate-heading`
- `no-setext-headings`
- `blanks-around-headings`
- `no-emphasis-as-heading`

Depends on Phase 2 (#346, merged).

## What changes

Each rule previously tracked **only fenced code** by hand. They now skip every block context the scanner already classified — **fenced code, indented code, HTML block, and HTML comment** — via a small shared `inBlockContext(ctx, i)` helper.

This **closes the audit gaps** (#337 matrix) these rules shared: heading-, setext-, and emphasis-looking lines inside **indented code blocks, HTML blocks, and HTML comments** are no longer reported, and `heading-level` no longer lets a fake heading inside those contexts pollute its running level state.

### `inBlockContext` helper

A small unexported helper in the `rule` package (not a method on `preprocess.Context`). The preprocess package deliberately exposes the four contexts individually because some rules skip only a subset (the Section-B divergences `max-line-length` / `no-hard-tabs` scan inside fenced code); the helper is just the common all-four set for rules that treat all code/HTML as non-content.

### Linter wiring

Migrated rules move from the `simpleRules` table to a new `contextRules` table (alongside `no-bare-urls`), iterated with the shared `*Context`. `heading-level` keeps its own option call, now passing `ctx`. `single-h1` lost a guard that became dead once the prefilter guarantees a leading `#`.

## Tests

- All existing heading-rule tests pass against the new signatures (wrapped through `preprocess.Scan`).
- New `TestHeadingFamilySkipsBlockContexts` regression suite asserts no violation for heading/setext/emphasis-looking lines inside indented code, HTML blocks, and HTML comments — one subtest per rule per applicable context.
- `make test-all` clean, `make static-lint` clean, 100% coverage.
- `make bench-compare`: **time −2.68%** (removing the per-rule fence passes), memory/allocs flat — first sign of the Phase 3 CPU clawback.

Refs #337. Part of #339.