### PR TITLE
feat(rule): migrate fence family to preprocess context (#337 Phase 3, wave 2)

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -363,13 +363,10 @@ var simpleRules = []struct {
 	fn   func(string, []string, int) []rule.LintError
 }{
 	{"final-blank-line", rule.CheckFinalBlankLine},
-	{"unclosed-code-block", rule.CheckUnclosedCodeBlocks},
 	{"empty-alt-text", rule.CheckEmptyAltText},
-	{"fenced-code-language", rule.CheckFencedCodeLanguage},
 	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
 	{"no-empty-links", rule.CheckNoEmptyLinks},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
-	{"blanks-around-fences", rule.CheckBlanksAroundFences},
 	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 
@@ -386,6 +383,9 @@ var contextRules = []struct {
 	{"no-setext-headings", rule.CheckNoSetextHeadings},
 	{"blanks-around-headings", rule.CheckBlanksAroundHeadings},
 	{"no-emphasis-as-heading", rule.CheckNoEmphasisAsHeading},
+	{"unclosed-code-block", rule.CheckUnclosedCodeBlocks},
+	{"fenced-code-language", rule.CheckFencedCodeLanguage},
+	{"blanks-around-fences", rule.CheckBlanksAroundFences},
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.
@@ -411,7 +411,7 @@ func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.
 		errs = append(errs, l.withSeverity(rule.CheckHeadingLevels(path, ctx, offset, l.headingMinLevel()), "heading-level")...)
 	}
 	if l.config.IsEnabled("consistent-code-fence") {
-		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, lines, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)
+		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, ctx, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)
 	}
 	if l.config.IsEnabled("consistent-emphasis-style") {
 		errs = append(errs, l.withSeverity(rule.CheckConsistentEmphasisStyle(path, lines, offset, l.consistentEmphasisStyle()), "consistent-emphasis-style")...)

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -54,6 +54,19 @@ type Context struct {
 	// absent from the map are their own sanitized form. nil until the first such
 	// line is seen.
 	sanitized map[int]string
+	// fences records one span per fenced code block, in document order. It is
+	// the structural view that InFencedCode (a per-line membership flag) cannot
+	// give: two back-to-back fences with no blank line between them are distinct
+	// spans here even though every line is InFencedCode.
+	fences []FenceSpan
+}
+
+// FenceSpan is the line range of one fenced code block. Start is the 0-based
+// opening-fence line; End is the 0-based closing-fence line, or -1 when the
+// fence is never closed (it then runs to end of file).
+type FenceSpan struct {
+	Start int
+	End   int
 }
 
 // Context flag bits, packed one set per line in Context.flags.
@@ -101,6 +114,12 @@ func (c *Context) InHTMLBlock(i int) bool { return c.flags[i]&flagHTMLBlock != 0
 // comment is blanked in Sanitized instead.
 func (c *Context) InHTMLComment(i int) bool { return c.flags[i]&flagHTMLComment != 0 }
 
+// FenceSpans returns the fenced code blocks in document order. Unlike the
+// InFencedCode flag, this distinguishes adjacent blocks and identifies each
+// block's opening and closing lines (End == -1 for an unclosed block). It is the
+// structural source of truth for fence rules.
+func (c *Context) FenceSpans() []FenceSpan { return c.fences }
+
 // Scan classifies every line of a Markdown file in a single pass and returns a
 // Context to query by line index. The input slice is borrowed, not copied, and
 // must not be mutated while the Context is in use. The input is expected to have
@@ -112,9 +131,22 @@ func Scan(lines []string) *Context {
 		flags: make([]uint8, len(lines)),
 	}
 	var s scanner
+	prevInFence := false
+	fenceStart := 0
 	for i, line := range lines {
 		lc := s.classify(line)
 		c.flags[i] = lc.flags
+		// Record fence spans from the scanner's open/close transitions. A line is
+		// at most one transition: a closing-fence line drops inFence on the same
+		// line that is still flagged fenced, and the next opener (even if
+		// adjacent) is a separate open transition, so adjacent blocks stay
+		// distinct.
+		if s.inFence && !prevInFence {
+			fenceStart = i
+		} else if !s.inFence && prevInFence {
+			c.fences = append(c.fences, FenceSpan{Start: fenceStart, End: i})
+		}
+		prevInFence = s.inFence
 		// Store the sanitized text only when it actually differs from the
 		// original. The fast path in sanitizeInline returns the original string
 		// unchanged for ordinary lines, so this comparison is a cheap identity
@@ -125,6 +157,10 @@ func Scan(lines []string) *Context {
 			}
 			c.sanitized[i] = lc.sanitized
 		}
+	}
+	// A fence still open at EOF is unclosed; record it with End == -1.
+	if s.inFence {
+		c.fences = append(c.fences, FenceSpan{Start: fenceStart, End: -1})
 	}
 	return c
 }

