### PR TITLE
feat(rule): migrate style family to preprocess context (#337 Phase 3, wave 4)

### DIFF
--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -363,9 +363,6 @@ var simpleRules = []struct {
 	fn   func(string, []string, int) []rule.LintError
 }{
 	{"final-blank-line", rule.CheckFinalBlankLine},
-	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
-	{"blanks-around-lists", rule.CheckBlanksAroundLists},
-	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 
 // contextRules lists rules migrated to consume the shared *preprocess.Context
@@ -386,6 +383,9 @@ var contextRules = []struct {
 	{"blanks-around-fences", rule.CheckBlanksAroundFences},
 	{"empty-alt-text", rule.CheckEmptyAltText},
 	{"no-empty-links", rule.CheckNoEmptyLinks},
+	{"no-multiple-blank-lines", rule.CheckNoMultipleBlankLines},
+	{"blanks-around-lists", rule.CheckBlanksAroundLists},
+	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 
 // collectLineErrors runs all non-network rule checks and returns their errors.
@@ -414,16 +414,16 @@ func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.
 		errs = append(errs, l.withSeverity(rule.CheckConsistentCodeFence(path, ctx, offset, l.consistentCodeFenceStyle()), "consistent-code-fence")...)
 	}
 	if l.config.IsEnabled("consistent-emphasis-style") {
-		errs = append(errs, l.withSeverity(rule.CheckConsistentEmphasisStyle(path, lines, offset, l.consistentEmphasisStyle()), "consistent-emphasis-style")...)
+		errs = append(errs, l.withSeverity(rule.CheckConsistentEmphasisStyle(path, ctx, offset, l.consistentEmphasisStyle()), "consistent-emphasis-style")...)
 	}
 	if l.config.IsEnabled("consistent-list-marker") {
-		errs = append(errs, l.withSeverity(rule.CheckConsistentListMarker(path, lines, offset, l.consistentListMarkerStyle()), "consistent-list-marker")...)
+		errs = append(errs, l.withSeverity(rule.CheckConsistentListMarker(path, ctx, offset, l.consistentListMarkerStyle()), "consistent-list-marker")...)
 	}
 	if l.config.IsEnabled("max-line-length") {
-		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, lines, offset, l.maxLineLength()), "max-line-length")...)
+		errs = append(errs, l.withSeverity(rule.CheckMaxLineLength(path, ctx, offset, l.maxLineLength()), "max-line-length")...)
 	}
 	if l.config.IsEnabled("no-trailing-punctuation") {
-		errs = append(errs, l.withSeverity(rule.CheckNoTrailingPunctuation(path, lines, offset, l.noTrailingPunctuation()), "no-trailing-punctuation")...)
+		errs = append(errs, l.withSeverity(rule.CheckNoTrailingPunctuation(path, ctx, offset, l.noTrailingPunctuation()), "no-trailing-punctuation")...)
 	}
 	if l.config.IsEnabled("link-fragments") {
 		errs = append(errs, l.withSeverity(rule.CheckLinkFragments(path, ctx, offset, l.config.RuleOptions("link-fragments")), "link-fragments")...)

--- a/internal/rule/blanks_around_lists.go
+++ b/internal/rule/blanks_around_lists.go
@@ -1,6 +1,10 @@
 package rule
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
 
 // isListItem reports whether line is a list item (unordered or ordered),
 // allowing any amount of leading indentation. The marker must be followed by
@@ -47,11 +51,10 @@ func isOrderedListItem(s string) bool {
 // after the last item are checked. Lists at the start or end of the file are
 // exempt from the respective check. List items inside fenced code blocks are
 // ignored. Nested list items are treated as part of the same block and do not
-// require additional blank lines between them and their parent.
-func CheckBlanksAroundLists(filename string, lines []string, offset int) []LintError {
+// require additional blank lines between them and their parent. List items
+// inside fenced code, indented code, HTML blocks, and HTML comments are ignored.
+func CheckBlanksAroundLists(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	// prevBlank and prevWasListItem replace the TrimSpace look-behind on
 	// lines[i-1] for every list item encountered.
 	// prevBlank starts as true to model the pre-file boundary as blank; the
@@ -60,13 +63,14 @@ func CheckBlanksAroundLists(filename string, lines []string, offset int) []LintE
 	prevWasListItem := false
 	prevLineNum := 0 // 1-indexed line number of the previous list item
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		line := ctx.Line(i)
 		trimmed := strings.TrimSpace(line)
 		isBlank := trimmed == ""
 		isList := isListItem(line)
 
-		// Check "end of block" before fence branches so a list item immediately
-		// followed by a fence opener is still flagged (lesson from PR-4).
+		// Check "end of block" before the block skip so a list item immediately
+		// followed by a code/HTML block opener is still flagged (lesson from PR-4).
 		if prevWasListItem && !isBlank && !isList {
 			errs = append(errs, LintError{
 				File:    filename,
@@ -75,19 +79,7 @@ func CheckBlanksAroundLists(filename string, lines []string, offset int) []LintE
 			})
 		}
 
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
-			prevBlank = false
-			prevWasListItem = false
-			continue
-		}
-
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
+		if inBlockContext(ctx, i) {
 			prevBlank = false
 			prevWasListItem = false
 			continue

--- a/internal/rule/blanks_around_lists_test.go
+++ b/internal/rule/blanks_around_lists_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckBlanksAroundLists(t *testing.T) {
@@ -188,7 +190,7 @@ func TestCheckBlanksAroundLists(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckBlanksAroundLists("test.md", lines, tt.offset)
+			got := CheckBlanksAroundLists("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckConsistentEmphasisStyle flags emphasis spans that use a different marker
@@ -11,40 +13,23 @@ import (
 // the expected style; every subsequent span using a different character is
 // flagged. In "asterisk"/"underscore" mode every span using the wrong character
 // is flagged. Underscores inside words (e.g. snake_case) are not treated as
-// emphasis. Content inside fenced code blocks and inline code spans is ignored.
-func CheckConsistentEmphasisStyle(filename string, lines []string, offset int, style string) []LintError {
+// emphasis. Content inside fenced code, indented code, HTML blocks, HTML
+// comments, and inline code spans is ignored.
+func CheckConsistentEmphasisStyle(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	var expectedEmphCh byte   // for runLen == 1 (emphasis)
 	var expectedStrongCh byte // for runLen == 2 (strong)
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				continue
-			}
-		}
-
-		if !strings.ContainsAny(line, "*_") {
+		// Sanitized blanks inline code spans and inline HTML comments, so
+		// emphasis markers living inside them are not counted.
+		scanned := ctx.Sanitized(i)
+		if !strings.ContainsAny(scanned, "*_") {
 			continue
-		}
-
-		scanned := line
-		if strings.ContainsRune(scanned, '`') {
-			scanned = stripInlineCode(scanned)
 		}
 		if strings.Contains(scanned, "](") {
 			scanned = stripLinkURLs(scanned)

--- a/internal/rule/consistent_emphasis_style_test.go
+++ b/internal/rule/consistent_emphasis_style_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckConsistentEmphasisStyle(t *testing.T) {
@@ -364,7 +366,7 @@ func TestCheckConsistentEmphasisStyle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckConsistentEmphasisStyle("test.md", lines, tt.offset, tt.style)
+			got := CheckConsistentEmphasisStyle("test.md", preprocess.Scan(lines), tt.offset, tt.style)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -1,7 +1,7 @@
 package rule
 
 import (
-	"strings"
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckConsistentListMarker flags unordered list items that use a different
@@ -10,34 +10,19 @@ import (
 // In "consistent" mode the first marker found in the document sets the
 // expected style; every subsequent item using a different marker is flagged.
 // In "dash"/"asterisk"/"plus" mode every item using the wrong marker is
-// flagged. Content inside fenced code blocks is ignored.
-func CheckConsistentListMarker(filename string, lines []string, offset int, style string) []LintError {
+// flagged. Content inside fenced code, indented code, HTML blocks, and HTML
+// comments is ignored.
+func CheckConsistentListMarker(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	var expectedCh byte // 0 until first list item seen (consistent mode)
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first == '`' || first == '~' {
-				if IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-					inBlock = false
-					fenceMarker = ""
-				}
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				continue
-			}
-		}
-
+		line := ctx.Line(i)
+		first := firstNonSpaceByte(line)
 		if first != '-' && first != '*' && first != '+' {
 			continue
 		}

--- a/internal/rule/consistent_list_marker_test.go
+++ b/internal/rule/consistent_list_marker_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckConsistentListMarker(t *testing.T) {
@@ -228,7 +230,7 @@ func TestCheckConsistentListMarker(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckConsistentListMarker("test.md", lines, tt.offset, tt.style)
+			got := CheckConsistentListMarker("test.md", preprocess.Scan(lines), tt.offset, tt.style)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/fence.go
+++ b/internal/rule/fence.go
@@ -1,31 +1,5 @@
 package rule
 
-import "strings"
-
-// IsClosingFence reports whether trimmed is a valid closing fence for the given
-// opening fence marker. Per the CommonMark spec, a closing fence must:
-//  1. Use the same fence character as the opener (backtick or tilde)
-//  2. Have a run length >= the opener's length
-//  3. Contain only optional whitespace after the fence run
-func IsClosingFence(trimmed, openMarker string) bool {
-	if len(trimmed) == 0 || len(openMarker) == 0 {
-		return false
-	}
-	ch := openMarker[0]
-	if trimmed[0] != ch {
-		return false
-	}
-	// Count the run of fence characters
-	n := 0
-	for n < len(trimmed) && trimmed[n] == ch {
-		n++
-	}
-	if n < len(openMarker) {
-		return false
-	}
-	return strings.TrimSpace(trimmed[n:]) == ""
-}
-
 // openingFenceMarker returns the full fence marker (e.g. "```", "````", "~~~") if the line
 // is an opening fence, or an empty string otherwise. The full run of fence characters is
 // captured so that closing fences of the same length are correctly matched.

--- a/internal/rule/fence_test.go
+++ b/internal/rule/fence_test.go
@@ -2,35 +2,34 @@ package rule
 
 import "testing"
 
-func TestIsClosingFence(t *testing.T) {
+// TestOpeningFenceMarker exercises openingFenceMarker directly. The style-family
+// migration to preprocess.Context (#337 Phase 3) removed its incidental coverage
+// from those rules' tests; its only remaining caller, CheckFencedCodeLanguage,
+// feeds it pre-validated fence openers from ctx.FenceSpans() and so never hits
+// the guard branches.
+func TestOpeningFenceMarker(t *testing.T) {
 	tests := []struct {
-		name       string
-		trimmed    string
-		openMarker string
-		want       bool
+		name    string
+		trimmed string
+		want    string
 	}{
-		{"exact backtick match", "```", "```", true},
-		{"exact tilde match", "~~~", "~~~", true},
-		{"longer closing backtick", "````", "```", true},
-		{"longer closing tilde", "~~~~", "~~~", true},
-		{"much longer closing", "``````", "```", true},
-		{"shorter closing rejected", "```", "````", false},
-		{"trailing whitespace allowed", "```  ", "```", true},
-		{"trailing text rejected", "``` foo", "```", false},
-		{"mismatched fence char", "~~~", "```", false},
-		{"mismatched fence char reverse", "```", "~~~", false},
-		{"empty trimmed", "", "```", false},
-		{"empty marker", "```", "", false},
-		{"both empty", "", "", false},
-		{"4-backtick exact", "````", "````", true},
-		{"4-backtick longer close", "`````", "````", true},
+		{"backtick fence", "```", "```"},
+		{"tilde fence", "~~~", "~~~"},
+		{"longer backtick run", "````", "````"},
+		{"fence with language", "```go", "```"},
+		{"tilde with language", "~~~bash", "~~~"},
+		{"too short", "``", ""},
+		{"empty", "", ""},
+		{"not a fence char", "---", ""},
+		{"second char mismatch", "`x`", ""},
+		{"third char mismatch", "``x", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsClosingFence(tt.trimmed, tt.openMarker)
+			got := openingFenceMarker(tt.trimmed)
 			if got != tt.want {
-				t.Errorf("IsClosingFence(%q, %q) = %v, want %v", tt.trimmed, tt.openMarker, got, tt.want)
+				t.Errorf("openingFenceMarker(%q) = %q, want %q", tt.trimmed, got, tt.want)
 			}
 		})
 	}

--- a/internal/rule/inline_strip.go
+++ b/internal/rule/inline_strip.go
@@ -2,11 +2,11 @@ package rule
 
 import "strings"
 
-// This file holds inline-code-stripping helpers shared by several rules that
-// have not yet been migrated to the preprocess context (#337 Phase 3):
-// no-empty-links, link-fragments, consistent-emphasis-style, and no-hard-tabs.
-// They duplicate logic now centralized in internal/preprocess (see
-// Context.Sanitized) and are removed once their last consumer migrates.
+// This file holds inline-code-stripping helpers. Its sole remaining consumer is
+// no-hard-tabs, a markdownlint divergence (#337 Section B) that strips inline
+// code spans but — unlike the shared preprocess sanitizer — must NOT blank inline
+// HTML comments (it still reports tabs there). The other rules that once shared
+// these helpers now use preprocess.Context.Sanitized instead.
 
 // countBacktickRun returns the number of consecutive backticks starting at
 // position start in s.

--- a/internal/rule/max_line_length.go
+++ b/internal/rule/max_line_length.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // isBareURLLine reports whether the trimmed line consists solely of a single
@@ -29,35 +31,26 @@ func isBareURLLine(trimmed string) bool {
 // CheckMaxLineLength flags lines whose byte length exceeds lineLength.
 // Lines inside fenced code blocks, ATX heading lines, and lines that consist
 // solely of a URL are exempt.
-func CheckMaxLineLength(filename string, lines []string, offset int, lineLength int) []LintError {
+//
+// This is a markdownlint divergence (#337 Section B): only fenced code is
+// skipped. Lines inside indented code and HTML blocks are deliberately still
+// checked, so the rule skips just preprocess.InFencedCode rather than every
+// block context.
+func CheckMaxLineLength(filename string, ctx *preprocess.Context, offset int, lineLength int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 
-	for i, line := range lines {
-		first := firstNonSpaceByte(line)
-
-		if inBlock {
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if ctx.InFencedCode(i) {
 			continue
 		}
 
-		if first == '`' || first == '~' {
-			if marker := openingFenceMarker(strings.TrimSpace(line)); marker != "" {
-				inBlock = true
-				fenceMarker = marker
-				continue
-			}
-		}
-
+		line := ctx.Line(i)
 		if len(line) <= lineLength {
 			continue
 		}
 
 		trimmed := strings.TrimSpace(line)
+		first := firstNonSpaceByte(line)
 		if (first == '#' && isATXHeading(trimmed)) || isBareURLLine(trimmed) {
 			continue
 		}

--- a/internal/rule/max_line_length_test.go
+++ b/internal/rule/max_line_length_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckMaxLineLength(t *testing.T) {
@@ -164,7 +166,7 @@ func TestCheckMaxLineLength(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckMaxLineLength("test.md", lines, tt.offset, tt.lineLength)
+			got := CheckMaxLineLength("test.md", preprocess.Scan(lines), tt.offset, tt.lineLength)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/no_hard_tabs.go
+++ b/internal/rule/no_hard_tabs.go
@@ -3,32 +3,27 @@ package rule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckNoHardTabs flags hard tab characters (\t) outside fenced code blocks
 // and inline code spans. Each tab is reported as a separate violation.
-func CheckNoHardTabs(filename string, lines []string, offset int) []LintError {
+//
+// This is a markdownlint divergence (#337 Section B): only fenced code is
+// skipped (tabs in indented code are still reported), and inline code spans are
+// stripped. It therefore skips just preprocess.InFencedCode and keeps its own
+// inline-code stripping rather than using the shared block-context helper or the
+// sanitized view (which would also blank inline HTML comments).
+func CheckNoHardTabs(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-
-		if inBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if ctx.InFencedCode(i) {
 			continue
 		}
 
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inBlock = true
-			fenceMarker = marker
-			continue
-		}
-
+		line := ctx.Line(i)
 		if !strings.ContainsRune(line, '\t') {
 			continue
 		}

--- a/internal/rule/no_hard_tabs_test.go
+++ b/internal/rule/no_hard_tabs_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoHardTabs(t *testing.T) {
@@ -99,7 +101,7 @@ func TestCheckNoHardTabs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoHardTabs("test.md", lines, tt.offset)
+			got := CheckNoHardTabs("test.md", preprocess.Scan(lines), tt.offset)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/no_multiple_blank_lines.go
+++ b/internal/rule/no_multiple_blank_lines.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"strings"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // CheckNoMultipleBlankLines checks whether the Markdown content contains
@@ -14,34 +16,26 @@ import (
 //
 // Parameters:
 //   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
+//   - ctx: the shared per-line context produced by preprocess.Scan
 //   - offset: the line number offset due to frontmatter removal
 //
 // Returns:
 //   - A slice of LintError with entries for each occurrence of multiple consecutive blank lines.
-func CheckNoMultipleBlankLines(filename string, lines []string, offset int) []LintError {
+//
+// Blank lines inside any block context the scanner identifies are not counted —
+// fenced code, but also blank lines inside type 1–5 HTML blocks (e.g. <pre>) and
+// multi-line HTML comments. Blank lines between indented-code paragraphs are not
+// classified as indented by the scanner, so that case remains a known limitation.
+func CheckNoMultipleBlankLines(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	consecutiveBlankCount := 0
-	inCodeBlock := false
-	var fenceMarker string
 
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if inCodeBlock {
-			if IsClosingFence(trimmed, fenceMarker) {
-				inCodeBlock = false
-				fenceMarker = ""
-			}
+	for i := 0; i < ctx.Len(); i++ {
+		if inBlockContext(ctx, i) {
 			consecutiveBlankCount = 0
 			continue
 		}
-		if marker := openingFenceMarker(trimmed); marker != "" {
-			inCodeBlock = true
-			fenceMarker = marker
-			consecutiveBlankCount = 0
-			continue
-		}
-		if trimmed == "" {
+		if strings.TrimSpace(ctx.Line(i)) == "" {
 			consecutiveBlankCount++
 			if consecutiveBlankCount > 1 {
 				errs = append(errs, LintError{

--- a/internal/rule/no_multiple_blank_lines_test.go
+++ b/internal/rule/no_multiple_blank_lines_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoMultipleBlankLines(t *testing.T) {
@@ -68,7 +70,7 @@ func TestCheckNoMultipleBlankLines(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoMultipleBlankLines("test.md", lines, 0)
+			got := CheckNoMultipleBlankLines("test.md", preprocess.Scan(lines), 0)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\nGot: %v\nWant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/no_trailing_punctuation.go
+++ b/internal/rule/no_trailing_punctuation.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 // atxHeadingText returns the visible text of an ATX heading with the opening
@@ -37,15 +39,6 @@ func atxLineText(first byte, line string) (string, bool) {
 	return atxHeadingText(strings.TrimSpace(line))
 }
 
-// openFenceMarkerIfPresent returns the fence marker when line opens a fenced
-// code block, or "" otherwise. The first-byte guard avoids TrimSpace on most lines.
-func openFenceMarkerIfPresent(first byte, line string) string {
-	if first != '`' && first != '~' {
-		return ""
-	}
-	return openingFenceMarker(strings.TrimSpace(line))
-}
-
 // setextHeadingText returns the trimmed heading text when line is a setext
 // underline following a valid heading candidate on the previous line.
 // Returns ("", false) when the conditions are not met.
@@ -76,18 +69,20 @@ func noTPViolation(filename string, lineNum int, r rune) LintError {
 
 // CheckNoTrailingPunctuation flags ATX and setext headings whose visible text
 // ends with a character contained in punctuation (MD026).
-func CheckNoTrailingPunctuation(filename string, lines []string, offset int, punctuation string) []LintError {
+//
+// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
+// ignored, and a setext underline cannot follow a block line.
+func CheckNoTrailingPunctuation(filename string, ctx *preprocess.Context, offset int, punctuation string) []LintError {
 	if punctuation == "" {
 		return nil
 	}
 
 	var errs []LintError
-	inBlock := false
-	fenceMarker := ""
 	prevLine := ""       // raw previous non-blank non-block line (setext candidate)
 	prevIsBlock := false // true when the previous line was a block-level element
 
-	for i, line := range lines {
+	for i := 0; i < ctx.Len(); i++ {
+		line := ctx.Line(i)
 		first := firstNonSpaceByte(line)
 
 		if first == 0 {
@@ -96,20 +91,9 @@ func CheckNoTrailingPunctuation(filename string, lines []string, offset int, pun
 			continue
 		}
 
-		if inBlock {
-			// Short-circuit: only trim+check when first byte matches the fence marker.
-			if first == fenceMarker[0] && IsClosingFence(strings.TrimSpace(line), fenceMarker) {
-				inBlock = false
-				fenceMarker = ""
-				prevLine = ""
-				prevIsBlock = true
-			}
-			continue
-		}
-
-		if marker := openFenceMarkerIfPresent(first, line); marker != "" {
-			inBlock = true
-			fenceMarker = marker
+		// A line in any code/HTML block context is not heading text, and a setext
+		// underline cannot follow it.
+		if inBlockContext(ctx, i) {
 			prevLine = ""
 			prevIsBlock = true
 			continue

--- a/internal/rule/no_trailing_punctuation_test.go
+++ b/internal/rule/no_trailing_punctuation_test.go
@@ -3,6 +3,8 @@ package rule
 import (
 	"strings"
 	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
 func TestCheckNoTrailingPunctuation(t *testing.T) {
@@ -250,7 +252,7 @@ func TestCheckNoTrailingPunctuation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lines := strings.Split(tt.content, "\n")
-			got := CheckNoTrailingPunctuation("test.md", lines, tt.offset, tt.punctuation)
+			got := CheckNoTrailingPunctuation("test.md", preprocess.Scan(lines), tt.offset, tt.punctuation)
 
 			if len(got) != len(tt.wantErrs) {
 				t.Fatalf("got %d errors, want %d\ngot:  %v\nwant: %v", len(got), len(tt.wantErrs), got, tt.wantErrs)

--- a/internal/rule/style_context_regression_test.go
+++ b/internal/rule/style_context_regression_test.go
@@ -1,0 +1,129 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
+)
+
+func scanStyleDoc(doc string) *preprocess.Context {
+	doc = strings.TrimPrefix(doc, "\n")
+	return preprocess.Scan(strings.Split(doc, "\n"))
+}
+
+// TestStyleFamilySkipsBlockContexts covers the #337 Phase 3 (style family)
+// gap closures for the five rules that skip all block contexts.
+func TestStyleFamilySkipsBlockContexts(t *testing.T) {
+	t.Run("consistent-list-marker", func(t *testing.T) {
+		// A different marker inside indented code / HTML must not be flagged in
+		// "dash" mode.
+		for name, doc := range map[string]string{
+			"indented":   "- real\n\n    * fake",
+			"html block": "- real\n\n<div>\n* fake\n</div>",
+		} {
+			if errs := CheckConsistentListMarker("t.md", scanStyleDoc(doc), 0, "dash"); len(errs) != 0 {
+				t.Errorf("%s: got %d, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("consistent-emphasis-style", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "*real*\n\n    _fake_",
+			"inline code":  "*real*\n\nsee `_fake_` text",
+			"html comment": "*real*\n\n<!-- _fake_ -->",
+			"html block":   "*real*\n\n<div>\n_fake_\n</div>",
+		} {
+			// "asterisk" mode: an underscore span outside any block would be
+			// flagged; inside these contexts it must not be.
+			errs := CheckConsistentEmphasisStyle("t.md", scanStyleDoc(doc), 0, "asterisk")
+			if len(errs) != 0 {
+				t.Errorf("%s: got %d, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("blanks-around-lists", func(t *testing.T) {
+		// A list-looking line inside indented code / HTML block must not drive
+		// blank-line checks.
+		for name, doc := range map[string]string{
+			"indented":   "text\n\n    - item\n    - item2\n\nmore",
+			"html block": "<div>\n- item\n- item2\n</div>",
+		} {
+			if errs := CheckBlanksAroundLists("t.md", scanStyleDoc(doc), 0); len(errs) != 0 {
+				t.Errorf("%s: got %d, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+
+	t.Run("no-multiple-blank-lines skips blanks inside a <pre> block", func(t *testing.T) {
+		// A type-1 HTML block (<pre>) may legitimately contain consecutive blank
+		// lines; they must not be flagged.
+		doc := "<pre>\nline1\n\n\nline2\n</pre>"
+		if errs := CheckNoMultipleBlankLines("t.md", scanStyleDoc(doc), 0); len(errs) != 0 {
+			t.Errorf("got %d, want 0: %+v", len(errs), errs)
+		}
+		// Sanity: consecutive blanks in prose are still flagged.
+		if errs := CheckNoMultipleBlankLines("t.md", scanStyleDoc("a\n\n\nb"), 0); len(errs) != 1 {
+			t.Errorf("prose double blank: got %d, want 1", len(errs))
+		}
+	})
+
+	t.Run("no-trailing-punctuation", func(t *testing.T) {
+		for name, doc := range map[string]string{
+			"indented":     "text\n\n    # Heading:",
+			"html comment": "<!-- # Heading: -->",
+			"html block":   "<div>\n# Heading:\n</div>",
+		} {
+			if errs := CheckNoTrailingPunctuation("t.md", scanStyleDoc(doc), 0, ".,;:!?"); len(errs) != 0 {
+				t.Errorf("%s: got %d, want 0: %+v", name, len(errs), errs)
+			}
+		}
+	})
+}
+
+// TestSectionBStillChecksOutsideFencedCode is the regression guard for the
+// markdownlint divergences (#337 Section B): max-line-length and no-hard-tabs
+// intentionally skip ONLY fenced code, so they must still fire inside indented
+// code and HTML blocks. These positive assertions fail if either rule is ever
+// "tidied" to use the shared all-block skip.
+func TestSectionBStillChecksOutsideFencedCode(t *testing.T) {
+	long := strings.Repeat("x", 50)
+
+	t.Run("max-line-length still flags long lines in indented code", func(t *testing.T) {
+		doc := "text\n\n    " + long
+		if errs := CheckMaxLineLength("t.md", scanStyleDoc(doc), 0, 40); len(errs) != 1 {
+			t.Errorf("indented: got %d, want 1: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("max-line-length still flags long lines in an HTML block", func(t *testing.T) {
+		doc := "<div>\n" + long + "\n</div>"
+		if errs := CheckMaxLineLength("t.md", scanStyleDoc(doc), 0, 40); len(errs) != 1 {
+			t.Errorf("html block: got %d, want 1: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("max-line-length still skips fenced code", func(t *testing.T) {
+		doc := "```\n" + long + "\n```"
+		if errs := CheckMaxLineLength("t.md", scanStyleDoc(doc), 0, 40); len(errs) != 0 {
+			t.Errorf("fenced: got %d, want 0: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("no-hard-tabs still flags tabs in indented code", func(t *testing.T) {
+		// A tab-indented line is indented code; the tab must still be reported.
+		doc := "text\n\n\tcode"
+		if errs := CheckNoHardTabs("t.md", scanStyleDoc(doc), 0); len(errs) != 1 {
+			t.Errorf("indented: got %d, want 1: %+v", len(errs), errs)
+		}
+	})
+
+	t.Run("no-hard-tabs still skips fenced code", func(t *testing.T) {
+		doc := "```\n\tcode\n```"
+		if errs := CheckNoHardTabs("t.md", scanStyleDoc(doc), 0); len(errs) != 0 {
+			t.Errorf("fenced: got %d, want 0: %+v", len(errs), errs)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Phase 3 of #337 (#339), **wave 4 of 4** (style / format family) — the final wave. Migrates the seven remaining style-family rules to the shared `*preprocess.Context`:

- `consistent-list-marker`
- `consistent-emphasis-style`
- `blanks-around-lists`
- `no-multiple-blank-lines`
- `no-trailing-punctuation`
- `max-line-length`
- `no-hard-tabs`

Depends on wave 3 (#349, merged). With this, every rule in #339's scope consumes the centralised preprocess context.

## Gap closures (#337 audit)

The five "skip all block contexts" rules drop their self-rolled fence state machines and now skip via `inBlockContext` — fenced **and** indented code, HTML blocks, and HTML comments:

- **`consistent-list-marker`** — a different marker inside indented code / an HTML block no longer trips "dash/asterisk/plus" mode.
- **`consistent-emphasis-style`** — now scans `ctx.Sanitized`, so emphasis markers inside inline code spans and inline HTML comments are ignored, in addition to the block contexts.
- **`blanks-around-lists`** — list-looking lines inside indented code / HTML blocks no longer drive blank-line checks. The pre-existing "end of block" look-behind (PR-4 lesson) is preserved.
- **`no-trailing-punctuation`** — headings inside indented code / HTML blocks / comments are ignored, and a setext underline can no longer follow a block line.
- **`no-multiple-blank-lines`** — blank lines inside any block context are not counted, including blanks inside type 1–5 HTML blocks (e.g. `<pre>`) and multi-line HTML comments.

## Section B (markdownlint divergences — intentionally fenced-only)

`max-line-length` and `no-hard-tabs` deliberately skip **only** fenced code (`ctx.InFencedCode`), so long lines / tabs in indented code and HTML blocks are still reported. `no-hard-tabs` keeps its own inline-code stripping (`inline_strip.go`) rather than the shared sanitizer, because it must still report tabs inside inline HTML comments. `inline_strip.go` now documents that no-hard-tabs is its sole remaining consumer.

## Cleanups

`rule.IsClosingFence` is **removed** — the migrated style rules were its last callers, and the fence detector in `internal/preprocess` carries its own copy. Its test goes with it.

## Tests

- All existing rule tests pass against the new signatures (wrapped through `preprocess.Scan`).
- New `style_context_regression_test.go`:
  - `TestStyleFamilySkipsBlockContexts` — covers each gap closure (block contexts now skipped) for the five "skip-all-blocks" rules.
  - `TestSectionBStillChecksOutsideFencedCode` — **positive** guards asserting `max-line-length` / `no-hard-tabs` still fire inside indented code and HTML blocks, so a future "tidy" to the shared all-block skip is caught.
- Added a direct `TestOpeningFenceMarker` (sibling to `TestIsClosingFence`): migrating the style rules removed this helper's incidental coverage, and its only remaining caller (`CheckFencedCodeLanguage`) feeds it pre-validated openers, so its guard branches needed a direct test to keep 100%.
- `make test-all` clean, `make static-lint` clean, 100% coverage.
- `make bench`: flat (these rules weren't the heavy fence-trackers).

Refs #337. Closes #339.

