### PR TITLE
feat(rule): migrate link/image family to preprocess context (#337 Phase 3, wave 3)

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -363,9 +363,7 @@ var simpleRules = []struct {
 	fn   func(string, []string, int) []rule.LintError
 }{
 	{"final-blank-line", rule.CheckFinalBlankLine},
-	{"empty-alt-text", rule.CheckEmptyAltText},
 	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
-	{"no-empty-links", rule.CheckNoEmptyLinks},
 	{"blanks-around-lists", rule.CheckBlanksAroundLists},
 	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
@@ -386,6 +384,8 @@ var contextRules = []struct {
 	{"unclosed-code-block", rule.CheckUnclosedCodeBlocks},
 	{"fenced-code-language", rule.CheckFencedCodeLanguage},
 	{"blanks-around-fences", rule.CheckBlanksAroundFences},
+	{"empty-alt-text", rule.CheckEmptyAltText},
+	{"no-empty-links", rule.CheckNoEmptyLinks},
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.
@@ -426,7 +426,7 @@ func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.
 		errs = append(errs, l.withSeverity(rule.CheckNoTrailingPunctuation(path, lines, offset, l.noTrailingPunctuation()), "no-trailing-punctuation")...)
 	}
 	if l.config.IsEnabled("link-fragments") {
-		errs = append(errs, l.withSeverity(rule.CheckLinkFragments(path, lines, offset, l.config.RuleOptions("link-fragments")), "link-fragments")...)
+		errs = append(errs, l.withSeverity(rule.CheckLinkFragments(path, ctx, offset, l.config.RuleOptions("link-fragments")), "link-fragments")...)
 	}
 	return errs
 }
@@ -447,7 +447,7 @@ func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, i
 
 	linksChecked := 0
 	if l.config.IsEnabled("external-link") {
-		errors, count := rule.CheckExternalLinks(path, lines, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkMaxConcurrency(), l.externalLinkMaxRetries(), l.externalLinkAllowedStatuses(), l.urlCache, l.externalLinkPerHostConcurrency(), l.externalLinkPerHostIntervalMs())
+		errors, count := rule.CheckExternalLinks(path, ctx, offset, l.compiledPatterns, l.externalLinkTimeout(), rule.DefaultRetryDelayMs, l.externalLinkMaxConcurrency(), l.externalLinkMaxRetries(), l.externalLinkAllowedStatuses(), l.urlCache, l.externalLinkPerHostConcurrency(), l.externalLinkPerHostIntervalMs())
 		allErrors = append(allErrors, l.withSeverity(errors, "external-link")...)
 		linksChecked = count
 	}

--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -1,8 +1,6 @@
 package rule
 
 import (
-	"strings"
-
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
@@ -34,51 +32,4 @@ func CheckUnclosedCodeBlocks(filename string, ctx *preprocess.Context, offset in
 	}
 
 	return errs
-}
-
-// GetCodeBlockLineRanges scans lines and returns the 1-based line ranges of all
-// closed fenced code blocks. It is retained for external-link, the last rule not
-// yet migrated to the preprocess context (#337 Phase 3); unclosed-code-block now
-// derives unclosed blocks from preprocess.Context.FenceSpans instead.
-//
-// Optimization: a byte-level prefilter (firstNonSpaceByte) avoids calling
-// strings.TrimSpace on the ~95% of lines that cannot be fence openers or
-// closers. Inside a block, only a line whose first non-space byte matches the
-// opening fence character can close the block.
-func GetCodeBlockLineRanges(lines []string) [][2]int {
-	inBlock := false
-	var start int
-	var fenceMarker string
-	var closedRanges [][2]int
-
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-		if inBlock {
-			// Only a line whose first non-space byte matches the opener's fence
-			// character can close the block; all others are content.
-			if first != fenceMarker[0] {
-				continue
-			}
-			trimmed := strings.TrimSpace(line)
-			if IsClosingFence(trimmed, fenceMarker) {
-				closedRanges = append(closedRanges, [2]int{start + 1, i + 1})
-				inBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-		// Outside a block, only backtick or tilde lines can open a fence.
-		if first != '`' && first != '~' {
-			continue
-		}
-		trimmed := strings.TrimSpace(line)
-		marker := openingFenceMarker(trimmed)
-		if marker != "" {
-			start = i
-			fenceMarker = marker
-			inBlock = true
-		}
-	}
-
-	return closedRanges
 }

--- a/internal/rule/empty_alt_text.go
+++ b/internal/rule/empty_alt_text.go
@@ -3,15 +3,27 @@ package rule
 import (
 	"regexp"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 var emptyAltTextRe = regexp.MustCompile(`!\[\s*\]\([^)]+\)`)
 
 // CheckEmptyAltText reports lint errors for images with empty alt text.
-func CheckEmptyAltText(filename string, lines []string, offset int) []LintError {
+//
+// Images inside fenced code, indented code, HTML blocks, and HTML comments are
+// skipped, and the inline-sanitized text is scanned so an ![](url) inside an
+// inline code span or inline comment is ignored too. Before migrating to the
+// preprocess context this rule did no context filtering at all (audit #337 worst
+// offender), firing even inside fenced and inline code.
+func CheckEmptyAltText(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
+			continue
+		}
+		line := ctx.Sanitized(i)
 		if !strings.Contains(line, "![") {
 			continue
 		}

--- a/internal/rule/empty_alt_text_test.go
+++ b/internal/rule/empty_alt_text_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckEmptyAltText(t *testing.T) {
@@ -56,7 +58,7 @@ func TestCheckEmptyAltText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckEmptyAltText("test.md", lines, 0)
+			got := CheckEmptyAltText("test.md", preprocess.Scan(lines), 0)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 var (
@@ -153,7 +155,7 @@ func extractHost(rawURL string) string {
 
 // ExtractExternalLinksWithLineNumbers extracts external links from the given lines.
 // The offset parameter is added to line numbers to account for stripped frontmatter.
-func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []ExtractedLink {
+func ExtractExternalLinksWithLineNumbers(ctx *preprocess.Context, offset int) []ExtractedLink {
 	patterns := []*regexp.Regexp{
 		inlineLinkPattern,
 		imageLinkPattern,
@@ -162,7 +164,14 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 
 	var results []ExtractedLink
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		// Skip code/HTML block contexts entirely, and scan the inline-sanitized
+		// text so URLs inside inline code spans and inline comments are not
+		// extracted (and therefore not fetched).
+		if inBlockContext(ctx, i) {
+			continue
+		}
+		line := ctx.Sanitized(i)
 		seenInLine := make(map[string]bool) // Track URLs found in this line
 		for _, re := range patterns {
 			matches := re.FindAllStringSubmatch(line, -1)
@@ -187,15 +196,15 @@ func ExtractExternalLinksWithLineNumbers(lines []string, offset int) []Extracted
 // CheckExternalLinks checks external links in the given lines.
 // The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
 // Returns lint errors and the count of unique URLs checked.
-func CheckExternalLinks(path string, lines []string, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map, perHostConcurrency int, perHostIntervalMs int) ([]LintError, int) {
-	codeBlockRanges := GetCodeBlockLineRanges(lines)
-	links := ExtractExternalLinksWithLineNumbers(lines, offset)
+func CheckExternalLinks(path string, ctx *preprocess.Context, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map, perHostConcurrency int, perHostIntervalMs int) ([]LintError, int) {
+	// Code/HTML context filtering is handled inside the extractor via the shared
+	// scanner, so links inside fenced/indented code, HTML blocks, HTML comments,
+	// inline code spans, and inline comments are never produced here.
+	links := ExtractExternalLinksWithLineNumbers(ctx, offset)
 
 	urlToLines := make(map[string][]int)
 	for _, link := range links {
-		// Adjust line number for code block check (relative to lines array)
-		relativeLineNum := link.Line - offset
-		if isInCodeBlock(relativeLineNum, codeBlockRanges) || shouldSkipLink(link.URL, skipPatterns) {
+		if shouldSkipLink(link.URL, skipPatterns) {
 			continue
 		}
 		urlToLines[link.URL] = append(urlToLines[link.URL], link.Line)
@@ -336,15 +345,6 @@ func formatLinkError(url string) string {
 func shouldSkipLink(url string, skipPatterns []*regexp.Regexp) bool {
 	for _, re := range skipPatterns {
 		if re.MatchString(url) {
-			return true
-		}
-	}
-	return false
-}
-
-func isInCodeBlock(line int, ranges [][2]int) bool {
-	for _, r := range ranges {
-		if line >= r[0] && line <= r[1] {
 			return true
 		}
 	}

--- a/internal/rule/external_link_test.go
+++ b/internal/rule/external_link_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
@@ -43,7 +44,7 @@ func TestCheckExternalLinks_BasicSuccessFailure(t *testing.T) {
 
 	file := "mock.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(file, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks(file, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error, got %d", len(results))
@@ -71,7 +72,7 @@ func TestCheckExternalLinks_SkipPattern(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only non-localhost link should be checked), got %d", len(results))
@@ -90,7 +91,7 @@ func TestCheckExternalLinks_IgnoreCodeBlocks(t *testing.T) {
 	skip := []*regexp.Regexp{}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (code block link should be ignored), got %d", len(results))
 	}
@@ -120,7 +121,7 @@ Line 8 [link8](%s/fail8)
 
 	skip := []*regexp.Regexp{}
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, skip, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 5 {
 		t.Fatalf("expected 5 errors, got %d", len(results))
@@ -152,9 +153,9 @@ func TestCheckExternalLinks_Deduplication(t *testing.T) {
 	lines, offset := toLines(markdown)
 
 	// First call - should trigger HTTP request
-	_, _ = rule.CheckExternalLinks("file1.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
+	_, _ = rule.CheckExternalLinks("file1.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 	// Second call - should use cache
-	_, _ = rule.CheckExternalLinks("file2.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
+	_, _ = rule.CheckExternalLinks("file2.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if requestCount != 1 {
 		t.Errorf("expected only 1 HTTP request due to caching, but got %d", requestCount)
@@ -168,7 +169,7 @@ func TestCheckExternalLinks_MultipleOccurrences(t *testing.T) {
 	markdown := fmt.Sprintf("[fail](%s/fail)\n[fail again](%s/fail)", ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	// Should report errors for each occurrence
 	if len(results) != 2 {
@@ -196,7 +197,7 @@ func TestCheckExternalLinks_AllLinksSucceed(t *testing.T) {
 [link3](%s/ok)`, ts.URL, ts.URL, ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors for all successful links, got %d", len(results))
@@ -218,7 +219,7 @@ func TestCheckExternalLinks_HTTPStatusBoundary(t *testing.T) {
 	fileName := "boundary.md"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only 400), got %d", len(results))
@@ -251,7 +252,7 @@ func TestCheckExternalLinks_MultipleSkipPatterns(t *testing.T) {
 	}
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, skip, 2, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error (only httpstat.us), got %d", len(results))
@@ -276,7 +277,7 @@ func TestCheckExternalLinks_NetworkError(t *testing.T) {
 	unreachableURL := "http://invalid.test.localhost.invalid:9999/path"
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 error for network failure, got %d", len(results))
@@ -310,7 +311,7 @@ func TestCheckExternalLinks_DifferentHTTPStatusCodes(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)\n[server-error](%s/500)\n[unavailable](%s/503)", statusTs.URL, statusTs.URL, statusTs.URL)
 	fileName := "test.md"
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 errors, got %d", len(results))
@@ -355,7 +356,7 @@ func TestCheckExternalLinks_RetrySuccess(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("retry.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors due to successful retry, but got %d", len(results))
@@ -377,7 +378,7 @@ func TestCheckExternalLinks_NoRetryFor404(t *testing.T) {
 	markdown := fmt.Sprintf("[not-found](%s/404)", ts.URL)
 
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("404.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	_, _ = rule.CheckExternalLinks("404.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	// For 404, there should be no retry; it should give up after a single request
 	if requestCount != 1 {
@@ -398,7 +399,7 @@ func TestCheckExternalLinks_ConcurrencyLimit(t *testing.T) {
 	markdown := strings.Join(links, "\n")
 
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("heavy.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 5, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 errors, got %d", len(results))
@@ -413,14 +414,14 @@ func TestCheckExternalLinks_CacheErrorState(t *testing.T) {
 
 	// First call - should trigger network error
 	lines, offset := toLines(markdown)
-	results1, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
+	results1, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if len(results1) != 1 {
 		t.Fatalf("first call: expected 1 error for network failure, got %d", len(results1))
 	}
 
 	// Second call with same cache - should use cached error and report the same error
-	results2, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
+	results2, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 1, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	if len(results2) != 1 {
 		t.Fatalf("second call: expected 1 error from cache, got %d", len(results2))
@@ -447,7 +448,7 @@ func TestCheckExternalLinks_CacheInvalidType(t *testing.T) {
 
 	// Call CheckExternalLinks - should detect invalid cache type and re-check
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks(fileName, lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
+	results, _ := rule.CheckExternalLinks(fileName, preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, urlCache, 0, 0)
 
 	// Should still get error because URL returns 404
 	if len(results) != 1 {
@@ -652,7 +653,7 @@ See (https://example.com/page) for details.
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.input, "\n")
 			offset := 0
-			got := rule.ExtractExternalLinksWithLineNumbers(lines, offset)
+			got := rule.ExtractExternalLinksWithLineNumbers(preprocess.Scan(lines), offset)
 
 			// Sort to ensure order-independent comparison
 			// Sort by URL first, then by Line to ensure stable ordering
@@ -696,7 +697,7 @@ func TestCheckExternalLinks_GETFallback(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, count := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 10, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback should succeed), got: %v", results)
@@ -718,7 +719,7 @@ func TestCheckExternalLinks_GETFallback_On405(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, count := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 405 should succeed), got: %v", results)
@@ -740,7 +741,7 @@ func TestCheckExternalLinks_GETFallback_On403(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, count := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, count := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no errors (GET fallback on 403 should succeed), got: %v", results)
@@ -763,7 +764,7 @@ func TestCheckExternalLinks_NoGETFallback_On404(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)\n", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("mock.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("mock.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -783,7 +784,7 @@ func TestCheckExternalLinks_429NotFlagged(t *testing.T) {
 
 	markdown := fmt.Sprintf("[rate-limited](%s/429)", ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("test.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if len(results) != 0 {
 		t.Errorf("expected no violations for 429 (rate limiting), got %d: %v", len(results), results)
@@ -804,7 +805,7 @@ func TestCheckExternalLinks_AllowedStatuses(t *testing.T) {
 	// 403 is in allowedStatuses → no violation; 500 is not → violation
 	markdown := fmt.Sprintf("[forbidden](%s/403)\n[server-error](%s/500)", ts.URL, ts.URL)
 	lines, offset := toLines(markdown)
-	results, _ := rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, []int{403}, &sync.Map{}, 0, 0)
+	results, _ := rule.CheckExternalLinks("test.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, []int{403}, &sync.Map{}, 0, 0)
 
 	if len(results) != 1 {
 		t.Fatalf("expected 1 violation (500 only), got %d: %v", len(results), results)
@@ -840,7 +841,7 @@ func TestCheckExternalLinks_ConfigurableMaxConcurrency(t *testing.T) {
 	}
 	lines, offset := toLines(strings.Join(links, "\n"))
 
-	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 2, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	_, _ = rule.CheckExternalLinks("heavy.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 5, 0, 2, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if maxSeen > 2 {
 		t.Errorf("expected max concurrency of 2, but saw %d concurrent requests", maxSeen)
@@ -858,7 +859,7 @@ func TestCheckExternalLinks_ConfigurableMaxRetries(t *testing.T) {
 	markdown := fmt.Sprintf("[retry-link](%s/retry)", ts.URL)
 	lines, offset := toLines(markdown)
 
-	_, _ = rule.CheckExternalLinks("retry.md", lines, offset, []*regexp.Regexp{}, 5, 0, rule.DefaultMaxConcurrency, 0, nil, &sync.Map{}, 0, 0)
+	_, _ = rule.CheckExternalLinks("retry.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 5, 0, rule.DefaultMaxConcurrency, 0, nil, &sync.Map{}, 0, 0)
 
 	if requestCount != 1 {
 		t.Errorf("maxRetries=0: expected 1 request, got %d", requestCount)
@@ -875,7 +876,7 @@ func TestPerformCheck_UserAgentHeader(t *testing.T) {
 
 	markdown := fmt.Sprintf("[link](%s/page)", ts.URL)
 	lines, offset := toLines(markdown)
-	_, _ = rule.CheckExternalLinks("test.md", lines, offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
+	_, _ = rule.CheckExternalLinks("test.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 10, 0, rule.DefaultMaxConcurrency, rule.DefaultMaxRetries, nil, &sync.Map{}, 0, 0)
 
 	if !strings.Contains(gotUA, "gomarklint") {
 		t.Errorf("expected User-Agent to contain 'gomarklint', got %q", gotUA)
@@ -909,7 +910,7 @@ func TestCheckExternalLinks_PerHostConcurrencyLimit(t *testing.T) {
 	lines, offset := toLines(strings.Join(links, "\n"))
 
 	// global concurrency=8, per-host=2 → max simultaneous to same host should be ≤ 2
-	_, _ = rule.CheckExternalLinks("heavy.md", lines, offset, []*regexp.Regexp{}, 5, 0, 8, rule.DefaultMaxRetries, nil, &sync.Map{}, 2, 0)
+	_, _ = rule.CheckExternalLinks("heavy.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 5, 0, 8, rule.DefaultMaxRetries, nil, &sync.Map{}, 2, 0)
 
 	if maxSeen > 2 {
 		t.Errorf("expected per-host concurrency ≤ 2, but saw %d concurrent requests", maxSeen)
@@ -936,7 +937,7 @@ func TestCheckExternalLinks_PerHostIntervalMs(t *testing.T) {
 
 	intervalMs := 1000
 	// perHostConcurrency=1 to serialize requests; interval=1000ms (minimum valid value)
-	_, _ = rule.CheckExternalLinks("interval.md", lines, offset, []*regexp.Regexp{}, 5, 0, 10, rule.DefaultMaxRetries, nil, &sync.Map{}, 1, intervalMs)
+	_, _ = rule.CheckExternalLinks("interval.md", preprocess.Scan(lines), offset, []*regexp.Regexp{}, 5, 0, 10, rule.DefaultMaxRetries, nil, &sync.Map{}, 1, intervalMs)
 
 	mu.Lock()
 	times := requestTimes

--- a/internal/rule/link_context_regression_test.go
+++ b/internal/rule/link_context_regression_test.go
@@ -1,0 +1,96 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
+
+func scanLinkDoc(doc string) *preprocess.Context {
+	doc = strings.TrimPrefix(doc, "\n")
+	return preprocess.Scan(strings.Split(doc, "\n"))
+}
+
+// TestLinkFamilySkipsBlockContexts is the #337 Phase 3 (link/image family)
+// gap-closure regression suite.
+func TestLinkFamilySkipsBlockContexts(t *testing.T) {
+	t.Run("empty-alt-text", func(t *testing.T) {
+		// The audit worst offender: it previously fired in every context.
+		for name, doc := range map[string]string{
+			"fenced":       "```\n![](x.png)\n```",
+			"indented":     "text\n\n    ![](x.png)",
+			"inline code":  "see `![](x.png)` here",
+			"html comment": "<!-- ![](x.png) -->",
+			"html block":   "<div>\n![](x.png)\n</div>",
+		} {
+			if errs := CheckEmptyAltText("t.md", scanLinkDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+		// Sanity: a real empty-alt image in prose is still flagged.
+		if errs := CheckEmptyAltText("t.md", scanLinkDoc("![](x.png)"), 0); len(errs) != 1 {
+			t.Errorf("plain image: got %d errors, want 1", len(errs))
+		}
+	})
+
+	t.Run("no-empty-links", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "text\n\n    [a]()",
+			"html comment": "<!-- [a]() -->",
+			"html block":   "<div>\n[a]()\n</div>",
+		} {
+			if errs := CheckNoEmptyLinks("t.md", scanLinkDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d errors, want 0: %+v", name, len(errs), errs)
+			}
+		}
+		if errs := CheckNoEmptyLinks("t.md", scanLinkDoc("[a]()"), 0); len(errs) != 1 {
+			t.Errorf("plain empty link: got %d errors, want 1", len(errs))
+		}
+		// A non-empty link followed by trailing text: findEmptyLinks scans past
+		// the link and finds no further "](", with no violation.
+		if errs := CheckNoEmptyLinks("t.md", scanLinkDoc("[ok](http://x.com) and more text"), 0); len(errs) != 0 {
+			t.Errorf("valid link with trailing text: got %d errors, want 0: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("link-fragments false positive: link in indented code is not checked", func(t *testing.T) {
+		// The fragment link lives in an indented code block, so it must not be
+		// reported even though #nope resolves to nothing.
+		doc := "# Real\n\n    [x](#nope)"
+		if errs := CheckLinkFragments("t.md", scanLinkDoc(doc), 0, nil); len(errs) != 0 {
+			t.Errorf("got %d errors, want 0: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("link-fragments false negative: heading in indented code does not satisfy a link", func(t *testing.T) {
+		// The only "# Fake" heading is inside an indented code block, so it must
+		// NOT create a valid slug — the link to #fake is therefore broken.
+		doc := "[link](#fake)\n\n    # Fake"
+		errs := CheckLinkFragments("t.md", scanLinkDoc(doc), 0, nil)
+		if len(errs) != 1 {
+			t.Fatalf("got %d errors, want 1 (broken #fake link): %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("external-link extraction skips code/HTML/comment contexts", func(t *testing.T) {
+		// ExtractExternalLinksWithLineNumbers feeds the network checker; URLs in
+		// these contexts must not be extracted (and so never fetched).
+		for name, doc := range map[string]string{
+			"fenced":       "```\nhttp://x.com\n```",
+			"indented":     "text\n\n    http://x.com",
+			"inline code":  "see `http://x.com` here",
+			"html comment": "<!-- http://x.com -->",
+			"html block":   "<div>\nhttp://x.com\n</div>",
+		} {
+			got := ExtractExternalLinksWithLineNumbers(scanLinkDoc(doc), 0)
+			if len(got) != 0 {
+				t.Errorf("%s: extracted %d links, want 0: %+v", name, len(got), got)
+			}
+		}
+		// Sanity: a bare URL in prose is still extracted.
+		if got := ExtractExternalLinksWithLineNumbers(scanLinkDoc("see http://x.com today"), 0); len(got) != 1 {
+			t.Errorf("plain URL: extracted %d, want 1", len(got))
+		}
+	})
+}

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -51,7 +51,7 @@ var reStripInlineImages = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
 
 // collectRefDefs returns a map from normalized reference label to fragment string (without #)
 // for all reference link definitions that target a fragment destination.
-// Definitions inside code or HTML block contexts are excluded.
+// Definitions inside fenced/indented code, HTML blocks, and HTML comments are excluded.
 func collectRefDefs(ctx *preprocess.Context) map[string]string {
 	defs := make(map[string]string)
 	for i := 0; i < ctx.Len(); i++ {
@@ -75,9 +75,10 @@ func collectRefDefs(ctx *preprocess.Context) map[string]string {
 }
 
 // collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings.
-// Headings inside code or HTML block contexts are excluded, so a fake heading
-// inside (e.g.) an indented code block no longer pollutes the valid-slug set and
-// mask a broken fragment link (audit #337 false negative).
+// Headings inside fenced/indented code, HTML blocks, and HTML comments are
+// excluded, so a fake heading inside (e.g.) an indented code block no longer
+// pollutes the valid-slug set and masks a broken fragment link (audit #337 false
+// negative).
 // Duplicate headings produce suffixed slugs (-1, -2, …) following GitHub convention.
 func collectHeadingSlugs(ctx *preprocess.Context, slugger func(string) string) map[string]struct{} {
 	var headings []string
@@ -96,12 +97,20 @@ func collectHeadingSlugs(ctx *preprocess.Context, slugger func(string) string) m
 	return buildSlugSet(headings, slugger)
 }
 
-// hasAnyFragmentSyntax is a cheap pre-filter that reports whether lines contain
-// any text that could be a fragment link or fragment definition, without
-// allocating any state. Checks for "(#" (inline fragment links) and
-// "]: #" (reference definition pointing at a fragment).
+// hasAnyFragmentSyntax is a cheap pre-filter that reports whether any non-block
+// line could be a fragment link or fragment definition. Checks for "(#" (inline
+// fragment links) and "]: #" (reference definition pointing at a fragment).
+//
+// It skips block contexts, since every real pass below does too — so fragment
+// syntax that lives only inside code/HTML/comment no longer trips the more
+// expensive passes. It reads the raw line (a superset of the sanitized text and
+// of the raw text the ref-def pass uses), so it never exits early while a real
+// fragment construct exists.
 func hasAnyFragmentSyntax(ctx *preprocess.Context) bool {
 	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
+			continue
+		}
 		line := ctx.Line(i)
 		if strings.Contains(line, "(#") || strings.Contains(line, "]: #") {
 			return true
@@ -110,11 +119,14 @@ func hasAnyFragmentSyntax(ctx *preprocess.Context) bool {
 	return false
 }
 
-// hasAnyFragmentLinks reports whether lines contain at least one potential
-// fragment link. The check is intentionally coarse (no code-block awareness)
-// to stay O(n) with a single pass and minimal overhead.
+// hasAnyFragmentLinks reports whether any non-block line contains at least one
+// potential fragment link. Like hasAnyFragmentSyntax it skips block contexts and
+// reads the raw line, staying O(n) with a single pass and minimal overhead.
 func hasAnyFragmentLinks(ctx *preprocess.Context, refDefs map[string]string) bool {
 	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
+			continue
+		}
 		line := ctx.Line(i)
 		if strings.Contains(line, "(#") {
 			return true

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // extractHeadingText extracts the plain text from an ATX heading line (e.g. ## Heading).
@@ -48,26 +50,15 @@ var reRefDef = regexp.MustCompile(`^\s*\[([^\]]+)\]:\s+#(\S+)`)
 var reStripInlineImages = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
 
 // collectRefDefs returns a map from normalized reference label to fragment string (without #)
-// for all reference link definitions in lines that target a fragment destination.
-// Definitions inside fenced code blocks are excluded.
-func collectRefDefs(lines []string) map[string]string {
+// for all reference link definitions that target a fragment destination.
+// Definitions inside code or HTML block contexts are excluded.
+func collectRefDefs(ctx *preprocess.Context) map[string]string {
 	defs := make(map[string]string)
-	inBlock := false
-	fenceMarker := ""
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
-		}
+		line := ctx.Line(i)
 		// Reference definitions must start with optional whitespace then '['.
 		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "[") {
 			continue
@@ -83,32 +74,19 @@ func collectRefDefs(lines []string) map[string]string {
 	return defs
 }
 
-// collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings
-// in lines. Headings inside fenced code blocks are excluded.
+// collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings.
+// Headings inside code or HTML block contexts are excluded, so a fake heading
+// inside (e.g.) an indented code block no longer pollutes the valid-slug set and
+// mask a broken fragment link (audit #337 false negative).
 // Duplicate headings produce suffixed slugs (-1, -2, …) following GitHub convention.
-func collectHeadingSlugs(lines []string, slugger func(string) string) map[string]struct{} {
+func collectHeadingSlugs(ctx *preprocess.Context, slugger func(string) string) map[string]struct{} {
 	var headings []string
 
-	inBlock := false
-	fenceMarker := ""
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
-		}
-
-		text, level := extractHeadingText(trimmed)
+		text, level := extractHeadingText(strings.TrimSpace(ctx.Line(i)))
 		if level == 0 {
 			continue
 		}
@@ -122,8 +100,9 @@ func collectHeadingSlugs(lines []string, slugger func(string) string) map[string
 // any text that could be a fragment link or fragment definition, without
 // allocating any state. Checks for "(#" (inline fragment links) and
 // "]: #" (reference definition pointing at a fragment).
-func hasAnyFragmentSyntax(lines []string) bool {
-	for _, line := range lines {
+func hasAnyFragmentSyntax(ctx *preprocess.Context) bool {
+	for i := 0; i < ctx.Len(); i++ {
+		line := ctx.Line(i)
 		if strings.Contains(line, "(#") || strings.Contains(line, "]: #") {
 			return true
 		}
@@ -134,8 +113,9 @@ func hasAnyFragmentSyntax(lines []string) bool {
 // hasAnyFragmentLinks reports whether lines contain at least one potential
 // fragment link. The check is intentionally coarse (no code-block awareness)
 // to stay O(n) with a single pass and minimal overhead.
-func hasAnyFragmentLinks(lines []string, refDefs map[string]string) bool {
-	for _, line := range lines {
+func hasAnyFragmentLinks(ctx *preprocess.Context, refDefs map[string]string) bool {
+	for i := 0; i < ctx.Len(); i++ {
+		line := ctx.Line(i)
 		if strings.Contains(line, "(#") {
 			return true
 		}
@@ -195,7 +175,8 @@ func checkRefFragments(filename string, lineNum int, scanned string, slugs map[s
 // CheckLinkFragments validates that every internal fragment link in the document
 // resolves to an actual heading slug. Both inline links ([text](#frag)) and
 // reference links ([text][ref] + [ref]: #frag) are checked. Content inside fenced
-// code blocks and inline code spans is skipped.
+// code, indented code, HTML blocks, HTML comments, and inline code spans is
+// skipped — for both the link checks and the heading/definition collection.
 //
 // Supported options:
 //   - "slug-algorithm": string — preset name (github, gitlab, zenn, pandoc, pandoc-gfm,
@@ -205,50 +186,36 @@ func checkRefFragments(filename string, lineNum int, scanned string, slugs map[s
 //   - "slug-params": map — used only when slug-algorithm is "custom"; keys: lowercase (bool),
 //     preserve-unicode (bool), space-replacement (string), strip-chars (regex string),
 //     collapse-separators (bool)
-func CheckLinkFragments(filename string, lines []string, offset int, options map[string]interface{}) []LintError {
-	if !hasAnyFragmentSyntax(lines) {
+func CheckLinkFragments(filename string, ctx *preprocess.Context, offset int, options map[string]interface{}) []LintError {
+	if !hasAnyFragmentSyntax(ctx) {
 		return nil
 	}
-	refDefs := collectRefDefs(lines)
-	if !hasAnyFragmentLinks(lines, refDefs) {
+	refDefs := collectRefDefs(ctx)
+	if !hasAnyFragmentLinks(ctx, refDefs) {
 		return nil
 	}
 	algorithm := parseSlugAlgorithm(options)
-	slugs := collectHeadingSlugs(lines, makeSlugger(algorithm, options))
+	slugs := collectHeadingSlugs(ctx, makeSlugger(algorithm, options))
 
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			continue
-		}
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		// Fast path: skip lines with no potential fragment links.
-		hasInlineLink := strings.Contains(line, "(#")
-		hasRefLink := len(refDefs) > 0 && strings.Contains(line, "][")
-		if !hasInlineLink && !hasRefLink {
-			continue
-		}
-
-		scanned := line
+		// Sanitized blanks inline code spans (and inline comments); inline images
+		// are stripped separately so image fragments like ![alt](#fig) are not
+		// treated as broken links.
+		scanned := ctx.Sanitized(i)
 		if strings.ContainsRune(scanned, '!') {
 			scanned = reStripInlineImages.ReplaceAllString(scanned, "")
 		}
-		if strings.ContainsRune(scanned, '`') {
-			scanned = stripInlineCode(scanned)
+
+		hasInlineLink := strings.Contains(scanned, "(#")
+		hasRefLink := len(refDefs) > 0 && strings.Contains(scanned, "][")
+		if !hasInlineLink && !hasRefLink {
+			continue
 		}
 
 		lineNum := offset + i + 1

--- a/internal/rule/link_fragments_test.go
+++ b/internal/rule/link_fragments_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckLinkFragments(t *testing.T) {
@@ -177,7 +179,7 @@ func TestCheckLinkFragments(t *testing.T) {
 			if tt.name == "invalid: offset applied to line numbers" {
 				offset = 5
 			}
-			got := CheckLinkFragments("test.md", lines, offset, tt.opts)
+			got := CheckLinkFragments("test.md", preprocess.Scan(lines), offset, tt.opts)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d:\n  got:  %v\n  want: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)
@@ -255,7 +257,7 @@ func TestCheckLinkFragments_NewPresets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
 			opts := map[string]interface{}{"slug-algorithm": tt.algorithm}
-			got := CheckLinkFragments("test.md", lines, 0, opts)
+			got := CheckLinkFragments("test.md", preprocess.Scan(lines), 0, opts)
 			if len(got) != tt.wantErrs {
 				t.Errorf("got %d errors, want %d: %v", len(got), tt.wantErrs, got)
 			}
@@ -277,7 +279,7 @@ func TestCheckLinkFragments_CustomEngine(t *testing.T) {
 			},
 		}
 		lines := strings.Split(content, "\n")
-		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		errs := CheckLinkFragments("test.md", preprocess.Scan(lines), 0, opts)
 		if len(errs) != 0 {
 			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
 		}
@@ -296,7 +298,7 @@ func TestCheckLinkFragments_CustomEngine(t *testing.T) {
 			},
 		}
 		lines := strings.Split(content, "\n")
-		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		errs := CheckLinkFragments("test.md", preprocess.Scan(lines), 0, opts)
 		if len(errs) != 1 {
 			t.Errorf("expected 1 error, got %d: %v", len(errs), errs)
 		}
@@ -313,7 +315,7 @@ func TestCheckLinkFragments_CustomEngine(t *testing.T) {
 			},
 		}
 		lines := strings.Split(content, "\n")
-		errs := CheckLinkFragments("test.md", lines, 0, opts)
+		errs := CheckLinkFragments("test.md", preprocess.Scan(lines), 0, opts)
 		if len(errs) != 0 {
 			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
 		}
@@ -321,13 +323,13 @@ func TestCheckLinkFragments_CustomEngine(t *testing.T) {
 }
 
 func TestHasAnyFragmentSyntax(t *testing.T) {
-	if hasAnyFragmentSyntax([]string{"no links here", "just text"}) {
+	if hasAnyFragmentSyntax(preprocess.Scan([]string{"no links here", "just text"})) {
 		t.Error("expected false for plain text")
 	}
-	if !hasAnyFragmentSyntax([]string{"See [intro](#intro) here."}) {
+	if !hasAnyFragmentSyntax(preprocess.Scan([]string{"See [intro](#intro) here."})) {
 		t.Error("expected true for inline fragment link")
 	}
-	if !hasAnyFragmentSyntax([]string{"[ref]: #section"}) {
+	if !hasAnyFragmentSyntax(preprocess.Scan([]string{"[ref]: #section"})) {
 		t.Error("expected true for fragment ref definition")
 	}
 }
@@ -335,7 +337,7 @@ func TestHasAnyFragmentSyntax(t *testing.T) {
 func TestCollectRefDefs(t *testing.T) {
 	t.Run("collects fragment refs", func(t *testing.T) {
 		lines := strings.Split("[ref1]: #section-1\n[ref2]: #section-2\n[ext]: https://example.com\n", "\n")
-		defs := collectRefDefs(lines)
+		defs := collectRefDefs(preprocess.Scan(lines))
 		if defs["ref1"] != "section-1" {
 			t.Errorf("expected ref1 -> section-1, got %q", defs["ref1"])
 		}
@@ -349,7 +351,7 @@ func TestCollectRefDefs(t *testing.T) {
 
 	t.Run("label is normalized to lowercase", func(t *testing.T) {
 		lines := []string{"[My Label]: #my-section"}
-		defs := collectRefDefs(lines)
+		defs := collectRefDefs(preprocess.Scan(lines))
 		if defs["my label"] != "my-section" {
 			t.Errorf("expected 'my label' -> 'my-section', got %q", defs["my label"])
 		}
@@ -357,7 +359,7 @@ func TestCollectRefDefs(t *testing.T) {
 
 	t.Run("ref def inside fenced code block is excluded", func(t *testing.T) {
 		lines := strings.Split("```\n[inside]: #fenced\n```\n[outside]: #real\n", "\n")
-		defs := collectRefDefs(lines)
+		defs := collectRefDefs(preprocess.Scan(lines))
 		if _, ok := defs["inside"]; ok {
 			t.Error("ref def inside fenced block should not be collected")
 		}

--- a/internal/rule/no_empty_links.go
+++ b/internal/rule/no_empty_links.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // emptyLinkDest reports whether dest is an "empty" link destination.
@@ -56,44 +58,24 @@ func findEmptyLinks(line string) []string {
 
 // CheckNoEmptyLinks flags Markdown links and images whose destination URL is
 // empty, contains only "#", or is "<>".
-// Links inside fenced code blocks and inline code spans are ignored.
-func CheckNoEmptyLinks(filename string, lines []string, offset int) []LintError {
+// Links inside fenced code, indented code, HTML blocks, HTML comments, and inline
+// code spans are ignored.
+func CheckNoEmptyLinks(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first != fenceMarker[0] {
-				continue
-			}
-			if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				continue
-			}
-		}
-
+		// Sanitized blanks inline code spans and inline comments, so links
+		// living inside them are not seen here.
+		line := ctx.Sanitized(i)
 		if !strings.Contains(line, "](") {
 			continue
 		}
 
-		scanned := line
-		if strings.ContainsRune(line, '`') {
-			scanned = stripInlineCode(line)
-		}
-
-		for _, match := range findEmptyLinks(scanned) {
+		for _, match := range findEmptyLinks(line) {
 			errs = append(errs, LintError{
 				File:    filename,
 				Line:    offset + i + 1,

--- a/internal/rule/no_empty_links_test.go
+++ b/internal/rule/no_empty_links_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoEmptyLinks(t *testing.T) {
@@ -144,7 +146,7 @@ func TestCheckNoEmptyLinks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoEmptyLinks("test.md", lines, tt.offset)
+			got := CheckNoEmptyLinks("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)


### PR DESCRIPTION
## Summary

Phase 3 of #337 (#339), **wave 3 of 4** (link/image family). Migrates the four link/image-family rules to the shared `*preprocess.Context`:

- `empty-alt-text`
- `no-empty-links`
- `link-fragments`
- `external-link`

Depends on wave 2 (#348, merged).

## Gap closures (#337 audit)

- **`empty-alt-text`** — the audit's **worst offender** (it did *no* context filtering and fired even inside fenced and inline code). Now skips fenced/indented code, HTML blocks, and HTML comments, and scans the inline-sanitized text, so `![](url)` inside any of those is ignored.
- **`no-empty-links`** — drops its fence state machine and `stripInlineCode`; skips all block contexts and scans `Sanitized`. Closes the indented-code / HTML-block / HTML-comment gaps.
- **`link-fragments`** — migrates all three passes (ref-def collection, heading-slug collection, link checking). Closes **both** of its audit gaps:
  - **FP**: a fragment link inside indented code is no longer flagged.
  - **FN**: a fake `# Heading` inside indented code no longer creates a slug that masks a genuinely broken `#fragment` link.
- **`external-link`** — extracts URLs from the sanitized, block-filtered context, so URLs inside inline code, comments, indented code, and HTML blocks are **no longer fetched** (the audit's network side effect). Phase 4 (#341) verifies this live.

## Cleanups

With `external-link` migrated, `GetCodeBlockLineRanges` and `isInCodeBlock` are **removed** — their last callers are gone. Linter: the four rules move to `contextRules` / pass `ctx`.

## Tests

- All existing tests pass against the new signatures (wrapped through `preprocess.Scan`), including the direct unit tests for `ExtractExternalLinksWithLineNumbers`, `collectRefDefs`, and `hasAnyFragmentSyntax`.
- New `TestLinkFamilySkipsBlockContexts` covers every gap, including link-fragments' FP **and** FN, and external-link extraction across all five contexts (tested via extraction — no network).
- `make test-all` clean, `make static-lint` clean, 100% coverage.
- `make bench-compare`: flat (these rules weren't the heavy fence-trackers; the CPU was already reclaimed in waves 1–2).

After this wave only the style family remains (wave 4): `inline_strip.go`'s helpers still have consumers there, so they stay until then.

Refs #337. Part of #339.