--- a/internal/preprocess/preprocess_test.go
+++ b/internal/preprocess/preprocess_test.go
@@ -298,3 +298,64 @@ func TestScanSanitizedIsSparse(t *testing.T) {
 		t.Errorf("sanitized map has %d entries, want 2 (only differing lines)", len(ctx.sanitized))
 	}
 }
+
+// TestFenceSpans verifies the structural fence view, which InFencedCode (a
+// per-line membership flag) cannot provide. The adjacency and closed-then-
+// unclosed cases are the ones a flag-run derivation would get wrong.
+func TestFenceSpans(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want []FenceSpan
+	}{
+		{
+			name: "single closed fence",
+			doc:  "```\ncode\n```",
+			want: []FenceSpan{{Start: 0, End: 2}},
+		},
+		{
+			// Two fences with NO blank line between them: the closing line of the
+			// first and the opening line of the second are both InFencedCode, so a
+			// flag-run would merge them. They must stay distinct spans.
+			name: "adjacent fences with no gap",
+			doc:  "```\na\n```\n~~~\nb\n~~~",
+			want: []FenceSpan{{Start: 0, End: 2}, {Start: 3, End: 5}},
+		},
+		{
+			name: "unclosed fence runs to EOF",
+			doc:  "```\ncode\nmore",
+			want: []FenceSpan{{Start: 0, End: -1}},
+		},
+		{
+			// A closed fence immediately followed by an unclosed one: the unclosed
+			// span's Start must be the second opener, not the first.
+			name: "closed fence then unclosed fence",
+			doc:  "```\na\n```\n```\nb",
+			want: []FenceSpan{{Start: 0, End: 2}, {Start: 3, End: -1}},
+		},
+		{
+			name: "no fences",
+			doc:  "just\nprose",
+			want: nil,
+		},
+		{
+			// A fence inside an HTML comment is not a fence at all.
+			name: "fence inside html comment is not a span",
+			doc:  "<!--\n```\ncode\n```\n-->",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Scan(strings.Split(tt.doc, "\n")).FenceSpans()
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d spans %+v, want %d %+v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("span %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -1,98 +1,62 @@
 package rule
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
 
 // CheckBlanksAroundFences flags fenced code blocks that are not preceded or
 // followed by a blank line. Fences at the start or end of the file are exempt
-// from the respective check. Fences inside HTML comment blocks are ignored.
-func CheckBlanksAroundFences(filename string, lines []string, offset int) []LintError {
+// from the respective check. Fences inside indented code, HTML blocks, and HTML
+// comments are not real fences and are ignored.
+//
+// A standalone single-line HTML comment (<!-- ... --> on its own line) is
+// transparent: it is invisible in rendered output, so it does not satisfy or
+// break the "preceded by a blank line" requirement. The preceding-blank check
+// therefore looks past such lines. Multi-line comment blocks and inline comments
+// (lines with visible text) are opaque.
+func CheckBlanksAroundFences(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
-	inHTMLComment := false
-	prevBlank := true
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-		isBlank := first == 0
-
-		// HTML comment tracking only applies outside fenced code blocks;
-		// `<!--`-like content inside a fenced block is just code and must not
-		// interfere with detecting the closing fence.
-		if !inBlock && (inHTMLComment || strings.IndexByte(line, '<') >= 0) {
-			skip, stillInComment, resetPrevBlank := stepHTMLComment(strings.TrimSpace(line), inHTMLComment)
-			if skip {
-				if resetPrevBlank {
-					prevBlank = false
-				}
-				inHTMLComment = stillInComment
-				continue
-			}
+	for _, span := range ctx.FenceSpans() {
+		// Preceded by a blank line? Skip past transparent standalone comment
+		// lines to find the nearest visible line.
+		j := span.Start - 1
+		for j >= 0 && isTransparentComment(ctx, j) {
+			j--
+		}
+		if j >= 0 && firstNonSpaceByte(ctx.Line(j)) != 0 {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + span.Start + 1,
+				Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
+			})
 		}
 
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-				errs = appendMissingTrailingBlank(errs, filename, lines, i, offset)
-			}
-			prevBlank = false
-			continue
+		// Followed by a blank line? Only closed fences have a line after them to
+		// check; an unclosed fence (End == -1) runs to EOF.
+		if span.End >= 0 && span.End+1 < ctx.Len() && firstNonSpaceByte(ctx.Line(span.End+1)) != 0 {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    offset + span.End + 1,
+				Message: "blanks-around-fences: fenced code block must be followed by a blank line",
+			})
 		}
-
-		if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			// opening fence: check the previous line
-			if i > 0 && !prevBlank {
-				errs = append(errs, LintError{
-					File:    filename,
-					Line:    offset + i + 1,
-					Message: "blanks-around-fences: fenced code block must be preceded by a blank line",
-				})
-			}
-			prevBlank = false
-			continue
-		}
-
-		prevBlank = isBlank
 	}
 
 	return errs
 }
 
