### PR TITLE
bench: add CPU profile delta for time/op regressions

### DIFF
--- a/.github/scripts/format-profile-delta.sh
+++ b/.github/scripts/format-profile-delta.sh
@@ -46,8 +46,9 @@ for bench in $REGRESSING; do
   echo "| Function | Δ cum |"
   echo "|---|---:|"
   go tool pprof "${PPROF_ARGS_CUM[@]}" 2>/dev/null | \
-    awk 'NR>5 && NF>=6 && /(gomarklint|shinagawa-web)/ && /^\s*\+/ {
-      printf "| %s | %s |\n", $NF, $4
+    awk 'NR>5 && NF>=6 && /(gomarklint|shinagawa-web)/ && $4 ~ /^[0-9]/ {
+      name = ($NF == "(inline)") ? $(NF-1) : $NF
+      printf "| %s | %s |\n", name, $4
     }' | head -10
   echo ""
 
@@ -56,8 +57,9 @@ for bench in $REGRESSING; do
   echo "| Function | Δ flat |"
   echo "|---|---:|"
   go tool pprof "${PPROF_ARGS_FLAT[@]}" 2>/dev/null | \
-    awk 'NR>5 && NF>=6 && /^\s*\+/ {
-      printf "| %s | %s |\n", $NF, $1
+    awk 'NR>5 && NF>=6 && $1 ~ /^[0-9]/ {
+      name = ($NF == "(inline)") ? $(NF-1) : $NF
+      printf "| %s | %s |\n", name, $1
     }' | head -10
   echo ""
 done

--- a/.github/scripts/format-profile-delta.sh
+++ b/.github/scripts/format-profile-delta.sh
@@ -6,8 +6,8 @@ set -e
 COMPARISON_FILE="$1"
 PROFILES_DIR="${2:-profiles}"
 
-# Find regressing benchmarks: time/op rows without ✅
-REGRESSING=$(grep 'time/op' "$COMPARISON_FILE" | grep -v '✅' | awk -F'|' '{
+# Find regressing benchmarks: time/op rows with explicit ⚠️ or ❌ marker
+REGRESSING=$(grep 'time/op' "$COMPARISON_FILE" | grep -E '⚠️|❌' | awk -F'|' '{
   name = $2
   gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
   gsub(/-[0-9]+$/, "", name)

--- a/.github/scripts/format-profile-delta.sh
+++ b/.github/scripts/format-profile-delta.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Append CPU profile delta sections for benchmarks with time/op regression (⚠️ or ❌)
+
+set -e
+
+COMPARISON_FILE="$1"
+PROFILES_DIR="${2:-profiles}"
+
+# Find regressing benchmarks: time/op rows without ✅
+REGRESSING=$(grep 'time/op' "$COMPARISON_FILE" | grep -v '✅' | awk -F'|' '{
+  name = $2
+  gsub(/^[[:space:]]+|[[:space:]]+$/, "", name)
+  gsub(/-[0-9]+$/, "", name)
+  print "Benchmark" name
+}')
+
+[[ -z "$REGRESSING" ]] && exit 0
+
+echo ""
+echo "---"
+
+for bench in $REGRESSING; do
+  old_prof="${PROFILES_DIR}/old-${bench}.prof"
+  new_prof="${PROFILES_DIR}/new-${bench}.prof"
+  new_bin="${PROFILES_DIR}/new-${bench}.test"
+
+  [[ ! -f "$old_prof" || ! -f "$new_prof" ]] && continue
+
+  short="${bench#Benchmark}"
+  echo ""
+  echo "### CPU Profile Delta — \`${short}\`"
+  echo ""
+
+  # Build pprof args — include binary only if it exists
+  PPROF_ARGS_CUM=("-top" "-cum" "-base=${old_prof}")
+  PPROF_ARGS_FLAT=("-top" "-base=${old_prof}")
+  if [[ -f "$new_bin" ]]; then
+    PPROF_ARGS_CUM+=("$new_bin")
+    PPROF_ARGS_FLAT+=("$new_bin")
+  fi
+  PPROF_ARGS_CUM+=("$new_prof")
+  PPROF_ARGS_FLAT+=("$new_prof")
+
+  echo "**Which rule got slower** — gomarklint functions, sorted by cum delta:"
+  echo ""
+  echo "| Function | Δ cum |"
+  echo "|---|---:|"
+  go tool pprof "${PPROF_ARGS_CUM[@]}" 2>/dev/null | \
+    awk 'NR>5 && NF>=6 && /(gomarklint|shinagawa-web)/ && /^\s*\+/ {
+      printf "| %s | %s |\n", $NF, $4
+    }' | head -10
+  echo ""
+
+  echo "**What operation got more expensive** — all functions, sorted by flat delta:"
+  echo ""
+  echo "| Function | Δ flat |"
+  echo "|---|---:|"
+  go tool pprof "${PPROF_ARGS_FLAT[@]}" 2>/dev/null | \
+    awk 'NR>5 && NF>=6 && /^\s*\+/ {
+      printf "| %s | %s |\n", $NF, $1
+    }' | head -10
+  echo ""
+done

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,9 +32,21 @@ jobs:
       - name: Run benchmarks on PR branch
         run: make bench BENCH_COUNT=6 | tee new-bench.txt
 
