### PR TITLE
bench: reorder benchmarks — FullLinting, FullLinting_ExtraLarge, EndToEnd

### DIFF
--- a/.github/scripts/format-benchmark.sh
+++ b/.github/scripts/format-benchmark.sh
@@ -6,6 +6,13 @@ set -e
 INPUT_FILE="$1"
 OUTPUT_FILE="$2"
 ENV_INFO="${3:-}"
+NEW_BENCH_FILE="${4:-}"
+
+# Extract PR benchmark order from new-bench.txt (strip Benchmark prefix, deduplicate)
+PR_ORDER=""
+if [[ -n "$NEW_BENCH_FILE" && -f "$NEW_BENCH_FILE" ]]; then
+  PR_ORDER=$(grep '^Benchmark' "$NEW_BENCH_FILE" | awk '{print $1}' | sed 's/^Benchmark//' | awk '!seen[$0]++' | tr '\n' ',')
+fi
 
 if [[ ! -f "$INPUT_FILE" ]]; then
   echo "Error: Input file '$INPUT_FILE' does not exist" >&2
@@ -18,7 +25,7 @@ if [[ ! -s "$INPUT_FILE" ]]; then
   exit 0
 fi
 
-awk -v env_info="$ENV_INFO" '
+awk -v env_info="$ENV_INFO" -v pr_order="$PR_ORDER" '
   function parse_val(v,    num, suffix) {
     num = v + 0
     suffix = v
@@ -102,14 +109,30 @@ awk -v env_info="$ENV_INFO" '
 
     print "| Benchmark | Metric | main | PR | Change |"
     print "|-----------|--------|-----:|---:|-------:|"
-    for (i = 0; i < bench_count; i++) {
-      name = bench_names[i]
-      for (mi = 1; mi <= n_metrics; mi++) {
-        mk = metric_keys[mi]
-        if (data[name, mk, "old"] == "") continue
-        printf "| %s | %s | %s | %s | %s%s |\n", \
-          name, metric_labels[mi], data[name, mk, "old"], data[name, mk, "new"], \
-          data[name, mk, "delta"], data[name, mk, "status"]
+
+    if (pr_order != "") {
+      n_ordered = split(pr_order, ordered_names, ",")
+      for (i = 1; i <= n_ordered; i++) {
+        name = ordered_names[i]
+        if (name == "" || !(name in seen)) continue
+        for (mi = 1; mi <= n_metrics; mi++) {
+          mk = metric_keys[mi]
+          if (data[name, mk, "old"] == "") continue
+          printf "| %s | %s | %s | %s | %s%s |\n", \
+            name, metric_labels[mi], data[name, mk, "old"], data[name, mk, "new"], \
+            data[name, mk, "delta"], data[name, mk, "status"]
+        }
+      }
+    } else {
+      for (i = 0; i < bench_count; i++) {
+        name = bench_names[i]
+        for (mi = 1; mi <= n_metrics; mi++) {
+          mk = metric_keys[mi]
+          if (data[name, mk, "old"] == "") continue
+          printf "| %s | %s | %s | %s | %s%s |\n", \
+            name, metric_labels[mi], data[name, mk, "old"], data[name, mk, "new"], \
+            data[name, mk, "delta"], data[name, mk, "status"]
+        }
       }
     }
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -70,7 +70,7 @@ jobs:
             echo "**Legend**: ✅ OK (≤0% or no change) | ⚠️ Caution (+10~50%) | ❌ Regression (+50%+)"
             echo ""
             benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
-            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "$ENV_INFO"
+            bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "$ENV_INFO" new-bench.txt
             cat formatted-comparison.txt
           } > comparison.txt
           cat comparison.txt

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -124,6 +124,20 @@ func BenchmarkFullLinting(b *testing.B) {
 	}
 }
 
+func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
+	content := generateComplexMarkdown(5000)
+	cfg := benchmarkConfig()
+	lint, err := linter.New(cfg)
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = lint.LintContent("benchmark.md", content)
+	}
+}
+
 // BenchmarkEndToEnd exercises the full lint.Run path: file discovery, concurrent
 // file reading, goroutine fan-out with mutex, and result collection.
 // 50 files × 100 sections each (~1700 lines/file, ~85k lines total).
@@ -147,19 +161,5 @@ func BenchmarkEndToEnd(b *testing.B) {
 	for b.Loop() {
 		paths := file.ExpandPaths([]string{dir}, cfg.Ignore)
 		_ = lint.Run(paths)
-	}
-}
-
-func BenchmarkFullLinting_ExtraLarge(b *testing.B) {
-	content := generateComplexMarkdown(5000)
-	cfg := benchmarkConfig()
-	lint, err := linter.New(cfg)
-	if err != nil {
-		b.Fatalf("unexpected error: %v", err)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _, _ = lint.LintContent("benchmark.md", content)
 	}
 }


### PR DESCRIPTION
## Summary

- Move `BenchmarkEndToEnd` after `BenchmarkFullLinting_ExtraLarge` so the PR benchmark table reads in a consistent order: FullLinting → FullLinting_ExtraLarge → EndToEnd