-func appendMissingTrailingBlank(errs []LintError, filename string, lines []string, i, offset int) []LintError {
-	if i+1 < len(lines) && firstNonSpaceByte(lines[i+1]) != 0 {
-		return append(errs, LintError{
-			File:    filename,
-			Line:    offset + i + 1,
-			Message: "blanks-around-fences: fenced code block must be followed by a blank line",
-		})
+// isTransparentComment reports whether line i is a standalone single-line HTML
+// comment (the whole line is a comment, and it both opens and closes on that
+// line). Such lines render to nothing, so blanks-around-fences looks through them
+// when checking for a preceding blank line. Multi-line comment lines carry only
+// one of the markers and are therefore opaque.
+func isTransparentComment(ctx *preprocess.Context, i int) bool {
+	if !ctx.InHTMLComment(i) {
+		return false
 	}
-	return errs
-}
-
-// stepHTMLComment advances the HTML-comment state machine for one line.
-// It returns (skip, newInComment, resetPrevBlank).
-// skip: caller should continue past this line.
-// newInComment: updated multi-line comment state.
-// resetPrevBlank: true when the line contains visible content and prevBlank
-// must be cleared; false for standalone single-line comments (<!-- ... -->)
-// that are invisible in rendered output and should not break a blank-line chain.
-func stepHTMLComment(trimmed string, inComment bool) (skip, newInComment, resetPrevBlank bool) {
-	if inComment {
-		if strings.Contains(trimmed, "-->") {
-			return true, false, true
-		}
-		return true, true, true
-	}
-	if strings.Contains(trimmed, "<!--") {
-		if strings.Contains(trimmed, "-->") {
-			// Standalone single-line comment is transparent; mixed lines like
-			// "text <!-- note -->" are not (HasPrefix distinguishes them).
-			return true, false, !strings.HasPrefix(trimmed, "<!--")
-		}
-		return true, true, true
-	}
-	return false, false, false
+	line := ctx.Line(i)
+	return strings.Contains(line, "<!--") && strings.Contains(line, "-->")
 }

--- a/internal/rule/blanks_around_fences_test.go
+++ b/internal/rule/blanks_around_fences_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckBlanksAroundFences(t *testing.T) {
@@ -155,7 +157,7 @@ func TestCheckBlanksAroundFences(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckBlanksAroundFences("test.md", lines, tt.offset)
+			got := CheckBlanksAroundFences("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckUnclosedCodeBlocks detects any unclosed fenced code blocks (e.g., ```)
@@ -9,39 +11,45 @@ import (
 //
 // Parameters:
 //   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //
 // Returns:
 //   - A slice of LintError indicating the location of any unclosed code block.
-func CheckUnclosedCodeBlocks(filename string, lines []string, offset int) []LintError {
+//
+// Because fence detection comes from the shared scanner, fence markers inside
+// indented code or HTML blocks can no longer be mispaired into phantom unclosed
+// blocks (audit #337 cascade).
+func CheckUnclosedCodeBlocks(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	_, unclosed := GetCodeBlockLineRanges(lines)
 
-	for _, start := range unclosed {
-		errs = append(errs, LintError{
-			File:    filename,
-			Line:    start + offset + 1,
-			Message: "Unclosed code block",
-		})
+	for _, span := range ctx.FenceSpans() {
+		if span.End == -1 {
+			errs = append(errs, LintError{
+				File:    filename,
+				Line:    span.Start + offset + 1,
+				Message: "Unclosed code block",
+			})
+		}
 	}
 
 	return errs
 }
 
 // GetCodeBlockLineRanges scans lines and returns the 1-based line ranges of all
-// closed fenced code blocks and the 0-based start lines of any unclosed ones.
+// closed fenced code blocks. It is retained for external-link, the last rule not
+// yet migrated to the preprocess context (#337 Phase 3); unclosed-code-block now
+// derives unclosed blocks from preprocess.Context.FenceSpans instead.
 //
 // Optimization: a byte-level prefilter (firstNonSpaceByte) avoids calling
 // strings.TrimSpace on the ~95% of lines that cannot be fence openers or
 // closers. Inside a block, only a line whose first non-space byte matches the
 // opening fence character can close the block.
-func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
+func GetCodeBlockLineRanges(lines []string) [][2]int {
 	inBlock := false
 	var start int
 	var fenceMarker string
 	var closedRanges [][2]int
-	var unclosedStarts []int
 
 	for i, line := range lines {
 		first := firstNonSpaceByte(line)
@@ -72,9 +80,5 @@ func GetCodeBlockLineRanges(lines []string) (closed [][2]int, unclosed []int) {
 		}
 	}
 
-	if inBlock {
-		unclosedStarts = append(unclosedStarts, start)
-	}
-
-	return closedRanges, unclosedStarts
+	return closedRanges
 }

--- a/internal/rule/code_block_test.go
+++ b/internal/rule/code_block_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckUnclosedCodeBlocks(t *testing.T) {
@@ -74,7 +76,7 @@ func TestCheckUnclosedCodeBlocks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckUnclosedCodeBlocks("test.md", lines, 0)
+			got := CheckUnclosedCodeBlocks("test.md", preprocess.Scan(lines), 0)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -1,7 +1,7 @@
 package rule
 
 import (
-	"strings"
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckConsistentCodeFence flags fenced code blocks that use a different fence
@@ -10,58 +10,17 @@ import (
 // In "consistent" mode the first fence character found in the document sets the
 // expected style; every subsequent opener that differs is flagged.
 // In "backtick"/"tilde" mode every opener using the wrong character is flagged.
-func CheckConsistentCodeFence(filename string, lines []string, offset int, style string) []LintError {
+//
+// Fence openers inside indented code, HTML blocks, and HTML comments are not
+// real fences and are excluded by the scanner, so they are never examined.
+func CheckConsistentCodeFence(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
-	inHTMLComment := false
 	var expectedCh byte // 0 until first fence seen (consistent mode)
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		// Inside a code block: only look for the closing fence.
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-
-		// Inside an HTML comment block: skip until "-->" is found.
-		if inHTMLComment {
-			if strings.Contains(line, "-->") {
-				inHTMLComment = false
-			}
-			continue
-		}
-
-		// Lines that cannot open a fence are checked only for "<!--".
-		if first != '`' && first != '~' {
-			if strings.IndexByte(line, '<') >= 0 {
-				inHTMLComment = isHTMLCommentStart(line)
-			}
-			continue
-		}
-
-		// Check for an opening fence before inspecting the line for "<!--" so
-		// that fence openers whose info string contains "<!--" (e.g.
-		// "```go <!-- note -->") are treated as fences, not comment starts.
-		trimmed := strings.TrimSpace(line)
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			ch := marker[0]
-			inBlock = true
-			fenceMarker = marker
-			if err := checkFenceStyle(filename, offset+i+1, ch, style, &expectedCh); err != nil {
-				errs = append(errs, *err)
-			}
-			continue
-		}
-
-		// `` ` ``/`~` line that is not a fence opener: still check for "<!--".
-		if strings.IndexByte(line, '<') >= 0 {
-			inHTMLComment = isHTMLCommentStart(trimmed)
+	for _, span := range ctx.FenceSpans() {
+		ch := firstNonSpaceByte(ctx.Line(span.Start))
+		if err := checkFenceStyle(filename, offset+span.Start+1, ch, style, &expectedCh); err != nil {
+			errs = append(errs, *err)
 		}
 	}
 
@@ -103,12 +62,6 @@ func checkFenceStyle(filename string, line int, ch byte, style string, expectedC
 		}
 	}
 	return nil
-}
-
-// isHTMLCommentStart reports whether line opens an HTML comment that does not
-// close on the same line (contains "<!--" but not "-->").
-func isHTMLCommentStart(line string) bool {
-	return strings.Contains(line, "<!--") && !strings.Contains(line, "-->")
 }
 
 func fenceCharName(ch byte) string {

--- a/internal/rule/consistent_code_fence_test.go
+++ b/internal/rule/consistent_code_fence_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckConsistentCodeFence(t *testing.T) {
@@ -188,7 +190,7 @@ func TestCheckConsistentCodeFence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckConsistentCodeFence("test.md", lines, tt.offset, tt.style)
+			got := CheckConsistentCodeFence("test.md", preprocess.Scan(lines), tt.offset, tt.style)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -188,7 +188,7 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 // The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
 // Returns lint errors and the count of unique URLs checked.
 func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map, perHostConcurrency int, perHostIntervalMs int) ([]LintError, int) {
-	codeBlockRanges, _ := GetCodeBlockLineRanges(lines)
+	codeBlockRanges := GetCodeBlockLineRanges(lines)
 	links := ExtractExternalLinksWithLineNumbers(lines, offset)
 
 	urlToLines := make(map[string][]int)

--- a/internal/rule/fence_context_regression_test.go
+++ b/internal/rule/fence_context_regression_test.go
@@ -1,0 +1,87 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
+
+func scanFenceDoc(doc string) *preprocess.Context {
+	doc = strings.TrimPrefix(doc, "\n")
+	return preprocess.Scan(strings.Split(doc, "\n"))
+}
+
+// TestFenceFamilySkipsBlockContexts is the #337 Phase 3 (fence family)
+// gap-closure regression suite. A fence marker inside an indented code block or
+// an HTML block is not a real fence, so none of the fence rules should treat it
+// as one. Previously each rule did its own fence detection and mispaired these
+// markers (audit #337, including the unclosed-code-block cascade).
+func TestFenceFamilySkipsBlockContexts(t *testing.T) {
+	// A lone ``` inside indented code (would previously open a phantom fence).
+	indentedLoneFence := "\ntext\n\n    ```\n    code\n"
+	// A no-language fence wholly inside an HTML block.
+	htmlBlockFence := "\n<div>\n```\nno lang\n```\n</div>\n"
+	// A tilde fence inside indented code (wrong marker, but not a real fence).
+	indentedTildeFence := "\ntext\n\n    ~~~\n    code\n    ~~~\n"
+
+	t.Run("unclosed-code-block ignores indented fence marker", func(t *testing.T) {
+		if errs := CheckUnclosedCodeBlocks("t.md", scanFenceDoc(indentedLoneFence), 0); len(errs) != 0 {
+			t.Errorf("got %d errors, want 0 (no phantom unclosed block): %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("fenced-code-language ignores fence in html block", func(t *testing.T) {
+		if errs := CheckFencedCodeLanguage("t.md", scanFenceDoc(htmlBlockFence), 0); len(errs) != 0 {
+			t.Errorf("got %d errors, want 0: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("consistent-code-fence ignores fence in indented code", func(t *testing.T) {
+		if errs := CheckConsistentCodeFence("t.md", scanFenceDoc(indentedTildeFence), 0, "backtick"); len(errs) != 0 {
+			t.Errorf("got %d errors, want 0: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("blanks-around-fences ignores fence in html block", func(t *testing.T) {
+		if errs := CheckBlanksAroundFences("t.md", scanFenceDoc(htmlBlockFence), 0); len(errs) != 0 {
+			t.Errorf("got %d errors, want 0: %+v", len(errs), errs)
+		}
+	})
+}
+
+// TestFenceFamilyAdjacentBlocks guards the adjacency case that a per-line
+// InFencedCode flag cannot represent: two fenced blocks with no blank line
+// between them. The closing line of the first and the opening line of the second
+// are both inside fenced code, so a flag-run derivation would merge them into one
+// block and miss the second opener / the missing blank between them.
+func TestFenceFamilyAdjacentBlocks(t *testing.T) {
+	t.Run("consistent-code-fence flags the second adjacent opener", func(t *testing.T) {
+		// ``` block immediately followed by a ~~~ block: in "consistent" mode the
+		// second opener's marker must be flagged.
+		doc := "```\na\n```\n~~~\nb\n~~~"
+		errs := CheckConsistentCodeFence("t.md", preprocess.Scan(strings.Split(doc, "\n")), 0, "consistent")
+		if len(errs) != 1 || errs[0].Line != 4 {
+			t.Fatalf("got %+v, want exactly 1 error on line 4 (the ~~~ opener)", errs)
+		}
+	})
+
+	t.Run("blanks-around-fences flags the missing blank between adjacent fences", func(t *testing.T) {
+		// Two backtick fences with nothing between them: the first needs a
+		// trailing blank (line 3) and the second a leading blank (line 4).
+		doc := "```\na\n```\n```\nb\n```"
+		errs := CheckBlanksAroundFences("t.md", preprocess.Scan(strings.Split(doc, "\n")), 0)
+		if len(errs) != 2 {
+			t.Fatalf("got %d errors, want 2 (trailing for block 1, leading for block 2): %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("fenced-code-language checks both adjacent openers", func(t *testing.T) {
+		// First fence has a language, second does not: only the second is flagged.
+		doc := "```go\na\n```\n```\nb\n```"
+		errs := CheckFencedCodeLanguage("t.md", preprocess.Scan(strings.Split(doc, "\n")), 0)
+		if len(errs) != 1 || errs[0].Line != 4 {
+			t.Fatalf("got %+v, want exactly 1 error on line 4 (second opener, no language)", errs)
+		}
+	})
+}

--- a/internal/rule/fenced_code_language.go
+++ b/internal/rule/fenced_code_language.go
@@ -1,76 +1,34 @@
 package rule
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
 
 // CheckFencedCodeLanguage checks that all fenced code blocks specify a language identifier.
 // Fenced code blocks opened with ``` or ~~~ without a language tag are flagged (MD040).
 //
 // Parameters:
 //   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //
 // Returns:
 //   - A slice of LintError, one per opening fence that is missing a language identifier.
-func CheckFencedCodeLanguage(filename string, lines []string, offset int) []LintError {
+//
+// Fence openers inside indented code, HTML blocks, and HTML comments are not real
+// fences and are excluded by the scanner, so they are never examined.
+func CheckFencedCodeLanguage(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
-	inComment := false
 
-	for i, line := range lines {
-		// HTML comments take priority: fences inside comments are ignored.
-		if inComment {
-			if idx := strings.Index(line, "-->"); idx != -1 {
-				inComment = false
-				line = strings.Repeat(" ", idx+3) + line[idx+3:]
-			} else {
-				continue
-			}
-		}
-
-		if inBlock {
-			// Only lines starting with the same fence character as the opener can close a fence.
-			first := firstNonSpaceByte(line)
-			if first != fenceMarker[0] {
-				continue
-			}
-			trimmed := strings.TrimSpace(line)
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-
-		// Cheap guard: '<' must be present before invoking stripHTMLComments.
-		if strings.IndexByte(line, '<') >= 0 && strings.Contains(line, "<!--") {
-			_, endedInComment := stripHTMLComments(line)
-			if endedInComment {
-				inComment = true
-				continue
-			}
-		}
-
-		// Only backtick or tilde lines can open a fence; skip TrimSpace for all others.
-		first := firstNonSpaceByte(line)
-		if first != '`' && first != '~' {
-			continue
-		}
-
-		trimmed := strings.TrimSpace(line)
+	for _, span := range ctx.FenceSpans() {
+		trimmed := strings.TrimSpace(ctx.Line(span.Start))
 		marker := openingFenceMarker(trimmed)
-		if marker == "" {
-			continue
-		}
-
-		inBlock = true
-		fenceMarker = marker
-
 		if strings.TrimSpace(trimmed[len(marker):]) == "" {
 			errs = append(errs, LintError{
 				File:    filename,
-				Line:    offset + i + 1,
+				Line:    offset + span.Start + 1,
 				Message: "Fenced code block must have a language identifier",
 			})
 		}

--- a/internal/rule/fenced_code_language_test.go
+++ b/internal/rule/fenced_code_language_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckFencedCodeLanguage(t *testing.T) {
@@ -162,7 +164,7 @@ func TestCheckFencedCodeLanguage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckFencedCodeLanguage("test.md", lines, tt.offset)
+			got := CheckFencedCodeLanguage("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/inline_strip.go
+++ b/internal/rule/inline_strip.go
@@ -2,13 +2,11 @@ package rule
 
 import "strings"
 
-// This file holds inline-sanitization helpers shared by several rules that have
-// not yet been migrated to the preprocess context (#337 Phase 3): no-empty-links,
-// link-fragments, consistent-emphasis-style, no-hard-tabs, and
-// fenced-code-language. They duplicate logic now centralized in
-// internal/preprocess (see Context.Sanitized) and are removed once their last
-// consumer migrates. no-bare-urls, the Phase 2 reference adoption, no longer
-// uses them.
+// This file holds inline-code-stripping helpers shared by several rules that
+// have not yet been migrated to the preprocess context (#337 Phase 3):
+// no-empty-links, link-fragments, consistent-emphasis-style, and no-hard-tabs.
+// They duplicate logic now centralized in internal/preprocess (see
+// Context.Sanitized) and are removed once their last consumer migrates.
 
 // countBacktickRun returns the number of consecutive backticks starting at
 // position start in s.
@@ -70,34 +68,4 @@ func stripInlineCode(s string) string {
 	}
 
 	return b.String()
-}
-
-// stripHTMLComments replaces content inside <!-- ... --> spans (including the
-// delimiters) with spaces so that URLs within HTML comments are not scanned.
-// It handles multiple comment spans on a single line. The second return value
-// reports whether the line ended inside an unclosed comment.
-func stripHTMLComments(s string) (string, bool) {
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); {
-		if i+4 <= len(s) && s[i:i+4] == "<!--" {
-			end := strings.Index(s[i+4:], "-->")
-			if end == -1 {
-				// Unclosed comment — blank the rest of the line.
-				for k := i; k < len(s); k++ {
-					b.WriteByte(' ')
-				}
-				return b.String(), true
-			}
-			spanLen := 4 + end + 3
-			for k := 0; k < spanLen; k++ {
-				b.WriteByte(' ')
-			}
-			i += spanLen
-		} else {
-			b.WriteByte(s[i])
-			i++
-		}
-	}
-	return b.String(), false
 }


### PR DESCRIPTION
## Summary

Phase 3 of #337 (#339), **wave 2 of 4** (fence family). Migrates the four fence-family rules off their per-rule fence + HTML-comment state machines to the shared scanner:

- `unclosed-code-block`
- `fenced-code-language`
- `consistent-code-fence`
- `blanks-around-fences`

Depends on wave 1 (#347, merged).

## New API: `Context.FenceSpans()`

Fence rules need fence **structure** (where each block opens and closes), which the per-line `InFencedCode` flag cannot give: two back-to-back fences with no blank line between them have the closer of the first and the opener of the second both flagged `InFencedCode`, with no gap — a flag-run derivation would silently **merge them into one block**.

So this adds `Context.FenceSpans() []FenceSpan{Start, End}` (one span per block, `End == -1` for unclosed), recorded from the scanner's open/close transitions in the single pass. It's the structural source of truth the fence rules consume.

## Gap closures (#337 audit)

Because fence detection now comes from the shared scanner, fence markers inside **indented code blocks** and **HTML blocks** are no longer mispaired into phantom fences:

- `unclosed-code-block`: the cascade is gone — a stray ```` ``` ```` inside indented code no longer produces a phantom "Unclosed code block".
- `fenced-code-language` / `consistent-code-fence` / `blanks-around-fences`: markers inside indented/HTML contexts are ignored.

`blanks-around-fences` keeps its single-line-HTML-comment **transparency** (a standalone `<!-- ... -->` doesn't break the preceding-blank requirement) via an `InHTMLComment`-aware skip-back — replacing the bespoke `stepHTMLComment` machine.

## Cleanups

- `GetCodeBlockLineRanges` loses its now-unused `unclosed` return — `external-link` (its last caller, migrating in wave 3) ignored it, and `unclosed-code-block` now uses `FenceSpans`.
- The `stripHTMLComments` helper is removed (last consumer migrated).
- Linter: the four rules move to `contextRules` / pass `ctx`.

## Tests

- All existing fence-rule tests pass against the new signatures.
- `TestFenceSpans` (preprocess) covers the discriminating cases: adjacent fences, closed-then-unclosed, fence-inside-comment.
- `TestFenceFamilySkipsBlockContexts` + `TestFenceFamilyAdjacentBlocks` (rule) cover gap closures and the adjacency case a flag run would merge.
- `make test-all` clean, `make static-lint` clean, 100% coverage.
- `make bench-compare`: **time −9.74%** (four more per-rule fence passes removed), memory/allocs flat.

Refs #337. Part of #339.