+      - name: Profile benchmarks on PR branch
+        run: |
+          mkdir -p profiles
+          grep '^Benchmark' new-bench.txt | awk '{print $1}' | sed 's/-[0-9]*$//' | sort -u > profiles/bench-names.txt
+          while IFS= read -r bench; do
+            go test -bench="^${bench}$" -benchmem -count=1 \
+              -cpuprofile="profiles/new-${bench}.prof" \
+              -o "profiles/new-${bench}.test" \
+              -run=^$ ./cmd/ > /dev/null 2>&1 || true
+          done < profiles/bench-names.txt
+
       - name: Save benchmark script and Makefile from PR branch
         run: |
           cp .github/scripts/format-benchmark.sh /tmp/format-benchmark.sh
+          cp .github/scripts/format-profile-delta.sh /tmp/format-profile-delta.sh
           cp Makefile /tmp/Makefile
 
       - name: Checkout main branch
@@ -47,6 +59,15 @@ jobs:
 
       - name: Run benchmarks on main branch
         run: make -f /tmp/Makefile bench BENCH_COUNT=6 | tee old-bench.txt
+
+      - name: Profile benchmarks on main branch
+        run: |
+          while IFS= read -r bench; do
+            go test -bench="^${bench}$" -benchmem -count=1 \
+              -cpuprofile="profiles/old-${bench}.prof" \
+              -o "profiles/old-${bench}.test" \
+              -run=^$ ./cmd/ > /dev/null 2>&1 || true
+          done < profiles/bench-names.txt
 
       - name: Collect environment info
         id: env_info
@@ -72,6 +93,7 @@ jobs:
             benchstat old-bench.txt new-bench.txt > raw-comparison.txt || true
             bash /tmp/format-benchmark.sh raw-comparison.txt formatted-comparison.txt "$ENV_INFO" new-bench.txt
             cat formatted-comparison.txt
+            bash /tmp/format-profile-delta.sh formatted-comparison.txt profiles/
           } > comparison.txt
           cat comparison.txt
 
@@ -83,6 +105,7 @@ jobs:
             old-bench.txt
             new-bench.txt
             comparison.txt
+            profiles/
 
       - name: Comment PR with benchmark results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ npm/node_modules/
 .claude/worktrees/
 .claude/settings.local.json
 .claude/memory/
+
+# Go test binary
+cmd.test

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
 	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 	"github.com/shinagawa-web/gomarklint/v3/internal/file"
 	"github.com/shinagawa-web/gomarklint/v3/internal/linter"
@@ -122,8 +120,17 @@ func BenchmarkFullLinting(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _, _ = lint.LintContent("benchmark.md", content)
-		time.Sleep(3 * time.Millisecond) // artificial regression to test CPU profile delta
+		artificialCPUWork() // artificial regression to test CPU profile delta
 	}
+}
+
+// artificialCPUWork simulates a CPU regression for testing the CPU profile delta feature.
+func artificialCPUWork() {
+	result := 0
+	for i := 0; i < 500000; i++ {
+		result += i * i
+	}
+	_ = result
 }
 
 func BenchmarkFullLinting_ExtraLarge(b *testing.B) {

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -128,7 +128,7 @@ func BenchmarkFullLinting(b *testing.B) {
 // artificialCPUWork simulates a CPU regression for testing the CPU profile delta feature.
 func artificialCPUWork() {
 	result := 0
-	for i := 0; i < 500000; i++ {
+	for i := 0; i < 10000000; i++ {
 		result += i * i
 	}
 	_ = result

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -121,17 +121,7 @@ func BenchmarkFullLinting(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _, _ = lint.LintContent("benchmark.md", content)
-		artificialCPUWork() // artificial regression to test CPU profile delta
 	}
-}
-
-// artificialCPUWork simulates a CPU regression for testing the CPU profile delta feature.
-func artificialCPUWork() {
-	result := 0
-	for i := 0; i < 10000000; i++ {
-		result += i * i
-	}
-	_ = result
 }
 
 func BenchmarkFullLinting_ExtraLarge(b *testing.B) {

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
 	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 	"github.com/shinagawa-web/gomarklint/v3/internal/file"
 	"github.com/shinagawa-web/gomarklint/v3/internal/linter"

--- a/cmd/root_bench_test.go
+++ b/cmd/root_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/shinagawa-web/gomarklint/v3/internal/config"
 	"github.com/shinagawa-web/gomarklint/v3/internal/file"
@@ -121,6 +122,7 @@ func BenchmarkFullLinting(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _, _ = lint.LintContent("benchmark.md", content)
+		time.Sleep(3 * time.Millisecond) // artificial regression to test CPU profile delta
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #395

When a benchmark shows ⚠️ or ❌ in `time/op`, the PR benchmark comment now includes a **CPU Profile Delta** section showing:

- **Which rule got slower** — gomarklint functions sorted by cumulative delta
- **What operation got more expensive** — all functions sorted by flat delta

### Design decisions

- Profiling runs are **separate** from the `BENCH_COUNT=6` timing runs — adding `-cpuprofile` to the timing runs would skew the measurements
- Profiles are taken for all benchmarks (`BenchmarkFullLinting`, `BenchmarkFullLinting_ExtraLarge`, `BenchmarkEndToEnd`) but the Delta section is only shown when regression is detected
- Test binaries are saved alongside profiles for `go tool pprof` symbol resolution
- All profile files are uploaded as artifacts for local investigation

### Example output (when regression detected)

---

### CPU Profile Delta — `FullLinting`

**Which rule got slower** — gomarklint functions, sorted by cum delta:

| Function | Δ cum |
|---|---:|
| rule.CheckBlanksAroundFences | +120ms |

**What operation got more expensive** — all functions, sorted by flat delta:

| Function | Δ flat |
|---|---:|
| strings.TrimSpace | +80ms |

---

When no regression is detected, this section is not shown.