### PR TITLE
ci: replace benchmark code block with markdown table

### DIFF
--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -21,7 +21,7 @@ fi
 awk -v env_info="$ENV_INFO" '
   BEGIN {
     time_old=""; time_new=""; time_delta=""; time_status=""
-    heap_old=""; heap_new=""; heap_delta=""; heap_status=""
+    asize_old=""; asize_new=""; asize_delta=""; asize_status=""
     alloc_old=""; alloc_new=""; alloc_delta=""; alloc_status=""
     in_cmd_pkg=0
     current_metric=""
@@ -33,7 +33,7 @@ awk -v env_info="$ENV_INFO" '
   }
 
   /│[[:space:]]*sec\/op[[:space:]]*│/    { current_metric = "time";   next }
-  /│[[:space:]]*B\/op[[:space:]]*│/      { current_metric = "heap";   next }
+  /│[[:space:]]*B\/op[[:space:]]*│/      { current_metric = "alloc_size"; next }
   /│[[:space:]]*allocs\/op[[:space:]]*│/ { current_metric = "allocs"; next }
 
   /^geomean/ && in_cmd_pkg {
@@ -54,15 +54,15 @@ awk -v env_info="$ENV_INFO" '
 
     if (current_metric == "time") {
       time_old=old_val; time_new=new_val; time_delta=delta; time_status=status
-    } else if (current_metric == "heap") {
-      heap_old=old_val; heap_new=new_val; heap_delta=delta; heap_status=status
+    } else if (current_metric == "alloc_size") {
+      asize_old=old_val; asize_new=new_val; asize_delta=delta; asize_status=status
     } else if (current_metric == "allocs") {
       alloc_old=old_val; alloc_new=new_val; alloc_delta=delta; alloc_status=status
     }
   }
 
   END {
-    if (time_old == "" && heap_old == "" && alloc_old == "") {
+    if (time_old == "" && asize_old == "" && alloc_old == "") {
       print "No benchmark comparison data available."
       exit
     }
@@ -70,7 +70,7 @@ awk -v env_info="$ENV_INFO" '
     print "| Metric | main | PR | Change |"
     print "|------------|-----:|---:|-------:|"
     if (time_old  != "") printf "| Exec time   | %s | %s | %s %s |\n", time_old,  time_new,  time_delta,  time_status
-    if (heap_old  != "") printf "| Heap usage  | %s | %s | %s %s |\n", heap_old,  heap_new,  heap_delta,  heap_status
+    if (asize_old != "") printf "| Alloc size  | %s | %s | %s %s |\n", asize_old, asize_new, asize_delta, asize_status
     if (alloc_old != "") printf "| Alloc count | %s | %s | %s %s |\n", alloc_old, alloc_new, alloc_delta, alloc_status
 
     if (env_info != "") {

--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -1,109 +1,81 @@
 #!/bin/bash
-# Format benchmark comparison results with status symbols
+# Format benchmark comparison results as a markdown table
 
 set -e
 
 INPUT_FILE="$1"
 OUTPUT_FILE="$2"
+ENV_INFO="${3:-}"
 
-# Validate input file exists
 if [[ ! -f "$INPUT_FILE" ]]; then
   echo "Error: Input file '$INPUT_FILE' does not exist" >&2
   exit 1
 fi
 
-# Check if input file has content
 if [[ ! -s "$INPUT_FILE" ]]; then
   echo "Warning: Input file '$INPUT_FILE' is empty. No benchmark comparison available." >&2
   echo "No benchmark comparison data available." > "$OUTPUT_FILE"
   exit 0
 fi
 
-# Extract only geomean (summary) results for cleaner output
-awk '
-  # Print system info
-  /^goos:|^goarch:|^cpu:/ {
-    print
-    next
+awk -v env_info="$ENV_INFO" '
+  BEGIN {
+    time_old=""; time_new=""; time_delta=""; time_status=""
+    heap_old=""; heap_new=""; heap_delta=""; heap_status=""
+    alloc_old=""; alloc_new=""; alloc_delta=""; alloc_status=""
+    in_cmd_pkg=0
+    current_metric=""
   }
-  
-  # Track which package we are in
+
   /^pkg:/ {
-    current_pkg = $0
-    # Only process cmd package
-    if ($0 ~ /\/cmd$/) {
-      in_cmd_pkg = 1
-      print
-    } else {
-      in_cmd_pkg = 0
-    }
+    in_cmd_pkg = ($0 ~ /\/cmd$/) ? 1 : 0
     next
   }
-  
-  # Track which metric we are in (sec/op, B/op, allocs/op)
-  /│[[:space:]]*sec\/op[[:space:]]*│/ {
-    current_metric = "time"
-    next
-  }
-  /│[[:space:]]*B\/op[[:space:]]*│/ {
-    current_metric = "memory"
-    next
-  }
-  /│[[:space:]]*allocs\/op[[:space:]]*│/ {
-    current_metric = "allocs"
-    next
-  }
-  
-  # Process only geomean lines (summary statistics) for cmd package
-  /^geomean/ {
-    # Skip if not in cmd package
-    if (!in_cmd_pkg) {
-      next
-    }
-    
-    # Remove statistical annotations like ± ∞ ¹
+
+  /│[[:space:]]*sec\/op[[:space:]]*│/    { current_metric = "time";   next }
+  /│[[:space:]]*B\/op[[:space:]]*│/      { current_metric = "heap";   next }
+  /│[[:space:]]*allocs\/op[[:space:]]*│/ { current_metric = "allocs"; next }
+
+  /^geomean/ && in_cmd_pkg {
     gsub(/±[[:space:]]*∞[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
-    # Remove statistical notes like (p=... n=...) ²
     gsub(/\([^)]*\)[[:space:]]*[¹²³⁴⁵⁶⁷⁸⁹⁰]*/, "")
-    
-    # Extract delta percentage from last field
-    delta = $NF
-    status = ""
-    
-    # Check for positive change (+X.XX%)
+
+    old_val = $2
+    new_val = $3
+    delta   = $NF
+
+    status = "✅"
     if (delta ~ /^\+[0-9.]+%$/) {
-      # Extract the number
-      sub(/^\+/, "", delta)
-      sub(/%$/, "", delta)
-      percent = delta + 0
-      
-      if (percent >= 50) {
-        status = " ❌"
-      } else if (percent >= 10) {
-        status = " ⚠️"
-      } else {
-        status = " ✅"
-      }
-    } 
-    # Check for negative change (-X.XX%)
-    else if (delta ~ /^-[0-9.]+%$/) {
-      status = " ✅"  # Faster is good
-    } 
-    # No change
-    else if (delta == "~") {
-      status = " ✅"
+      num = delta
+      sub(/^\+/, "", num); sub(/%$/, "", num)
+      if (num + 0 >= 50)      status = "❌"
+      else if (num + 0 >= 10) status = "⚠️"
     }
-    
-    # Add metric label
-    metric_label = ""
+
     if (current_metric == "time") {
-      metric_label = " [time/op]"
-    } else if (current_metric == "memory") {
-      metric_label = " [memory/op]"
+      time_old=old_val; time_new=new_val; time_delta=delta; time_status=status
+    } else if (current_metric == "heap") {
+      heap_old=old_val; heap_new=new_val; heap_delta=delta; heap_status=status
     } else if (current_metric == "allocs") {
-      metric_label = " [allocs/op]"
+      alloc_old=old_val; alloc_new=new_val; alloc_delta=delta; alloc_status=status
     }
-    
-    print $0 status metric_label
+  }
+
+  END {
+    if (time_old == "" && heap_old == "" && alloc_old == "") {
+      print "No benchmark comparison data available."
+      exit
+    }
+
+    print "| Metric | main | PR | Change |"
+    print "|------------|-----:|---:|-------:|"
+    if (time_old  != "") printf "| Exec time   | %s | %s | %s %s |\n", time_old,  time_new,  time_delta,  time_status
+    if (heap_old  != "") printf "| Heap usage  | %s | %s | %s %s |\n", heap_old,  heap_new,  heap_delta,  heap_status
+    if (alloc_old != "") printf "| Alloc count | %s | %s | %s %s |\n", alloc_old, alloc_new, alloc_delta, alloc_status
+
+    if (env_info != "") {
+      print ""
+      print "> " env_info
+    }
   }
 ' "$INPUT_FILE" > "$OUTPUT_FILE"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,9 +50,9 @@ jobs:
         id: env_info
         run: |
           VCPU=$(nproc)
-          RAM_GB=$(awk '/MemTotal/ { printf "%.0f", $2/1024/1024 }' /proc/meminfo)
+          RAM_GB=$(awk '/MemTotal/ { printf "%d", $2/1024/1024 }' /proc/meminfo)
           CPU_MODEL=$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)
-          GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+          GO_VERSION=$(go version | awk '{print $3}' | sed 's/^go//')
           echo "value=ubuntu-latest (${VCPU} vCPU, ${RAM_GB} GB RAM) · CPU: ${CPU_MODEL} · Go: ${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Compare benchmarks
@@ -65,7 +65,7 @@ jobs:
             echo ""
             echo "Comparing PR branch against main branch:"
             echo ""
-            echo "**Legend**: ✅ OK (no change or faster) | ⚠️ Caution (+10~50% slower) | ❌ Regression (+50%+ slower)"
+            echo "**Legend**: ✅ OK (≤0% or no change) | ⚠️ Caution (+10~50%) | ❌ Regression (+50%+)"
             echo ""
             benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
             bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "$ENV_INFO"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,6 +46,15 @@ jobs:
       - name: Run benchmarks on main branch
         run: make bench | tee old-bench.txt
 
+      - name: Collect environment info
+        id: env_info
+        run: |
+          VCPU=$(nproc)
+          RAM_GB=$(awk '/MemTotal/ { printf "%.0f", $2/1024/1024 }' /proc/meminfo)
+          CPU_MODEL=$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)
+          GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+          echo "value=ubuntu-latest (${VCPU} vCPU, ${RAM_GB} GB RAM) · CPU: ${CPU_MODEL} · Go: ${GO_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Compare benchmarks
         id: benchmark_comparison
         run: |
@@ -56,11 +65,9 @@ jobs:
             echo ""
             echo "**Legend**: ✅ OK (no change or faster) | ⚠️ Caution (+10~50% slower) | ❌ Regression (+50%+ slower)"
             echo ""
-            echo '```'
             benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
-            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt
+            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "${{ steps.env_info.outputs.value }}"
             cat formatted-comparison.txt
-            echo '```'
           } > comparison.txt
           cat comparison.txt
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Compare benchmarks
         id: benchmark_comparison
+        env:
+          ENV_INFO: ${{ steps.env_info.outputs.value }}
         run: |
           {
             echo "## Benchmark Comparison"
@@ -66,7 +68,7 @@ jobs:
             echo "**Legend**: ✅ OK (no change or faster) | ⚠️ Caution (+10~50% slower) | ❌ Regression (+50%+ slower)"
             echo ""
             benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
-            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "${{ steps.env_info.outputs.value }}"
+            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "$ENV_INFO"
             cat formatted-comparison.txt
           } > comparison.txt
           cat comparison.txt


### PR DESCRIPTION
## Summary

- Replaces the raw `geomean` text block in benchmark PR comments with a readable markdown table
- Renames metrics from Go jargon (`geomean [time/op]` etc.) to plain English: **Exec time**, **Heap usage**, **Alloc count**
- Adds an environment footer (vCPU, RAM, CPU model, Go version) collected dynamically at runtime — useful for explaining differences in absolute values across runs
- Drops noisy `goos` / `goarch` / `pkg` lines

**Before:**
```
goos: linux
goarch: amd64
pkg: github.com/shinagawa-web/gomarklint/v3/cmd
cpu: AMD EPYC 7763 64-Core Processor
geomean    13.11m    13.25m    +1.09% ✅ [time/op]
geomean    1.698Mi   1.696Mi   -0.12% ✅ [memory/op]
geomean    4.513k    4.513k    -0.00% ✅ [allocs/op]
```

**After:**
| Metric | main | PR | Change |
|------------|-----:|---:|-------:|
| Exec time   | 13.11m | 13.25m | +1.09% ✅ |
| Heap usage  | 1.698Mi | 1.696Mi | -0.12% ✅ |
| Alloc count | 4.513k | 4.513k | -0.00% ✅ |

> ubuntu-latest (4 vCPU, 15 GB RAM) · CPU: AMD EPYC 7763 · Go: 1.24.2

Closes #391