### PR TITLE
ci: map bench: prefix to test label in auto-label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -38,7 +38,8 @@ jobs:
             if (title.startsWith('refactor:') || title.startsWith('refactor(')) {
               labels.push('refactor');
             }
-            if (title.startsWith('test:') || title.startsWith('test(')) {
+            if (title.startsWith('test:') || title.startsWith('test(') ||
+                title.startsWith('bench:') || title.startsWith('bench(')) {
               labels.push('test');
             }
             if (title.startsWith('deps:') || title.startsWith('deps(') || title.includes('dependencies')) {


### PR DESCRIPTION
## Summary

- PRs with `bench:` or `bench(...)` title prefix were not matched by the auto-label workflow, causing `check-labels` to fail
- Map `bench:` to the `test` label, consistent with how benchmark PRs are classified