### PR TITLE
refactor: remove redundant comments from source files

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,19 +13,15 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
-// ErrLintViolations is returned when error-severity violations are found.
 var ErrLintViolations = errors.New("lint violations found")
 
-// Options holds the parameters for a lint run.
 type Options struct {
-	ConfigPath   string              // path to config file
-	Args         []string            // files/dirs to lint
-	OutputFormat string              // overrides config if non-empty
-	MinSeverity  config.RuleSeverity // overrides config if non-empty
+	ConfigPath   string
+	Args         []string
+	OutputFormat string
+	MinSeverity  config.RuleSeverity
 }
 
-// Run loads config, lints files, and writes results to w.
-// Returns ErrLintViolations if any error-severity violations are found.
 func Run(w io.Writer, opts Options) error {
 	start := time.Now()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,12 +146,12 @@ func (r *RuleConfig) applyObjectField(k string, v json.RawMessage) error {
 }
 
 type Config struct {
-	Default      bool                    `json:"default"`
-	Rules        map[string]*RuleConfig  `json:"rules"`
-	Include      []string                `json:"include"`
-	Ignore       []string                `json:"ignore"`
-	OutputFormat string                  `json:"output"`
-	MinSeverity  RuleSeverity            `json:"-"`
+	Default      bool                   `json:"default"`
+	Rules        map[string]*RuleConfig `json:"rules"`
+	Include      []string               `json:"include"`
+	Ignore       []string               `json:"ignore"`
+	OutputFormat string                 `json:"output"`
+	MinSeverity  RuleSeverity           `json:"-"`
 }
 
 func (c *Config) IsEnabled(name string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 )
 
-// DefaultNoTrailingPunctuation is the default punctuation set for the no-trailing-punctuation rule.
 const DefaultNoTrailingPunctuation = ".,;:!"
 
 // DefaultConfigJSON is the canonical JSON written by `gomarklint init`.
@@ -43,7 +42,6 @@ const DefaultConfigJSON = `{
 }
 `
 
-// RuleSeverity represents the severity level of a rule violation.
 type RuleSeverity string
 
 const (
@@ -52,20 +50,12 @@ const (
 	SeverityOff     RuleSeverity = "off"
 )
 
-// RuleConfig holds per-rule configuration.
-// It supports three JSON shorthand forms:
-//
-//	true             → enabled, severity = "error"
-//	false            → disabled
-//	"warning"        → enabled, severity = "warning"
-//	{"enabled": true, "severity": "warning", ...options}
 type RuleConfig struct {
 	Enabled  bool
 	Severity RuleSeverity
 	Options  map[string]interface{}
 }
 
-// UnmarshalJSON handles bool, string, and object forms.
 func (r *RuleConfig) UnmarshalJSON(data []byte) error {
 	var b bool
 	if err := json.Unmarshal(data, &b); err == nil {
@@ -155,30 +145,15 @@ func (r *RuleConfig) applyObjectField(k string, v json.RawMessage) error {
 	return nil
 }
 
-// Config defines the options for gomarklint, loaded from a config file.
 type Config struct {
-	// Default controls whether rules are enabled by default when not listed in Rules.
-	// true = all rules on by default; false = opt-in mode (only listed rules run).
-	Default bool `json:"default"`
-
-	// Rules maps rule keys to their configuration.
-	Rules map[string]*RuleConfig `json:"rules"`
-
-	// Include lists files or directories to lint when no arguments are given.
-	Include []string `json:"include"`
-
-	// Ignore lists glob patterns to exclude from linting.
-	Ignore []string `json:"ignore"`
-
-	// OutputFormat controls output: "text" or "json".
-	OutputFormat string `json:"output"`
-
-	// MinSeverity filters output: only report rules at or above this severity ("warning" or "error").
-	// This field is not serialized to JSON; it is set via CLI flag only.
-	MinSeverity RuleSeverity `json:"-"`
+	Default      bool                    `json:"default"`
+	Rules        map[string]*RuleConfig  `json:"rules"`
+	Include      []string                `json:"include"`
+	Ignore       []string                `json:"ignore"`
+	OutputFormat string                  `json:"output"`
+	MinSeverity  RuleSeverity            `json:"-"`
 }
 
-// IsEnabled reports whether the named rule should run.
 func (c *Config) IsEnabled(name string) bool {
 	rc, ok := c.Rules[name]
 	if !ok || rc == nil {
@@ -187,7 +162,6 @@ func (c *Config) IsEnabled(name string) bool {
 	return rc.Enabled
 }
 
-// RuleOptions returns the options map for the named rule, or an empty map.
 func (c *Config) RuleOptions(name string) map[string]interface{} {
 	rc, ok := c.Rules[name]
 	if !ok || rc == nil || rc.Options == nil {
@@ -196,8 +170,6 @@ func (c *Config) RuleOptions(name string) map[string]interface{} {
 	return rc.Options
 }
 
-// RuleSeverity returns the configured severity for the named rule.
-// Returns "error" if the rule is not listed or has no severity set.
 func (c *Config) RuleSeverity(name string) string {
 	rc, ok := c.Rules[name]
 	if !ok || rc == nil || rc.Severity == "" {
@@ -206,12 +178,10 @@ func (c *Config) RuleSeverity(name string) string {
 	return string(rc.Severity)
 }
 
-// enabledRule returns a RuleConfig with Enabled=true, Severity=error, and no options.
 func enabledRule() *RuleConfig {
 	return &RuleConfig{Enabled: true, Severity: SeverityError, Options: map[string]interface{}{}}
 }
 
-// Default returns the default configuration with all standard rules enabled.
 func Default() Config {
 	return Config{
 		Default: true,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -7,8 +7,6 @@ import (
 	"os"
 )
 
-// LoadConfig reads the config file from the given path and returns a Config object.
-// If the file is missing or unreadable, an error is returned.
 func LoadConfig(path string) (Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -7,13 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// FlagValues holds the command-line flag values.
 type FlagValues struct {
 	OutputFormat string
 	MinSeverity  string
 }
 
-// LoadOrDefault loads configuration from file if it exists, otherwise returns default config.
 func LoadOrDefault(configPath string) (Config, error) {
 	if _, err := os.Stat(configPath); err != nil {
 		if os.IsNotExist(err) {
@@ -24,7 +22,6 @@ func LoadOrDefault(configPath string) (Config, error) {
 	return LoadConfig(configPath)
 }
 
-// MergeFlags merges command-line flag values into the config, respecting which flags were actually set.
 func MergeFlags(cfg Config, cmd *cobra.Command, flags FlagValues) Config {
 	if cmd.Flags().Changed("output") {
 		cfg.OutputFormat = flags.OutputFormat
@@ -35,14 +32,12 @@ func MergeFlags(cfg Config, cmd *cobra.Command, flags FlagValues) Config {
 	return cfg
 }
 
-// Validate checks if the configuration values are valid.
 func Validate(cfg Config) error {
 	if cfg.OutputFormat != "text" && cfg.OutputFormat != "json" {
 		return fmt.Errorf("invalid output format: %q (must be 'text' or 'json')", cfg.OutputFormat)
 	}
 	switch cfg.MinSeverity {
 	case SeverityWarning, SeverityError:
-		// valid
 	default:
 		return fmt.Errorf("invalid severity: %q (must be 'warning' or 'error')", cfg.MinSeverity)
 	}

--- a/internal/file/expand.go
+++ b/internal/file/expand.go
@@ -6,19 +6,6 @@ import (
 	"strings"
 )
 
-// ExpandPaths takes a list of file or directory paths and returns a slice of
-// all Markdown (.md) file paths found.
-//
-// It handles the following behavior:
-//   - Recursively searches directories for files ending in .md
-//   - Skips hidden directories (e.g., .git/)
-//   - Ignores non-existent paths without failing
-//   - Does not follow symbolic links
-//
-// Example:
-//
-//	input:  []string{"docs", "README.md"}
-//	output: ["docs/a.md", "docs/sub/b.md", "README.md"]
 func ExpandPaths(paths []string, ignorePatterns []string) []string {
 	var results []string
 

--- a/internal/file/pathutil.go
+++ b/internal/file/pathutil.go
@@ -4,7 +4,6 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// shouldIgnore checks if the given path matches any of the ignore patterns.
 func ShouldIgnore(path string, patterns []string) bool {
 	for _, pattern := range patterns {
 		matched, err := doublestar.PathMatch(pattern, path)

--- a/internal/file/reader.go
+++ b/internal/file/reader.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 )
 
-// ReadFile reads the content of a file and returns it as a string.
 func ReadFile(path string) (string, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -14,7 +13,6 @@ func ReadFile(path string) (string, error) {
 	return string(bytes), nil
 }
 
-// StripFrontmatter removes the YAML frontmatter and returns the remaining content and the number of lines stripped.
 func StripFrontmatter(content string) (string, int) {
 	lines := strings.Split(content, "\n")
 	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "---" {

--- a/internal/linter/disable_comment.go
+++ b/internal/linter/disable_comment.go
@@ -27,7 +27,6 @@ func (ld lineDisable) isRuleDisabled(ruleName string) bool {
 	return false
 }
 
-// disabledSet maps absolute line numbers to their disable state.
 type disabledSet map[int]lineDisable
 
 func (d disabledSet) isDisabled(line int, ruleName string) bool {
@@ -50,7 +49,6 @@ func (d disabledSet) addLine(line int, ruleNames []string) {
 	d[line] = lineDisable{names: append(existing.names, ruleNames...)}
 }
 
-// blockState holds the current block-level disable state while scanning lines.
 type blockState struct {
 	allDisabled bool
 	exceptions  []string // re-enabled rules when allDisabled=true
@@ -73,16 +71,12 @@ func (bs *blockState) applyTo(set disabledSet, absLine int) {
 		set[absLine] = lineDisable{allDisabled: true, names: bs.exceptions}
 		return
 	}
-	// named-disable mode
 	if exists && existing.allDisabled {
 		return // all-disabled takes priority
 	}
 	set[absLine] = lineDisable{names: append(existing.names, bs.rules...)}
 }
 
-// parseDisableComments scans lines for gomarklint-disable directives and returns
-// a disabledSet mapping absolute line numbers to the set of disabled rules.
-// offset is the frontmatter line count used to compute absolute line numbers.
 func parseDisableComments(lines []string, offset int) disabledSet {
 	set := make(disabledSet)
 	var bs blockState
@@ -120,7 +114,6 @@ func parseDisableComments(lines []string, offset int) disabledSet {
 	return set
 }
 
-// removeAll returns s with all elements in remove filtered out.
 func removeAll(s []string, remove []string) []string {
 	result := s[:0]
 	for _, v := range s {
@@ -138,9 +131,6 @@ func removeAll(s []string, remove []string) []string {
 	return result
 }
 
-// parseDirectiveLine extracts the directive keyword and optional rule names
-// from a gomarklint HTML comment directive on a line.
-// Returns ("", nil) when no valid directive is found.
 func parseDirectiveLine(line string) (directive string, ruleNames []string) {
 	start := strings.Index(line, "<!--")
 	if start == -1 {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -14,26 +14,22 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
-// Linter performs linting on markdown files.
 type Linter struct {
 	config           config.Config
 	compiledPatterns []*regexp.Regexp
 	urlCache         *sync.Map
 }
 
-// Result holds the results of a linting run.
 type Result struct {
-	Errors            map[string][]rule.LintError // All violations (errors + warnings) per file path
-	OrderedPaths      []string                    // Sorted file paths
-	TotalErrors       int                         // Count of severity=error violations (used for exit code)
-	TotalWarnings     int                         // Count of severity=warning violations
-	TotalLines        int                         // Total number of lines checked
-	TotalLinksChecked int                         // Total number of links checked
-	FailedFiles       map[string]error            // Files that failed to read
+	Errors            map[string][]rule.LintError
+	OrderedPaths      []string
+	TotalErrors       int
+	TotalWarnings     int
+	TotalLines        int
+	TotalLinksChecked int
+	FailedFiles       map[string]error
 }
 
-// New creates a new Linter with the given configuration.
-// Returns an error if any rule option value is invalid.
 func New(cfg config.Config) (*Linter, error) {
 	if err := validateStyleOption(cfg, "consistent-code-fence", "style", []string{"consistent", "backtick", "tilde"}); err != nil {
 		return nil, err
@@ -84,8 +80,6 @@ func New(cfg config.Config) (*Linter, error) {
 	}, nil
 }
 
-// validateStyleOption checks that the named option for a rule, if present and non-empty,
-// is one of the valid values. Returns a descriptive error if not.
 func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []string) error {
 	opts := cfg.RuleOptions(ruleName)
 	raw, exists := opts[optKey]
@@ -107,8 +101,7 @@ func validateStyleOption(cfg config.Config, ruleName, optKey string, valid []str
 	return fmt.Errorf("gomarklint: invalid value %q for %s.%s (valid values: %s)", val, ruleName, optKey, strings.Join(valid, ", "))
 }
 
-// validatePerHostIntervalMs checks that perHostIntervalMs is either 0 (disabled) or within
-// [MinPerHostIntervalMs, MaxPerHostIntervalMsLimit]. Values between 1 and 999 are rejected.
+// validatePerHostIntervalMs rejects values between 1 and 999 (too small to be intentional).
 func validatePerHostIntervalMs(cfg config.Config) error {
 	raw, exists := cfg.RuleOptions("external-link")["perHostIntervalMs"]
 	if !exists {
@@ -128,8 +121,6 @@ func validatePerHostIntervalMs(cfg config.Config) error {
 	return nil
 }
 
-// validateExternalLinkIntOption checks that a numeric external-link option, if present,
-// is within [minVal, maxVal]. Returns a descriptive error if not.
 func validateExternalLinkIntOption(cfg config.Config, optKey string, minVal, maxVal int) error {
 	raw, exists := cfg.RuleOptions("external-link")[optKey]
 	if !exists {
@@ -146,7 +137,6 @@ func validateExternalLinkIntOption(cfg config.Config, optKey string, minVal, max
 	return nil
 }
 
-// Run performs linting on the given file paths concurrently.
 func (l *Linter) Run(filePaths []string) *Result {
 	// Deduplicate file paths to prevent double-counting
 	uniquePaths := make(map[string]struct{})
@@ -202,7 +192,6 @@ func (l *Linter) Run(filePaths []string) *Result {
 
 	wg.Wait()
 
-	// Sort paths to ensure consistent output order
 	sort.Strings(orderedPaths)
 
 	return &Result{
@@ -216,13 +205,10 @@ func (l *Linter) Run(filePaths []string) *Result {
 	}
 }
 
-// LintContent performs linting checks on the provided content string.
-// This is useful for benchmarking and testing without file I/O overhead.
 func (l *Linter) LintContent(path string, content string) ([]rule.LintError, int, int) {
 	return l.collectErrors(path, content)
 }
 
-// withSeverity tags each error in errs with the configured severity and rule name.
 func (l *Linter) withSeverity(errs []rule.LintError, ruleName string) []rule.LintError {
 	sev := l.config.RuleSeverity(ruleName)
 	for i := range errs {
@@ -232,7 +218,6 @@ func (l *Linter) withSeverity(errs []rule.LintError, ruleName string) []rule.Lin
 	return errs
 }
 
-// headingMinLevel returns the configured minLevel for the heading-level rule.
 func (l *Linter) headingMinLevel() int {
 	minLevel := 2
 	if v, ok := l.config.RuleOptions("heading-level")["minLevel"]; ok {
@@ -243,7 +228,6 @@ func (l *Linter) headingMinLevel() int {
 	return minLevel
 }
 
-// noTrailingPunctuation returns the configured punctuation string for the no-trailing-punctuation rule.
 func (l *Linter) noTrailingPunctuation() string {
 	if v, ok := l.config.RuleOptions("no-trailing-punctuation")["punctuation"]; ok {
 		if s, ok := v.(string); ok {
@@ -253,7 +237,6 @@ func (l *Linter) noTrailingPunctuation() string {
 	return config.DefaultNoTrailingPunctuation
 }
 
-// consistentCodeFenceStyle returns the configured style for the consistent-code-fence rule.
 func (l *Linter) consistentCodeFenceStyle() string {
 	style, _ := l.config.RuleOptions("consistent-code-fence")["style"].(string)
 	if style == "" {
@@ -262,7 +245,6 @@ func (l *Linter) consistentCodeFenceStyle() string {
 	return style
 }
 
-// consistentEmphasisStyle returns the configured style for the consistent-emphasis-style rule.
 func (l *Linter) consistentEmphasisStyle() string {
 	style, _ := l.config.RuleOptions("consistent-emphasis-style")["style"].(string)
 	if style == "" {
@@ -271,7 +253,6 @@ func (l *Linter) consistentEmphasisStyle() string {
 	return style
 }
 
-// consistentListMarkerStyle returns the configured style for the consistent-list-marker rule.
 func (l *Linter) consistentListMarkerStyle() string {
 	style, _ := l.config.RuleOptions("consistent-list-marker")["style"].(string)
 	if style == "" {
@@ -280,7 +261,6 @@ func (l *Linter) consistentListMarkerStyle() string {
 	return style
 }
 
-// maxLineLength returns the configured lineLength for the max-line-length rule.
 func (l *Linter) maxLineLength() int {
 	lineLength := 80
 	if v, ok := l.config.RuleOptions("max-line-length")["lineLength"]; ok {
@@ -291,7 +271,6 @@ func (l *Linter) maxLineLength() int {
 	return lineLength
 }
 
-// externalLinkTimeout returns the configured timeoutSeconds for the external-link rule.
 func (l *Linter) externalLinkTimeout() int {
 	timeoutSeconds := 5
 	if v, ok := l.config.RuleOptions("external-link")["timeoutSeconds"]; ok {
@@ -302,7 +281,6 @@ func (l *Linter) externalLinkTimeout() int {
 	return timeoutSeconds
 }
 
-// externalLinkMaxConcurrency returns the configured maxConcurrency for the external-link rule.
 func (l *Linter) externalLinkMaxConcurrency() int {
 	if v, ok := l.config.RuleOptions("external-link")["maxConcurrency"]; ok {
 		if f, ok := v.(float64); ok && int(f) > 0 {
@@ -312,7 +290,6 @@ func (l *Linter) externalLinkMaxConcurrency() int {
 	return rule.DefaultMaxConcurrency
 }
 
-// externalLinkMaxRetries returns the configured maxRetries for the external-link rule.
 func (l *Linter) externalLinkMaxRetries() int {
 	if v, ok := l.config.RuleOptions("external-link")["maxRetries"]; ok {
 		if f, ok := v.(float64); ok && int(f) >= 0 {
@@ -322,7 +299,6 @@ func (l *Linter) externalLinkMaxRetries() int {
 	return rule.DefaultMaxRetries
 }
 
-// externalLinkPerHostConcurrency returns the configured perHostConcurrency for the external-link rule.
 func (l *Linter) externalLinkPerHostConcurrency() int {
 	if v, ok := l.config.RuleOptions("external-link")["perHostConcurrency"]; ok {
 		if f, ok := v.(float64); ok && int(f) > 0 {
@@ -332,7 +308,6 @@ func (l *Linter) externalLinkPerHostConcurrency() int {
 	return rule.DefaultPerHostConcurrency
 }
 
-// externalLinkPerHostIntervalMs returns the configured perHostIntervalMs for the external-link rule.
 func (l *Linter) externalLinkPerHostIntervalMs() int {
 	if v, ok := l.config.RuleOptions("external-link")["perHostIntervalMs"]; ok {
 		if f, ok := v.(float64); ok && int(f) >= 0 {
@@ -342,7 +317,6 @@ func (l *Linter) externalLinkPerHostIntervalMs() int {
 	return rule.DefaultPerHostIntervalMs
 }
 
-// externalLinkAllowedStatuses returns the configured allowedStatuses for the external-link rule.
 func (l *Linter) externalLinkAllowedStatuses() []int {
 	raw, _ := l.config.RuleOptions("external-link")["allowedStatuses"].([]interface{})
 	statuses := make([]int, 0, len(raw))
@@ -354,10 +328,6 @@ func (l *Linter) externalLinkAllowedStatuses() []int {
 	return statuses
 }
 
-// simpleRules lists rules whose check function takes only (path, lines, offset)
-// and have not yet been migrated to the preprocess context. Rules that require
-// additional options, or that consume the shared *preprocess.Context, are
-// handled separately below.
 var simpleRules = []struct {
 	name string
 	fn   func(string, []string, int) []rule.LintError
@@ -365,9 +335,6 @@ var simpleRules = []struct {
 	{"final-blank-line", rule.CheckFinalBlankLine},
 }
 
-// contextRules lists rules migrated to consume the shared *preprocess.Context
-// (issue #337). They take (path, ctx, offset); rules that also need extra
-// options are still handled separately below.
 var contextRules = []struct {
 	name string
 	fn   func(string, *preprocess.Context, int) []rule.LintError
@@ -388,10 +355,6 @@ var contextRules = []struct {
 	{"no-hard-tabs", rule.CheckNoHardTabs},
 }
 
-// collectLineErrors runs all non-network rule checks and returns their errors.
-// ctx is the shared per-line context produced once by preprocess.Scan; rules
-// that have migrated to consume it receive ctx, while the rest continue to read
-// the raw lines slice (which Scan borrows, so no copy is made).
 func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.Context, offset int) []rule.LintError {
 	var errs []rule.LintError
 
@@ -431,7 +394,6 @@ func (l *Linter) collectLineErrors(path string, lines []string, ctx *preprocess.
 	return errs
 }
 
-// collectErrors performs linting checks on a single file's content.
 func (l *Linter) collectErrors(path string, content string) ([]rule.LintError, int, int) {
 	body, offset := file.StripFrontmatter(content)
 	lines := strings.Split(body, "\n")

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -7,20 +7,17 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
-// Formatter is the interface for formatting lint results.
 type Formatter interface {
-	// Format writes the formatted output to the provided writer.
 	Format(w io.Writer, result *Result) error
 }
 
-// Result holds the linting results to be formatted.
 type Result struct {
-	Files        int                         // Total number of files checked
-	Lines        int                         // Total number of lines checked
-	Total        int                         // Total number of issues shown (errors + warnings, after MinSeverity filter)
-	Warnings     int                         // Number of those that are warnings
-	LinksChecked *int                        // Number of links checked (nil if link check disabled)
-	Duration     time.Duration               // Time taken for linting
-	Details      map[string][]rule.LintError // Detailed violations per file (after MinSeverity filter)
-	OrderedPaths []string                    // Sorted file paths for consistent output
+	Files        int
+	Lines        int
+	Total        int
+	Warnings     int
+	LinksChecked *int
+	Duration     time.Duration
+	Details      map[string][]rule.LintError
+	OrderedPaths []string
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -7,15 +7,12 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/rule"
 )
 
-// JSONFormatter formats lint results as JSON.
 type JSONFormatter struct{}
 
-// NewJSONFormatter creates a new JSONFormatter.
 func NewJSONFormatter() *JSONFormatter {
 	return &JSONFormatter{}
 }
 
-// Format implements the Formatter interface for JSON output.
 func (f *JSONFormatter) Format(w io.Writer, result *Result) error {
 	output := struct {
 		Files        int                         `json:"files"`

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -16,15 +16,12 @@ const (
 	colorReset  = "\033[0m"
 )
 
-// TextFormatter formats lint results as human-readable text with colors.
 type TextFormatter struct{}
 
-// NewTextFormatter creates a new TextFormatter.
 func NewTextFormatter() *TextFormatter {
 	return &TextFormatter{}
 }
 
-// Format implements the Formatter interface for text output.
 func (f *TextFormatter) Format(w io.Writer, result *Result) error {
 	if _, err := fmt.Fprintln(w); err != nil {
 		return err
@@ -41,7 +38,6 @@ func (f *TextFormatter) Format(w io.Writer, result *Result) error {
 	return nil
 }
 
-// formatErrorDetails prints error details for each file.
 func (f *TextFormatter) formatErrorDetails(w io.Writer, result *Result) error {
 	for _, path := range result.OrderedPaths {
 		errors := result.Details[path]
@@ -78,7 +74,6 @@ func (f *TextFormatter) formatErrorDetails(w io.Writer, result *Result) error {
 	return nil
 }
 
-// formatSummary prints the summary (errors found or no issues).
 func (f *TextFormatter) formatSummary(w io.Writer, result *Result) error {
 	errorCount := result.Total - result.Warnings
 	if errorCount > 0 {
@@ -101,7 +96,6 @@ func (f *TextFormatter) formatSummary(w io.Writer, result *Result) error {
 	return nil
 }
 
-// formatStats prints statistics (files, lines, links, duration).
 func (f *TextFormatter) formatStats(w io.Writer, result *Result) error {
 	if result.LinksChecked != nil {
 		return f.formatStatsWithLinks(w, result)
@@ -109,7 +103,6 @@ func (f *TextFormatter) formatStats(w io.Writer, result *Result) error {
 	return f.formatStatsWithoutLinks(w, result)
 }
 
-// formatStatsWithLinks prints statistics when link checking is enabled.
 func (f *TextFormatter) formatStatsWithLinks(w io.Writer, result *Result) error {
 	if result.Duration < time.Second {
 		_, err := fmt.Fprintf(w, "%s✓%s Checked %d file(s), %d line(s), %d link(s) in %s%dms%s\n",
@@ -121,7 +114,6 @@ func (f *TextFormatter) formatStatsWithLinks(w io.Writer, result *Result) error 
 	return err
 }
 
-// formatStatsWithoutLinks prints statistics when link checking is disabled.
 func (f *TextFormatter) formatStatsWithoutLinks(w io.Writer, result *Result) error {
 	if result.Duration < time.Second {
 		_, err := fmt.Fprintf(w, "%s✓%s Checked %d file(s), %d line(s) in %s%dms%s\n",

--- a/internal/preprocess/fenced_code.go
+++ b/internal/preprocess/fenced_code.go
@@ -2,15 +2,6 @@ package preprocess
 
 import "strings"
 
-// openingFenceMarker returns the full fence marker (e.g. "```", "````", "~~~")
-// if trimmed is an opening code fence, or an empty string otherwise. The full
-// run of fence characters is captured so that closing fences of the same length
-// are correctly matched. trimmed must already have its leading indentation
-// removed by the caller; per CommonMark a fence is only valid at an indentation
-// of less than four columns, which Scan enforces before calling this.
-//
-// Modeled on internal/rule/fence.go; reimplemented here so the preprocess
-// package stays self-contained and has no dependency on the rule package.
 func openingFenceMarker(trimmed string) string {
 	if len(trimmed) < 3 {
 		return ""
@@ -26,11 +17,8 @@ func openingFenceMarker(trimmed string) string {
 	return trimmed[:n]
 }
 
-// isClosingFence reports whether trimmed is a valid closing fence for the given
-// opening fence marker. Per the CommonMark spec, a closing fence must:
-//  1. Use the same fence character as the opener (backtick or tilde)
-//  2. Have a run length >= the opener's length
-//  3. Contain only optional whitespace after the fence run
+// isClosingFence reports whether trimmed closes openMarker: same character,
+// run length >= opener, only optional whitespace after the run.
 func isClosingFence(trimmed, openMarker string) bool {
 	if len(trimmed) == 0 || len(openMarker) == 0 {
 		return false

--- a/internal/preprocess/html.go
+++ b/internal/preprocess/html.go
@@ -2,21 +2,10 @@ package preprocess
 
 import "strings"
 
-// HTML comments (CommonMark §4.6 type 2) are handled by sanitizeInline and the
-// comment-continuation state in Scan, not here, so they can be tracked
-// independently of other HTML blocks and surfaced via Context.InHTMLComment.
-// The detectors below cover the remaining HTML block types 1 and 3–7.
-
-// htmlType1Names are the tag names whose blocks (type 1) end only when a
-// matching close tag appears, not on a blank line.
 var htmlType1Names = []string{"script", "pre", "style", "textarea"}
 
-// htmlType1CloseTags are the strings whose presence on any line closes a type 1
-// HTML block.
 var htmlType1CloseTags = []string{"</script>", "</style>", "</pre>", "</textarea>"}
 
-// htmlBlockTags is the set of tag names that start a type 6 HTML block
-// (CommonMark §4.6, condition 6). div is the load-bearing case for the audit.
 var htmlBlockTags = map[string]bool{
 	"address": true, "article": true, "aside": true, "base": true,
 	"basefont": true, "blockquote": true, "body": true, "caption": true,
@@ -41,11 +30,9 @@ func isTagNameChar(c byte) bool {
 	return isASCIILetter(c) || (c >= '0' && c <= '9') || c == '-'
 }
 
-// htmlBlockStart reports the HTML block type (1, 3, 4, 5, 6, or 7) that line
-// opens, or 0 if it does not start an HTML block. line must already have its
-// leading indentation stripped (HTML blocks are only valid at an indentation of
-// less than four columns, which Scan enforces). Type 7 cannot interrupt a
-// paragraph, so inParagraph suppresses it.
+// htmlBlockStart returns the HTML block type (1, 3, 4, 5, 6, or 7) opened by
+// line, or 0 if it does not start an HTML block. Type 7 cannot interrupt a
+// paragraph (inParagraph suppresses it).
 func htmlBlockStart(line string, inParagraph bool) int {
 	if len(line) < 2 || line[0] != '<' {
 		return 0
@@ -71,9 +58,6 @@ func htmlBlockStart(line string, inParagraph bool) int {
 	return 0
 }
 
-// matchType1 reports whether line opens a type 1 HTML block: '<' followed by
-// script/pre/style/textarea (case-insensitive), then whitespace, '>', or
-// end-of-line.
 func matchType1(line string) bool {
 	for _, name := range htmlType1Names {
 		if len(line) < 1+len(name) {
@@ -94,9 +78,6 @@ func matchType1(line string) bool {
 	return false
 }
 
-// matchType6 reports whether line opens a type 6 HTML block: '<' or '</'
-// followed by a tag name in htmlBlockTags, then whitespace, end-of-line, '>',
-// or '/>'.
 func matchType6(line string) bool {
 	i := 1
 	if i < len(line) && line[i] == '/' {
@@ -125,12 +106,6 @@ func matchType6(line string) bool {
 	return false
 }
 
-// matchType7 reports whether line is a single complete open or closing tag that
-// fills the whole line (only trailing whitespace allowed), with a tag name that
-// is not a type 1 tag. This is a pragmatic subset of CommonMark's full tag
-// grammar — sufficient for the standalone-tag case the audit cares about — and
-// deliberately conservative: anything it is unsure about returns false rather
-// than over-claiming an HTML block.
 func matchType7(line string) bool {
 	s := strings.TrimRight(line, " \t")
 	if len(s) < 3 || s[0] != '<' || s[len(s)-1] != '>' {
@@ -161,15 +136,11 @@ func matchType7(line string) bool {
 		}
 	}
 	if closing {
-		// A closing tag has no attributes.
 		return strings.TrimSpace(inner[j:]) == ""
 	}
 	return true
 }
 
-// htmlBlockEndsOnLine reports whether a type 1–5 HTML block's end condition is
-// satisfied on line. Types 6 and 7 end on a blank line and are handled in Scan,
-// not here.
 func htmlBlockEndsOnLine(line string, blockType int) bool {
 	switch blockType {
 	case 1:

--- a/internal/preprocess/indented_code.go
+++ b/internal/preprocess/indented_code.go
@@ -1,13 +1,7 @@
 package preprocess
 
-// indentColumns returns the indentation of line measured in columns and the
-// byte index of the first non-whitespace character. A tab advances to the next
-// multiple of four columns, matching CommonMark's tab-stop handling. If the
-// line is empty or contains only whitespace, firstIdx equals len(line) and the
-// line should be treated as blank.
-//
-// Only spaces and tabs count as indentation here; a leading carriage return is
-// not expected because callers split on newlines.
+// indentColumns returns the indentation of line in columns (tabs expand to the
+// next multiple of 4) and the byte index of the first non-whitespace character.
 func indentColumns(line string) (cols, firstIdx int) {
 	col := 0
 	for i := 0; i < len(line); i++ {
@@ -23,15 +17,8 @@ func indentColumns(line string) (cols, firstIdx int) {
 	return col, len(line)
 }
 
-// Indented code blocks (CommonMark §4.4) are detected in Scan rather than here,
-// because the rule is stateful: a line indented four or more columns is code
-// only when it does not continue an open paragraph (an indented code block
-// cannot interrupt a paragraph). The paragraph state is tracked across lines in
-// Scan.
-//
-// Known limitation (Phase 1): indentation is measured from the start of the
-// line, not relative to an enclosing list item or block quote. Inside a list,
-// continuation text is commonly indented several columns and is list content,
-// not an indented code block. Scan does not model container blocks, so such
-// lines may be mis-flagged as InIndentedCode. Downstream rules should not treat
-// InIndentedCode as authoritative inside list/blockquote contexts.
+// Known limitation: indentation is measured from the start of the line, not
+// relative to an enclosing list item or block quote. Lines inside a list that
+// happen to be indented ≥4 columns may be mis-flagged as InIndentedCode.
+// Downstream rules should not treat InIndentedCode as authoritative inside
+// list/blockquote contexts.

--- a/internal/preprocess/inline.go
+++ b/internal/preprocess/inline.go
@@ -2,8 +2,6 @@ package preprocess
 
 import "strings"
 
-// countBacktickRun returns the number of consecutive backticks starting at
-// position start in s.
 func countBacktickRun(s string, start int) int {
 	n := 0
 	for start+n < len(s) && s[start+n] == '`' {
@@ -12,8 +10,6 @@ func countBacktickRun(s string, start int) int {
 	return n
 }
 
-// findClosingBacktickRun returns the start index of the next run of exactly
-// delimLen backticks at or after from, or -1 if there is none.
 func findClosingBacktickRun(s string, from, delimLen int) int {
 	j := from
 	for j < len(s) {
@@ -30,11 +26,6 @@ func findClosingBacktickRun(s string, from, delimLen int) int {
 	return -1
 }
 
-// writeBlankedCodeSpan handles an inline code span whose opening backtick run
-// begins at index start (line[start] == '`'). If the run has a matching closing
-// run, the whole span (delimiters and content) is written to b as spaces;
-// otherwise the unmatched backticks are written literally. It returns the index
-// in line immediately after what it consumed.
 func writeBlankedCodeSpan(b *strings.Builder, line string, start int) int {
 	delimLen := countBacktickRun(line, start)
 	closing := findClosingBacktickRun(line, start+delimLen, delimLen)
@@ -52,29 +43,12 @@ func writeBlankedCodeSpan(b *strings.Builder, line string, start int) int {
 	return closing + delimLen
 }
 
-// sanitizeInline replaces inline code spans and inline HTML comments with
-// spaces so that downstream rules do not scan their contents. Length is
-// preserved (each blanked byte becomes a single space) so that column positions
-// in the sanitized string still line up with the original.
-//
-// Processing is a single left-to-right pass, so the construct that opens first
-// wins: a "<!--" inside a code span is treated as code (blanked as code, not a
-// comment), and a backtick inside a comment is treated as comment text. This is
-// consistent with CommonMark, where neither construct nests in the other.
-//
-// startInComment indicates the line begins inside an HTML comment that was
-// opened on a previous line. The returns are:
-//   - sanitized: the line with code spans and comments blanked
-//   - endedInComment: true if the line ends inside an unclosed comment
-//   - fullyComment: true if the line's only non-whitespace content was comment
-//     text (i.e. it is a standalone comment line, not prose with a trailing
-//     comment). Always false unless a comment was actually present.
+// sanitizeInline blanks inline code spans and HTML comments with spaces
+// (length-preserving). The opener that appears first wins; neither construct
+// nests in the other (consistent with CommonMark).
 func sanitizeInline(line string, startInComment bool) (sanitized string, endedInComment, fullyComment bool) {
-	// Fast path: a line outside any open comment with no inline code span or
-	// comment opener has nothing to blank, so it is returned verbatim with no
-	// allocation. Returning the input string unchanged also lets Scan detect via
-	// identity that the line needs no entry in its sparse sanitized map. This is
-	// the common case once the linter runs Scan on every file.
+	// Fast path: no backtick or comment opener — return verbatim (no allocation).
+	// Returning the same string pointer lets Scan skip the sparse map entry.
 	if !startInComment &&
 		strings.IndexByte(line, '`') < 0 &&
 		!strings.Contains(line, "<!--") {
@@ -102,7 +76,6 @@ func sanitizeInline(line string, startInComment bool) (sanitized string, endedIn
 			continue
 		}
 
-		// Opening of an inline HTML comment.
 		if i+4 <= len(line) && line[i:i+4] == "<!--" {
 			inComment = true
 			hasComment = true
@@ -111,7 +84,6 @@ func sanitizeInline(line string, startInComment bool) (sanitized string, endedIn
 			continue
 		}
 
-		// Inline code span.
 		if line[i] == '`' {
 			i = writeBlankedCodeSpan(&b, line, i)
 			hasOther = true

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -23,13 +23,13 @@ const (
 	flagHTMLComment
 )
 
-func (c *Context) Len() int                    { return len(c.lines) }
-func (c *Context) Line(i int) string           { return c.lines[i] }
-func (c *Context) InFencedCode(i int) bool     { return c.flags[i]&flagFencedCode != 0 }
-func (c *Context) InIndentedCode(i int) bool   { return c.flags[i]&flagIndentedCode != 0 }
-func (c *Context) InHTMLBlock(i int) bool      { return c.flags[i]&flagHTMLBlock != 0 }
-func (c *Context) InHTMLComment(i int) bool    { return c.flags[i]&flagHTMLComment != 0 }
-func (c *Context) FenceSpans() []FenceSpan     { return c.fences }
+func (c *Context) Len() int                  { return len(c.lines) }
+func (c *Context) Line(i int) string         { return c.lines[i] }
+func (c *Context) InFencedCode(i int) bool   { return c.flags[i]&flagFencedCode != 0 }
+func (c *Context) InIndentedCode(i int) bool { return c.flags[i]&flagIndentedCode != 0 }
+func (c *Context) InHTMLBlock(i int) bool    { return c.flags[i]&flagHTMLBlock != 0 }
+func (c *Context) InHTMLComment(i int) bool  { return c.flags[i]&flagHTMLComment != 0 }
+func (c *Context) FenceSpans() []FenceSpan   { return c.fences }
 
 func (c *Context) Sanitized(i int) string {
 	if s, ok := c.sanitized[i]; ok {

--- a/internal/preprocess/preprocess.go
+++ b/internal/preprocess/preprocess.go
@@ -1,75 +1,21 @@
-// Package preprocess provides a single shared pre-pass over a Markdown file's
-// lines, classifying each line by the context it lives in (fenced code,
-// indented code, HTML block, HTML comment) and exposing an inline-sanitized
-// view with inline code spans and inline HTML comments blanked out.
-//
-// It exists to replace the per-rule "skip code blocks / HTML" machinery that
-// each rule currently re-implements, which the audit in issue #337 found to be
-// inconsistent and incomplete. Rules consume the result instead of re-deriving
-// context, so the three systematically missed contexts — indented code blocks,
-// HTML blocks, and HTML comments — are handled once, the same way, everywhere.
-//
-// The classification follows CommonMark's block structure but is intentionally
-// not a full parser: it does not model container blocks (lists, block quotes),
-// so indentation is measured from the start of the line. See the note in
-// indented_code.go for the consequences.
-//
-// The result is stored compactly: context flags are packed one byte per line and
-// the sanitized text is materialized only for the lines that actually differ
-// from the original (those carrying an inline code span or comment). The
-// original lines are borrowed, not copied. This keeps the per-line overhead near
-// one byte rather than two string headers plus four bools, which matters because
-// the linter runs Scan over every file. Access the result through the Context
-// methods rather than touching the fields.
 package preprocess
 
 import "strings"
 
-// Context is the result of Scan: the per-line Markdown classification of a file,
-// queried by line index through its methods.
-//
-// The four context predicates (InFencedCode, InIndentedCode, InHTMLBlock,
-// InHTMLComment) describe structural block membership and are mutually
-// exclusive: a line is in at most one of them. They are exposed individually
-// rather than via a single "skippable" convenience predicate because different
-// rules skip different subsets — for example, rules implementing the markdownlint
-// divergences in issue #337 (max-line-length, no-hard-tabs) deliberately scan
-// inside fenced code blocks.
-//
-// Sanitized returns an inline-level transformation only: inline code spans and
-// inline HTML comments are replaced by spaces (length-preserving), so a rule can
-// scan it without matching content that lives in those spans. Block-level code
-// (fenced and indented) is NOT blanked — it is returned verbatim so that rules
-// which want to inspect code-block contents still can; use the predicates to skip
-// block code instead. For lines reported by InHTMLComment, Sanitized is fully
-// blank because the entire line was comment text.
 type Context struct {
-	// lines is the borrowed input slice. The caller must not mutate it for the
-	// lifetime of the Context, since Line and Sanitized read from it directly.
-	lines []string
-	// flags holds the packed context bits for each line, parallel to lines.
-	flags []uint8
-	// sanitized holds the inline-sanitized text only for the lines that differ
-	// from their original (those with an inline code span or comment). Lines
-	// absent from the map are their own sanitized form. nil until the first such
-	// line is seen.
+	lines     []string
+	flags     []uint8
 	sanitized map[int]string
-	// fences records one span per fenced code block, in document order. It is
-	// the structural view that InFencedCode (a per-line membership flag) cannot
-	// give: two back-to-back fences with no blank line between them are distinct
-	// spans here even though every line is InFencedCode.
-	fences []FenceSpan
+	fences    []FenceSpan
 }
 
-// FenceSpan is the line range of one fenced code block. Start is the 0-based
-// opening-fence line; End is the 0-based closing-fence line, or -1 when the
-// fence is never closed (it then runs to end of file).
+// FenceSpan is the line range of one fenced code block.
+// End is -1 when the fence is never closed (runs to end of file).
 type FenceSpan struct {
 	Start int
 	End   int
 }
 
-// Context flag bits, packed one set per line in Context.flags.
 const (
 	flagFencedCode uint8 = 1 << iota
 	flagIndentedCode
@@ -77,15 +23,14 @@ const (
 	flagHTMLComment
 )
 
-// Len returns the number of lines classified (equal to len(input)).
-func (c *Context) Len() int { return len(c.lines) }
+func (c *Context) Len() int                    { return len(c.lines) }
+func (c *Context) Line(i int) string           { return c.lines[i] }
+func (c *Context) InFencedCode(i int) bool     { return c.flags[i]&flagFencedCode != 0 }
+func (c *Context) InIndentedCode(i int) bool   { return c.flags[i]&flagIndentedCode != 0 }
+func (c *Context) InHTMLBlock(i int) bool      { return c.flags[i]&flagHTMLBlock != 0 }
+func (c *Context) InHTMLComment(i int) bool    { return c.flags[i]&flagHTMLComment != 0 }
+func (c *Context) FenceSpans() []FenceSpan     { return c.fences }
 
-// Line returns the original text of line i, exactly as it appeared in the input.
-func (c *Context) Line(i int) string { return c.lines[i] }
-
-// Sanitized returns line i with inline code spans and inline HTML comments
-// replaced by spaces. For block-code and HTML-block lines it equals Line(i); for
-// fully-commented lines it is all whitespace.
 func (c *Context) Sanitized(i int) string {
 	if s, ok := c.sanitized[i]; ok {
 		return s
@@ -93,38 +38,8 @@ func (c *Context) Sanitized(i int) string {
 	return c.lines[i]
 }
 
-// InFencedCode reports whether line i is part of a fenced code block, including
-// the opening and closing fence lines. If a fence is never closed, every line
-// from the opener to end of file is flagged, which prevents downstream rules from
-// mispairing fences inside the unclosed region.
-func (c *Context) InFencedCode(i int) bool { return c.flags[i]&flagFencedCode != 0 }
-
-// InIndentedCode reports whether line i is inside an indented code block
-// (CommonMark §4.4). See the limitation noted in indented_code.go.
-func (c *Context) InIndentedCode(i int) bool { return c.flags[i]&flagIndentedCode != 0 }
-
-// InHTMLBlock reports whether line i is inside an HTML block of CommonMark types
-// 1 and 3–7 (e.g. <div>…</div>). HTML comments are reported via InHTMLComment,
-// not this predicate.
-func (c *Context) InHTMLBlock(i int) bool { return c.flags[i]&flagHTMLBlock != 0 }
-
-// InHTMLComment reports whether line i is a line whose entire content is an HTML
-// comment — a standalone <!-- … --> line or a continuation line of a multi-line
-// comment. A prose line with a trailing inline comment is not reported here; its
-// comment is blanked in Sanitized instead.
-func (c *Context) InHTMLComment(i int) bool { return c.flags[i]&flagHTMLComment != 0 }
-
-// FenceSpans returns the fenced code blocks in document order. Unlike the
-// InFencedCode flag, this distinguishes adjacent blocks and identifies each
-// block's opening and closing lines (End == -1 for an unclosed block). It is the
-// structural source of truth for fence rules.
-func (c *Context) FenceSpans() []FenceSpan { return c.fences }
-
-// Scan classifies every line of a Markdown file in a single pass and returns a
-// Context to query by line index. The input slice is borrowed, not copied, and
-// must not be mutated while the Context is in use. The input is expected to have
-// already had YAML front matter stripped by the caller (the linter does this
-// centrally), so Scan does not handle front matter.
+// Scan classifies every line in a single pass. The input slice is borrowed and
+// must not be mutated while the Context is in use.
 func Scan(lines []string) *Context {
 	c := &Context{
 		lines: lines,
@@ -136,21 +51,15 @@ func Scan(lines []string) *Context {
 	for i, line := range lines {
 		lc := s.classify(line)
 		c.flags[i] = lc.flags
-		// Record fence spans from the scanner's open/close transitions. A line is
-		// at most one transition: a closing-fence line drops inFence on the same
-		// line that is still flagged fenced, and the next opener (even if
-		// adjacent) is a separate open transition, so adjacent blocks stay
-		// distinct.
+		// Track fence open/close transitions so adjacent blocks stay distinct.
+		// A closing-fence line is still flagged fenced, so the transition fires
+		// on the line after the closer, not the closer itself.
 		if s.inFence && !prevInFence {
 			fenceStart = i
 		} else if !s.inFence && prevInFence {
 			c.fences = append(c.fences, FenceSpan{Start: fenceStart, End: i})
 		}
 		prevInFence = s.inFence
-		// Store the sanitized text only when it actually differs from the
-		// original. The fast path in sanitizeInline returns the original string
-		// unchanged for ordinary lines, so this comparison is a cheap identity
-		// check for the common case.
 		if lc.sanitized != line {
 			if c.sanitized == nil {
 				c.sanitized = make(map[int]string)
@@ -165,15 +74,11 @@ func Scan(lines []string) *Context {
 	return c
 }
 
-// lineClass is the per-line classification produced by the scanner: the packed
-// context flags and the inline-sanitized text (which equals the original line
-// unless an inline code span or comment was blanked).
 type lineClass struct {
 	flags     uint8
 	sanitized string
 }
 
-// scanner holds the cross-line state needed to classify each line in context.
 type scanner struct {
 	inFence     bool
 	fenceMarker string
@@ -185,7 +90,6 @@ type scanner struct {
 	inParagraph bool
 }
 
-// classify advances the scanner by one line and returns that line's class.
 func (s *scanner) classify(line string) lineClass {
 	cols, firstIdx := indentColumns(line)
 	isBlank := firstIdx == len(line)
@@ -196,14 +100,8 @@ func (s *scanner) classify(line string) lineClass {
 	return s.startLine(line, cols, isBlank)
 }
 
-// continueOpenBlock handles a line that lies inside a block opened on an earlier
-// line (fenced code, HTML comment, or HTML block). It returns handled=false when
-// no such block is open, or when a type 6/7 HTML block has just ended on this
-// blank line and the line should be classified afresh by startLine.
 func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (lineClass, bool) {
 	switch {
-	// Fences take precedence over every other context; a comment or HTML start
-	// inside a code block is literal.
 	case s.inFence:
 		if !isBlank && cols < 4 && isClosingFence(strings.TrimSpace(line), s.fenceMarker) {
 			s.inFence = false
@@ -212,10 +110,6 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (lineCl
 		s.inParagraph = false
 		return lineClass{flags: flagFencedCode, sanitized: line}, true
 
-	// Multi-line HTML comment: track until the closing "-->". The comment may
-	// close mid-line and leave trailing prose; in that case the line is not a
-	// pure comment line, so it is not flagged InHTMLComment and it reopens a
-	// paragraph — mirroring startLine's handling of a fresh comment line.
 	case s.inComment:
 		sanitized, stillInComment, fullyComment := sanitizeInline(line, true)
 		s.inComment = stillInComment
@@ -228,8 +122,6 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (lineCl
 		}
 		return lc, true
 
-	// Open HTML block. Types 1 and 3–5 end on a delimiter line; types 6 and 7
-	// end on a blank line, which is itself outside the block.
 	case s.inHTMLBlock:
 		if (s.htmlType == 6 || s.htmlType == 7) && isBlank {
 			s.inHTMLBlock = false
@@ -244,37 +136,27 @@ func (s *scanner) continueOpenBlock(line string, cols int, isBlank bool) (lineCl
 	return lineClass{}, false
 }
 
-// startLine classifies a line that does not continue an already-open block.
 func (s *scanner) startLine(line string, cols int, isBlank bool) lineClass {
-	// Blank line outside any block closes an open paragraph.
 	if isBlank {
 		s.inParagraph = false
 		return lineClass{sanitized: line}
 	}
 
-	// Indented code block: four or more columns of indentation, but only when it
-	// does not continue an open paragraph (indented code cannot interrupt a
-	// paragraph). Checked before openers because an indented line can open
-	// neither a fence nor an HTML block.
+	// Indented code cannot interrupt a paragraph.
 	if cols >= 4 && !s.inParagraph {
 		return lineClass{flags: flagIndentedCode, sanitized: line}
 	}
 
-	// Block openers are recognized only at an indentation below four columns.
 	if cols < 4 {
 		if lc, opened := s.tryOpenBlock(line); opened {
 			return lc
 		}
 	}
 
-	// Everything else is prose: paragraph text, headings, list items, lazy
-	// paragraph continuations, and standalone HTML comments. Inline code spans
-	// and inline comments are blanked in the sanitized text.
 	sanitized, endedInComment, fullyComment := sanitizeInline(line, false)
 	s.inComment = endedInComment
 	lc := lineClass{sanitized: sanitized}
 	if fullyComment {
-		// The line was nothing but comment text — a standalone comment line.
 		lc.flags = flagHTMLComment
 		s.inParagraph = false
 	} else {
@@ -283,9 +165,6 @@ func (s *scanner) startLine(line string, cols int, isBlank bool) lineClass {
 	return lc
 }
 
-// tryOpenBlock attempts to open a fenced code block or an HTML block on line
-// (which must be indented fewer than four columns). It returns opened=false when
-// the line is not a block opener.
 func (s *scanner) tryOpenBlock(line string) (lineClass, bool) {
 	trimmed := strings.TrimSpace(line)
 

--- a/internal/rule/blanks_around_fences.go
+++ b/internal/rule/blanks_around_fences.go
@@ -6,16 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckBlanksAroundFences flags fenced code blocks that are not preceded or
-// followed by a blank line. Fences at the start or end of the file are exempt
-// from the respective check. Fences inside indented code, HTML blocks, and HTML
-// comments are not real fences and are ignored.
-//
-// A standalone single-line HTML comment (<!-- ... --> on its own line) is
-// transparent: it is invisible in rendered output, so it does not satisfy or
-// break the "preceded by a blank line" requirement. The preceding-blank check
-// therefore looks past such lines. Multi-line comment blocks and inline comments
-// (lines with visible text) are opaque.
 func CheckBlanksAroundFences(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 
@@ -48,11 +38,6 @@ func CheckBlanksAroundFences(filename string, ctx *preprocess.Context, offset in
 	return errs
 }
 
-// isTransparentComment reports whether line i is a standalone single-line HTML
-// comment (the whole line is a comment, and it both opens and closes on that
-// line). Such lines render to nothing, so blanks-around-fences looks through them
-// when checking for a preceding blank line. Multi-line comment lines carry only
-// one of the markers and are therefore opaque.
 func isTransparentComment(ctx *preprocess.Context, i int) bool {
 	if !ctx.InHTMLComment(i) {
 		return false

--- a/internal/rule/blanks_around_headings.go
+++ b/internal/rule/blanks_around_headings.go
@@ -6,7 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// isATXHeading reports whether s is an ATX-style heading (levels 1–6).
 func isATXHeading(s string) bool {
 	level := 0
 	for level < len(s) && s[level] == '#' {
@@ -18,10 +17,6 @@ func isATXHeading(s string) bool {
 	return level == len(s) || s[level] == ' ' || s[level] == '\t'
 }
 
-// CheckBlanksAroundHeadings flags ATX-style headings that are not preceded or
-// followed by a blank line. Headings at the start or end of the file are exempt
-// from the respective check. Headings inside fenced code, indented code, HTML
-// blocks, and HTML comments are ignored.
 func CheckBlanksAroundHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	// prevBlank tracks whether the previous line was blank so we avoid a

--- a/internal/rule/blanks_around_lists.go
+++ b/internal/rule/blanks_around_lists.go
@@ -6,9 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// isListItem reports whether line is a list item (unordered or ordered),
-// allowing any amount of leading indentation. The marker must be followed by
-// at least one space or tab, matching CommonMark's list item definition.
 func isListItem(line string) bool {
 	s := strings.TrimLeft(line, " \t")
 	if len(s) < 2 {
@@ -17,8 +14,6 @@ func isListItem(line string) bool {
 	return isUnorderedListItem(s) || isOrderedListItem(s)
 }
 
-// isUnorderedListItem reports whether s (already left-trimmed) starts with an
-// unordered list marker ("- ", "* ", or "+ ").
 func isUnorderedListItem(s string) bool {
 	if s[0] != '-' && s[0] != '*' && s[0] != '+' {
 		return false
@@ -26,9 +21,6 @@ func isUnorderedListItem(s string) bool {
 	return s[1] == ' ' || s[1] == '\t'
 }
 
-// isOrderedListItem reports whether s (already left-trimmed) starts with an
-// ordered list marker: one or more digits followed by '.' or ')' then a space
-// or tab.
 func isOrderedListItem(s string) bool {
 	i := 0
 	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
@@ -46,13 +38,6 @@ func isOrderedListItem(s string) bool {
 	return s[i+1] == ' ' || s[i+1] == '\t'
 }
 
-// CheckBlanksAroundLists flags list blocks that are not preceded or followed by
-// a blank line (MD032). The first item of a list block and the line immediately
-// after the last item are checked. Lists at the start or end of the file are
-// exempt from the respective check. List items inside fenced code blocks are
-// ignored. Nested list items are treated as part of the same block and do not
-// require additional blank lines between them and their parent. List items
-// inside fenced code, indented code, HTML blocks, and HTML comments are ignored.
 func CheckBlanksAroundLists(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	// prevBlank and prevWasListItem replace the TrimSpace look-behind on

--- a/internal/rule/block_context.go
+++ b/internal/rule/block_context.go
@@ -2,15 +2,8 @@ package rule
 
 import "github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 
-// inBlockContext reports whether line i sits in any code or HTML block context —
-// fenced code, indented code, an HTML block, or an HTML comment. It is the full
-// block-skip set used by rules that treat all such lines as non-content (heading,
-// link, and structure rules).
-//
-// It is deliberately not a method on preprocess.Context: the preprocess package
-// exposes the four contexts individually because some rules skip only a subset
-// (e.g. the markdownlint divergences max-line-length and no-hard-tabs scan inside
-// fenced code). Rules wanting a different subset call the individual predicates.
+// Not a method on preprocess.Context: some rules (max-line-length, no-hard-tabs)
+// skip only a subset of block contexts and call the individual predicates directly.
 func inBlockContext(ctx *preprocess.Context, i int) bool {
 	return ctx.InFencedCode(i) || ctx.InIndentedCode(i) || ctx.InHTMLBlock(i) || ctx.InHTMLComment(i)
 }

--- a/internal/rule/code_block.go
+++ b/internal/rule/code_block.go
@@ -4,20 +4,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckUnclosedCodeBlocks detects any unclosed fenced code blocks (e.g., ```)
-// in the Markdown content. It ensures that every opening fence has a corresponding closing fence.
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError indicating the location of any unclosed code block.
-//
-// Because fence detection comes from the shared scanner, fence markers inside
-// indented code or HTML blocks can no longer be mispaired into phantom unclosed
-// blocks (audit #337 cascade).
 func CheckUnclosedCodeBlocks(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/consistent_code_fence.go
+++ b/internal/rule/consistent_code_fence.go
@@ -4,15 +4,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckConsistentCodeFence flags fenced code blocks that use a different fence
-// character than expected. style must be "consistent", "backtick", or "tilde".
-//
-// In "consistent" mode the first fence character found in the document sets the
-// expected style; every subsequent opener that differs is flagged.
-// In "backtick"/"tilde" mode every opener using the wrong character is flagged.
-//
-// Fence openers inside indented code, HTML blocks, and HTML comments are not
-// real fences and are excluded by the scanner, so they are never examined.
 func CheckConsistentCodeFence(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
 	var expectedCh byte // 0 until first fence seen (consistent mode)
@@ -27,9 +18,6 @@ func CheckConsistentCodeFence(filename string, ctx *preprocess.Context, offset i
 	return errs
 }
 
-// checkFenceStyle validates ch against the configured style and updates
-// expectedCh in consistent mode. Returns a LintError if the fence character
-// does not match, nil otherwise.
 func checkFenceStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
 	switch style {
 	case "consistent":

--- a/internal/rule/consistent_emphasis_style.go
+++ b/internal/rule/consistent_emphasis_style.go
@@ -6,15 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckConsistentEmphasisStyle flags emphasis spans that use a different marker
-// than expected. style must be "consistent", "asterisk", or "underscore".
-//
-// In "consistent" mode the first emphasis character found in the document sets
-// the expected style; every subsequent span using a different character is
-// flagged. In "asterisk"/"underscore" mode every span using the wrong character
-// is flagged. Underscores inside words (e.g. snake_case) are not treated as
-// emphasis. Content inside fenced code, indented code, HTML blocks, HTML
-// comments, and inline code spans is ignored.
 func CheckConsistentEmphasisStyle(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
 	var expectedEmphCh byte   // for runLen == 1 (emphasis)
@@ -41,14 +32,6 @@ func CheckConsistentEmphasisStyle(filename string, ctx *preprocess.Context, offs
 	return errs
 }
 
-// checkEmphasisLine scans s for emphasis spans and appends any style violations
-// to errs. Only valid spans (opener + matching closer) are counted, so closing
-// delimiters followed by punctuation are never double-counted. The function is
-// allocation-free: no intermediate slice is created.
-//
-// expectedEmphCh tracks the expected marker for single-delimiter spans (emphasis);
-// expectedStrongCh tracks it for double-delimiter spans (strong). They are kept
-// separate so that *italic* and __strong__ can coexist without a violation.
 func checkEmphasisLine(s string, filename string, lineNum int, style string, expectedEmphCh *byte, expectedStrongCh *byte, errs *[]LintError) {
 	i := 0
 	for i < len(s) {
@@ -110,8 +93,6 @@ func checkEmphasisLine(s string, filename string, lineNum int, style string, exp
 	}
 }
 
-// findEmphCloser returns the start position of the first right-flanking run of
-// ch with exactly runLen characters at or after start. Returns -1 if not found.
 func findEmphCloser(s string, start int, ch byte, runLen int) int {
 	j := start
 	for j < len(s) {
@@ -132,27 +113,18 @@ func findEmphCloser(s string, start int, ch byte, runLen int) int {
 	return -1
 }
 
-// isEmphLeftFlanking reports whether afterRun is a valid left-flanking position
-// (followed by a non-whitespace character).
 func isEmphLeftFlanking(s string, afterRun int) bool {
 	return afterRun < len(s) && s[afterRun] != ' ' && s[afterRun] != '\t'
 }
 
-// isEmphMidWord reports whether the delimiter run starting at i is a mid-word
-// underscore (flanked by word characters on both sides).
 func isEmphMidWord(s string, i, afterRun int) bool {
 	return i > 0 && isEmphWordChar(s[i-1]) && isEmphWordChar(s[afterRun])
 }
 
-// isEmphWordChar reports whether b is a word character for emphasis purposes.
 func isEmphWordChar(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
-// checkEmphasisStyle validates ch against the configured style and updates
-// expectedCh in consistent mode. kind is "emphasis" for single-delimiter spans
-// and "strong" for double-delimiter spans. Returns a LintError if the marker
-// character does not match, nil otherwise.
 func checkEmphasisStyle(filename string, line int, ch byte, style string, expectedCh *byte, kind string) *LintError {
 	switch style {
 	case "consistent":
@@ -194,9 +166,6 @@ func emphCharName(ch byte) string {
 	return "underscore"
 }
 
-// stripLinkURLs replaces the destination and title of inline Markdown links
-// with spaces so that underscores or asterisks in URLs are not mistaken for
-// emphasis markers. The link text between [ and ] is preserved.
 func stripLinkURLs(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -220,7 +189,6 @@ func stripLinkURLs(s string) string {
 	return b.String()
 }
 
-// hasPrecedingBracket reports whether there is an unescaped '[' before position i in s.
 func hasPrecedingBracket(s string, i int) bool {
 	for j := i - 1; j >= 0; j-- {
 		if s[j] == '[' {
@@ -230,9 +198,6 @@ func hasPrecedingBracket(s string, i int) bool {
 	return false
 }
 
-// consumeLinkDest blanks out the link destination starting at i and returns
-// the position after it. Handles both angle-bracket form (<dest>) and the
-// regular balanced-paren form.
 func consumeLinkDest(b *strings.Builder, s string, i int) int {
 	if i >= len(s) {
 		return i
@@ -272,8 +237,6 @@ func consumeLinkDest(b *strings.Builder, s string, i int) int {
 	return i
 }
 
-// consumeLinkTitle blanks out optional whitespace and the link title (if any)
-// starting at i and returns the position after it.
 func consumeLinkTitle(b *strings.Builder, s string, i int) int {
 	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
 		b.WriteByte(' ')

--- a/internal/rule/consistent_list_marker.go
+++ b/internal/rule/consistent_list_marker.go
@@ -4,14 +4,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckConsistentListMarker flags unordered list items that use a different
-// marker than expected. style must be "consistent", "dash", "asterisk", or "plus".
-//
-// In "consistent" mode the first marker found in the document sets the
-// expected style; every subsequent item using a different marker is flagged.
-// In "dash"/"asterisk"/"plus" mode every item using the wrong marker is
-// flagged. Content inside fenced code, indented code, HTML blocks, and HTML
-// comments is ignored.
 func CheckConsistentListMarker(filename string, ctx *preprocess.Context, offset int, style string) []LintError {
 	var errs []LintError
 	var expectedCh byte // 0 until first list item seen (consistent mode)
@@ -40,9 +32,6 @@ func CheckConsistentListMarker(filename string, ctx *preprocess.Context, offset 
 	return errs
 }
 
-// listItemMarker returns the marker byte and true if line is an unordered list
-// item (optional leading spaces, one of - * +, then one or more spaces/tabs,
-// then a non-whitespace byte). Returns 0, false otherwise.
 func listItemMarker(line string) (byte, bool) {
 	i := 0
 	for i < len(line) && (line[i] == ' ' || line[i] == '\t') {
@@ -68,9 +57,6 @@ func listItemMarker(line string) (byte, bool) {
 	return ch, true
 }
 
-// checkListMarkerStyle validates ch against the configured style and updates
-// expectedCh in consistent mode. Returns a LintError if the marker does not
-// match, nil otherwise.
 func checkListMarkerStyle(filename string, line int, ch byte, style string, expectedCh *byte) *LintError {
 	switch style {
 	case "consistent":

--- a/internal/rule/duplicate_headings.go
+++ b/internal/rule/duplicate_headings.go
@@ -7,23 +7,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckDuplicateHeadings detects duplicate headings in the given Markdown content.
-// It treats headings as duplicates if their normalized text matches, regardless of level,
-// case differences, or trailing spaces (including full-width spaces).
-//
-// This check helps enforce clear and non-redundant structure in documents,
-// which improves readability and avoids confusion.
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError entries for each detected duplicate heading (excluding the first occurrence).
-//
-// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
-// ignored.
 func CheckDuplicateHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	seen := make(map[string]struct{}, ctx.Len()/10)

--- a/internal/rule/empty_alt_text.go
+++ b/internal/rule/empty_alt_text.go
@@ -9,13 +9,6 @@ import (
 
 var emptyAltTextRe = regexp.MustCompile(`!\[\s*\]\([^)]+\)`)
 
-// CheckEmptyAltText reports lint errors for images with empty alt text.
-//
-// Images inside fenced code, indented code, HTML blocks, and HTML comments are
-// skipped, and the inline-sanitized text is scanned so an ![](url) inside an
-// inline code span or inline comment is ignored too. Before migrating to the
-// preprocess context this rule did no context filtering at all (audit #337 worst
-// offender), firing even inside fenced and inline code.
 func CheckEmptyAltText(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -12,10 +12,6 @@ import (
 )
 
 var (
-	// Link pattern matchers
-	// Inline/image patterns allow balanced (...) groups inside the URL per CommonMark spec.
-	// [^\s()]+ allows square brackets (needed for IPv6 hosts like https://[::1]/).
-	// + quantifier ensures at least one character after the scheme (rejects bare https://).
 	inlineLinkPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://(?:[^\s()]+|\([^\s()]*\))+)\)`)
 	imageLinkPattern  = regexp.MustCompile(`!\[[^\]]*\]\((https?://(?:[^\s()]+|\([^\s()]*\))+)\)`)
 	bareURLPattern    = regexp.MustCompile(`(?m)^.*?(https?://(?:[^\s<>"'()]+|\([^\s<>"'()]*\))+).*?$`)
@@ -26,40 +22,27 @@ type cacheResult struct {
 	err    error
 }
 
-// ExtractedLink represents an external link found in markdown content
 type ExtractedLink struct {
 	URL  string
 	Line int
 }
 
 const (
-	// DefaultRetryDelayMs is the default delay in milliseconds before retrying a failed HTTP request
-	DefaultRetryDelayMs = 1000
-	// DefaultMaxConcurrency is the default maximum number of concurrent HTTP requests
-	DefaultMaxConcurrency = 10
-	// MaxConcurrencyLimit is the maximum allowed value for maxConcurrency
-	MaxConcurrencyLimit = 15
-	// DefaultMaxRetries is the default maximum number of retry attempts for failed requests
-	DefaultMaxRetries = 2
-	// MaxRetriesLimit is the maximum allowed value for maxRetries
-	MaxRetriesLimit = 4
-
-	// DefaultPerHostConcurrency is the default per-host concurrency limit
+	DefaultRetryDelayMs       = 1000
+	DefaultMaxConcurrency     = 10
+	MaxConcurrencyLimit       = 15
+	DefaultMaxRetries         = 2
+	MaxRetriesLimit           = 4
 	DefaultPerHostConcurrency = 2
-	// MaxPerHostConcurrencyLimit is the maximum allowed value for perHostConcurrency
 	MaxPerHostConcurrencyLimit = 15
-	// DefaultPerHostIntervalMs is the default minimum interval between requests to the same host
-	DefaultPerHostIntervalMs = 3000
-	// MinPerHostIntervalMs is the minimum non-zero value for perHostIntervalMs; values between 1 and 999 are rejected
-	MinPerHostIntervalMs = 1000
-	// MaxPerHostIntervalMsLimit is the maximum allowed value for perHostIntervalMs in milliseconds
+	DefaultPerHostIntervalMs  = 3000
+	MinPerHostIntervalMs      = 1000
 	MaxPerHostIntervalMsLimit = 60000
 
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )
 
-// defaultAllowedStatuses contains status codes never treated as link failures.
-// 429 (Too Many Requests) indicates rate limiting, not a broken link.
+// 429 (Too Many Requests) is rate limiting, not a broken link.
 var defaultAllowedStatuses = []int{http.StatusTooManyRequests}
 
 func isAllowedStatus(status int, extra []int) bool {
@@ -76,7 +59,6 @@ func isAllowedStatus(status int, extra []int) bool {
 	return false
 }
 
-// hostLimiter enforces per-host concurrency and minimum request interval.
 type hostLimiter struct {
 	sem       chan struct{} // nil when perHostConcurrency == 0
 	interval  time.Duration
@@ -84,7 +66,6 @@ type hostLimiter struct {
 	mu        sync.Mutex
 }
 
-// acquire waits for a per-host slot and enforces the minimum interval before returning.
 func (h *hostLimiter) acquire() {
 	if h.sem != nil {
 		h.sem <- struct{}{}
@@ -107,14 +88,12 @@ func (h *hostLimiter) acquire() {
 	}
 }
 
-// release frees the per-host semaphore slot.
 func (h *hostLimiter) release() {
 	if h.sem != nil {
 		<-h.sem
 	}
 }
 
-// hostLimiterRegistry maintains one hostLimiter per host.
 type hostLimiterRegistry struct {
 	mu                 sync.Mutex
 	limiters           map[string]*hostLimiter
@@ -144,7 +123,6 @@ func (r *hostLimiterRegistry) get(host string) *hostLimiter {
 	return lim
 }
 
-// extractHost returns the host component of rawURL (e.g. "github.com").
 func extractHost(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" {
@@ -153,8 +131,6 @@ func extractHost(rawURL string) string {
 	return u.Host
 }
 
-// ExtractExternalLinksWithLineNumbers extracts external links from the given lines.
-// The offset parameter is added to line numbers to account for stripped frontmatter.
 func ExtractExternalLinksWithLineNumbers(ctx *preprocess.Context, offset int) []ExtractedLink {
 	patterns := []*regexp.Regexp{
 		inlineLinkPattern,
@@ -182,7 +158,7 @@ func ExtractExternalLinksWithLineNumbers(ctx *preprocess.Context, offset int) []
 					if !seenInLine[url] {
 						results = append(results, ExtractedLink{
 							URL:  url,
-							Line: i + 1 + offset, // 1-based line number + offset for frontmatter
+							Line: i + 1 + offset,
 						})
 						seenInLine[url] = true
 					}
@@ -193,13 +169,7 @@ func ExtractExternalLinksWithLineNumbers(ctx *preprocess.Context, offset int) []
 	return results
 }
 
-// CheckExternalLinks checks external links in the given lines.
-// The offset parameter is used to calculate correct line numbers accounting for stripped frontmatter.
-// Returns lint errors and the count of unique URLs checked.
 func CheckExternalLinks(path string, ctx *preprocess.Context, offset int, skipPatterns []*regexp.Regexp, timeoutSeconds int, retryDelayMs int, maxConcurrency int, maxRetries int, allowedStatuses []int, urlCache *sync.Map, perHostConcurrency int, perHostIntervalMs int) ([]LintError, int) {
-	// Code/HTML context filtering is handled inside the extractor via the shared
-	// scanner, so links inside fenced/indented code, HTML blocks, HTML comments,
-	// inline code spans, and inline comments are never produced here.
 	links := ExtractExternalLinksWithLineNumbers(ctx, offset)
 
 	urlToLines := make(map[string][]int)
@@ -267,7 +237,6 @@ func CheckExternalLinks(path string, ctx *preprocess.Context, offset int, skipPa
 	return errs, len(urlToLines)
 }
 
-// checkURL performs the URL check with retry logic.
 func checkURL(client *http.Client, url string, retryDelayMs int, maxRetries int, allowedStatuses []int) (int, error) {
 	retryDelay := time.Duration(retryDelayMs) * time.Millisecond
 
@@ -281,33 +250,23 @@ func checkURL(client *http.Client, url string, retryDelayMs int, maxRetries int,
 
 		status, err = performCheck(client, url)
 
-		// Success: 2xx or 3xx
 		if err == nil && status < 400 {
 			return status, nil
 		}
-
-		// Allowed statuses (e.g. 429, user-configured): return immediately without retrying
 		if err == nil && isAllowedStatus(status, allowedStatuses) {
 			return status, nil
 		}
-
-		// Permanent failures: Don't bother retrying if it's 404 (Not Found) or 401 (Unauthorized)
 		if err == nil && (status == http.StatusNotFound || status == http.StatusUnauthorized) {
 			return status, nil
 		}
-
-		// If it's the last attempt, don't log "retrying"
 		if i == maxRetries {
 			break
 		}
-
-		// Optional: You could log that you're retrying here
 	}
 
 	return status, err
 }
 
-// performCheck contains the core HEAD -> GET fallback logic.
 func performCheck(client *http.Client, url string) (int, error) {
 	req, err := http.NewRequest("HEAD", url, nil)
 	if err != nil {

--- a/internal/rule/external_link.go
+++ b/internal/rule/external_link.go
@@ -28,16 +28,16 @@ type ExtractedLink struct {
 }
 
 const (
-	DefaultRetryDelayMs       = 1000
-	DefaultMaxConcurrency     = 10
-	MaxConcurrencyLimit       = 15
-	DefaultMaxRetries         = 2
-	MaxRetriesLimit           = 4
-	DefaultPerHostConcurrency = 2
+	DefaultRetryDelayMs        = 1000
+	DefaultMaxConcurrency      = 10
+	MaxConcurrencyLimit        = 15
+	DefaultMaxRetries          = 2
+	MaxRetriesLimit            = 4
+	DefaultPerHostConcurrency  = 2
 	MaxPerHostConcurrencyLimit = 15
-	DefaultPerHostIntervalMs  = 3000
-	MinPerHostIntervalMs      = 1000
-	MaxPerHostIntervalMsLimit = 60000
+	DefaultPerHostIntervalMs   = 3000
+	MinPerHostIntervalMs       = 1000
+	MaxPerHostIntervalMsLimit  = 60000
 
 	userAgent = "gomarklint/v3 (+https://github.com/shinagawa-web/gomarklint)"
 )

--- a/internal/rule/fence.go
+++ b/internal/rule/fence.go
@@ -1,8 +1,5 @@
 package rule
 
-// openingFenceMarker returns the full fence marker (e.g. "```", "````", "~~~") if the line
-// is an opening fence, or an empty string otherwise. The full run of fence characters is
-// captured so that closing fences of the same length are correctly matched.
 // Returns a substring of trimmed to avoid heap allocation.
 func openingFenceMarker(trimmed string) string {
 	if len(trimmed) < 3 {

--- a/internal/rule/fenced_code_language.go
+++ b/internal/rule/fenced_code_language.go
@@ -6,19 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckFencedCodeLanguage checks that all fenced code blocks specify a language identifier.
-// Fenced code blocks opened with ``` or ~~~ without a language tag are flagged (MD040).
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError, one per opening fence that is missing a language identifier.
-//
-// Fence openers inside indented code, HTML blocks, and HTML comments are not real
-// fences and are excluded by the scanner, so they are never examined.
 func CheckFencedCodeLanguage(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/final_blank_line.go
+++ b/internal/rule/final_blank_line.go
@@ -1,15 +1,5 @@
 package rule
 
-// CheckFinalBlankLine checks whether the Markdown content ends with a blank line.
-// This is a common requirement in many Markdown style guides.
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - lines: the Markdown content split into lines (with frontmatter already removed)
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError with one entry if the final blank line is missing.
 func CheckFinalBlankLine(filename string, lines []string, offset int) []LintError {
 	// A frontmatter-only file has an empty body (lines==[""]). Offset > 0 means
 	// frontmatter was stripped; there is no body to enforce the rule on.

--- a/internal/rule/heading_level.go
+++ b/internal/rule/heading_level.go
@@ -7,7 +7,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// LintError represents a single lint violation detected in a Markdown file.
 type LintError struct {
 	File     string `json:"file"`
 	Line     int    `json:"line"`
@@ -16,10 +15,6 @@ type LintError struct {
 	Severity string `json:"severity"`
 }
 
-// atxHeadingLevel returns the ATX heading level (1–6) if line begins with a
-// valid ATX heading marker, or 0 otherwise. A valid marker is one to six '#'
-// characters followed by a space, a tab, or end-of-string.
-// This replaces a regex match and allocates nothing.
 func atxHeadingLevel(line string) int {
 	level := 0
 	for level < len(line) && line[level] == '#' {
@@ -35,21 +30,6 @@ func atxHeadingLevel(line string) int {
 	return 0
 }
 
-// CheckHeadingLevels analyzes the heading structure of the given Markdown content
-// and reports any issues such as the first heading not starting at the specified minimum level
-// or heading levels that jump more than one level (e.g., from ## to ####).
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//   - minLevel: the expected minimum level for the first heading (e.g., 2 for ##)
-//
-// Returns:
-//   - A slice of LintError containing the line number and description of each detected issue.
-//
-// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
-// ignored, so they neither report nor pollute the heading-level state.
 func CheckHeadingLevels(filename string, ctx *preprocess.Context, offset int, minLevel int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/inline_strip.go
+++ b/internal/rule/inline_strip.go
@@ -2,14 +2,9 @@ package rule
 
 import "strings"
 
-// This file holds inline-code-stripping helpers. Its sole remaining consumer is
-// no-hard-tabs, a markdownlint divergence (#337 Section B) that strips inline
-// code spans but — unlike the shared preprocess sanitizer — must NOT blank inline
-// HTML comments (it still reports tabs there). The other rules that once shared
-// these helpers now use preprocess.Context.Sanitized instead.
+// no-hard-tabs strips inline code but NOT inline HTML comments (markdownlint divergence #337 Section B).
+// Other rules use preprocess.Context.Sanitized which blanks both.
 
-// countBacktickRun returns the number of consecutive backticks starting at
-// position start in s.
 func countBacktickRun(s string, start int) int {
 	n := 0
 	for start+n < len(s) && s[start+n] == '`' {
@@ -18,11 +13,6 @@ func countBacktickRun(s string, start int) int {
 	return n
 }
 
-// stripInlineCode replaces content inside backtick spans (including the
-// delimiters) with spaces so that URLs within inline code are not scanned.
-// Handles single- and multi-backtick code spans (e.g. `code`) per CommonMark:
-// a code span opens with a run of N backticks and closes with the next run of
-// exactly N backticks, so a longer run can contain shorter ones.
 func stripInlineCode(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))

--- a/internal/rule/link_fragments.go
+++ b/internal/rule/link_fragments.go
@@ -8,9 +8,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// extractHeadingText extracts the plain text from an ATX heading line (e.g. ## Heading).
-// Returns the trimmed heading text and its level (1–6).
-// Returns "", 0 for lines that are not valid ATX headings.
 func extractHeadingText(line string) (string, int) {
 	if len(line) == 0 || line[0] != '#' {
 		return "", 0
@@ -32,26 +29,11 @@ func extractHeadingText(line string) (string, int) {
 	return strings.TrimSpace(rest[1:]), level
 }
 
-// reFragmentLink matches inline fragment links: [text](#fragment)
-// Capture group 1 is the fragment without the leading #.
 var reFragmentLink = regexp.MustCompile(`\[[^\]]*\]\(#([^)]+)\)`)
-
-// reRefLinkUsage matches reference-style link usage: [text][label]
-// Capture group 1 is the reference label.
 var reRefLinkUsage = regexp.MustCompile(`\[[^\]]*\]\[([^\]]+)\]`)
-
-// reRefDef matches reference link definitions that target a fragment: [label]: #fragment
-// Capture group 1 is the label; group 2 is the fragment without the leading #.
 var reRefDef = regexp.MustCompile(`^\s*\[([^\]]+)\]:\s+#(\S+)`)
-
-// reStripInlineImages matches inline images: ![alt](url)
-// Used to remove image syntax before fragment link detection to avoid false positives
-// from image fragments like ![alt](#fig-1).
 var reStripInlineImages = regexp.MustCompile(`!\[[^\]]*\]\([^)]*\)`)
 
-// collectRefDefs returns a map from normalized reference label to fragment string (without #)
-// for all reference link definitions that target a fragment destination.
-// Definitions inside fenced/indented code, HTML blocks, and HTML comments are excluded.
 func collectRefDefs(ctx *preprocess.Context) map[string]string {
 	defs := make(map[string]string)
 	for i := 0; i < ctx.Len(); i++ {
@@ -59,7 +41,6 @@ func collectRefDefs(ctx *preprocess.Context) map[string]string {
 			continue
 		}
 		line := ctx.Line(i)
-		// Reference definitions must start with optional whitespace then '['.
 		if !strings.HasPrefix(strings.TrimLeft(line, " \t"), "[") {
 			continue
 		}
@@ -74,12 +55,6 @@ func collectRefDefs(ctx *preprocess.Context) map[string]string {
 	return defs
 }
 
-// collectHeadingSlugs returns the set of all valid fragment slugs computed from ATX headings.
-// Headings inside fenced/indented code, HTML blocks, and HTML comments are
-// excluded, so a fake heading inside (e.g.) an indented code block no longer
-// pollutes the valid-slug set and masks a broken fragment link (audit #337 false
-// negative).
-// Duplicate headings produce suffixed slugs (-1, -2, …) following GitHub convention.
 func collectHeadingSlugs(ctx *preprocess.Context, slugger func(string) string) map[string]struct{} {
 	var headings []string
 
@@ -97,15 +72,6 @@ func collectHeadingSlugs(ctx *preprocess.Context, slugger func(string) string) m
 	return buildSlugSet(headings, slugger)
 }
 
-// hasAnyFragmentSyntax is a cheap pre-filter that reports whether any non-block
-// line could be a fragment link or fragment definition. Checks for "(#" (inline
-// fragment links) and "]: #" (reference definition pointing at a fragment).
-//
-// It skips block contexts, since every real pass below does too — so fragment
-// syntax that lives only inside code/HTML/comment no longer trips the more
-// expensive passes. It reads the raw line (a superset of the sanitized text and
-// of the raw text the ref-def pass uses), so it never exits early while a real
-// fragment construct exists.
 func hasAnyFragmentSyntax(ctx *preprocess.Context) bool {
 	for i := 0; i < ctx.Len(); i++ {
 		if inBlockContext(ctx, i) {
@@ -119,9 +85,6 @@ func hasAnyFragmentSyntax(ctx *preprocess.Context) bool {
 	return false
 }
 
-// hasAnyFragmentLinks reports whether any non-block line contains at least one
-// potential fragment link. Like hasAnyFragmentSyntax it skips block contexts and
-// reads the raw line, staying O(n) with a single pass and minimal overhead.
 func hasAnyFragmentLinks(ctx *preprocess.Context, refDefs map[string]string) bool {
 	for i := 0; i < ctx.Len(); i++ {
 		if inBlockContext(ctx, i) {
@@ -138,7 +101,6 @@ func hasAnyFragmentLinks(ctx *preprocess.Context, refDefs map[string]string) boo
 	return false
 }
 
-// parseSlugAlgorithm extracts the slug-algorithm option, defaulting to "github".
 func parseSlugAlgorithm(options map[string]interface{}) string {
 	if v, ok := options["slug-algorithm"]; ok {
 		if s, ok := v.(string); ok && s != "" {
@@ -148,7 +110,6 @@ func parseSlugAlgorithm(options map[string]interface{}) string {
 	return "github"
 }
 
-// checkInlineFragments checks inline fragment links ([text](#frag)) on one line.
 func checkInlineFragments(filename string, lineNum int, scanned string, slugs map[string]struct{}) []LintError {
 	var errs []LintError
 	for _, m := range reFragmentLink.FindAllStringSubmatch(scanned, -1) {
@@ -164,7 +125,6 @@ func checkInlineFragments(filename string, lineNum int, scanned string, slugs ma
 	return errs
 }
 
-// checkRefFragments checks reference-style fragment links ([text][ref] with [ref]: #frag) on one line.
 func checkRefFragments(filename string, lineNum int, scanned string, slugs map[string]struct{}, refDefs map[string]string) []LintError {
 	var errs []LintError
 	for _, m := range reRefLinkUsage.FindAllStringSubmatch(scanned, -1) {
@@ -184,20 +144,6 @@ func checkRefFragments(filename string, lineNum int, scanned string, slugs map[s
 	return errs
 }
 
-// CheckLinkFragments validates that every internal fragment link in the document
-// resolves to an actual heading slug. Both inline links ([text](#frag)) and
-// reference links ([text][ref] + [ref]: #frag) are checked. Content inside fenced
-// code, indented code, HTML blocks, HTML comments, and inline code spans is
-// skipped — for both the link checks and the heading/definition collection.
-//
-// Supported options:
-//   - "slug-algorithm": string — preset name (github, gitlab, zenn, pandoc, pandoc-gfm,
-//     kramdown, mkdocs, docfx, hugo, qiita, mdbook, vitepress, gitea, forgejo, sphinx,
-//     eleventy, azure-devops, myst, docusaurus, gatsby, astro, starlight, nuxt-content,
-//     quarto) or "custom" (default: "github")
-//   - "slug-params": map — used only when slug-algorithm is "custom"; keys: lowercase (bool),
-//     preserve-unicode (bool), space-replacement (string), strip-chars (regex string),
-//     collapse-separators (bool)
 func CheckLinkFragments(filename string, ctx *preprocess.Context, offset int, options map[string]interface{}) []LintError {
 	if !hasAnyFragmentSyntax(ctx) {
 		return nil

--- a/internal/rule/link_fragments_slug.go
+++ b/internal/rule/link_fragments_slug.go
@@ -10,48 +10,19 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// reSlugHTMLComment matches HTML comments for removal from heading text.
 var reSlugHTMLComment = regexp.MustCompile(`<!--.*?-->`)
-
-// reSlugHTMLTag matches HTML tags for removal from heading text.
 var reSlugHTMLTag = regexp.MustCompile(`<[^>]+>`)
-
-// reSlugRefImage matches reference-style images: ![alt][ref]
 var reSlugRefImage = regexp.MustCompile(`!\[([^\]]*)\]\[[^\]]*\]`)
-
-// reSlugImage matches inline images: ![alt](url)
 var reSlugImage = regexp.MustCompile(`!\[([^\]]*)\]\([^)]*\)`)
-
-// reSlugRefLink matches reference-style links: [text][ref]
 var reSlugRefLink = regexp.MustCompile(`\[([^\]]*)\]\[[^\]]*\]`)
-
-// reSlugLink matches inline links: [text](url)
 var reSlugLink = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
-
-// reSlugBoldAsterisk matches **bold**
 var reSlugBoldAsterisk = regexp.MustCompile(`\*\*([^*]+)\*\*`)
-
-// reSlugBoldUnderscore matches __bold__
 var reSlugBoldUnderscore = regexp.MustCompile(`__([^_]+)__`)
-
-// reSlugItalicAsterisk matches *italic*
 var reSlugItalicAsterisk = regexp.MustCompile(`\*([^*]+)\*`)
-
-// reSlugItalicUnderscore matches _italic_
 var reSlugItalicUnderscore = regexp.MustCompile(`_([^_]+)_`)
-
-// reSlugCode matches inline code spans (single or multi-backtick), keeping content.
 var reSlugCode = regexp.MustCompile("`+([^`]+)`+")
-
-// reSphinxNonAlnum replaces runs of non-alphanumeric ASCII chars with a single hyphen.
 var reSphinxNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 
-// stripHeadingFormatting removes Markdown and HTML inline formatting from heading text,
-// returning plain text for slug generation.
-// Order: HTML comments → HTML tags → images → links → code spans (saved as placeholders) →
-// bold → italic → code span content restored.
-// Code spans are saved before bold/italic to prevent underscores/asterisks inside backticks
-// from being mis-parsed as emphasis markers.
 func stripHeadingFormatting(s string) string {
 	// Fast path: plain headings with no formatting markers need no processing.
 	if !strings.ContainsAny(s, "*_[<`!") {
@@ -81,8 +52,6 @@ func stripHeadingFormatting(s string) string {
 	return s
 }
 
-// githubStripRune reports whether r should be removed by the GitHub slug algorithm.
-// Matches github-slugger v2: keeps \p{L}, \p{Nd}, \p{Nl}, hyphens, and underscores.
 func githubStripRune(r rune) bool {
 	if r == '-' || r == '_' {
 		return false
@@ -90,9 +59,6 @@ func githubStripRune(r rune) bool {
 	return !unicode.IsLetter(r) && !unicode.Is(unicode.Nd, r) && !unicode.Is(unicode.Nl, r)
 }
 
-// slugGitHub computes the GitHub-compatible slug (github-slugger v2).
-// Lowercases, strips all runes outside \p{L}/\p{Nd}/\p{Nl}/-/_, replaces whitespace with hyphens.
-// Consecutive whitespace produces consecutive hyphens (no collapsing).
 func slugGitHub(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -107,8 +73,6 @@ func slugGitHub(text string) string {
 	return sb.String()
 }
 
-// slugGitLab computes the GitLab (goldmark slugify) slug.
-// Lowercases, keeps Unicode letters/numbers/hyphens/underscores, collapses consecutive hyphens.
 func slugGitLab(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -123,8 +87,6 @@ func slugGitLab(text string) string {
 	return collapseDashes(sb.String())
 }
 
-// slugZenn computes the Zenn (markdown-it-anchor default) slug.
-// Lowercases and replaces whitespace with hyphens; all other characters are preserved.
 func slugZenn(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -139,9 +101,6 @@ func slugZenn(text string) string {
 	return sb.String()
 }
 
-// slugPandoc computes the Pandoc auto_identifiers slug.
-// Lowercases, keeps only ASCII letters/digits/hyphens/underscores/periods, collapses consecutive
-// hyphens, then strips everything up to the first letter (Pandoc auto_identifiers step 5).
 func slugPandoc(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -162,9 +121,6 @@ func slugPandoc(text string) string {
 	return ""
 }
 
-// slugKramdown computes the kramdown header_ids slug.
-// Lowercases, keeps only ASCII letters/digits/hyphens, replaces spaces with hyphens, collapses,
-// then strips leading digits and hyphens (kramdown skips chars until the first letter).
 func slugKramdown(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -181,10 +137,6 @@ func slugKramdown(text string) string {
 	return strings.TrimLeft(result, "0123456789-")
 }
 
-// slugMkDocs computes the MkDocs (Python-Markdown toc.py) slug.
-// NFKD-normalizes to decompose accented chars (é→e), lowercases, keeps Unicode letters,
-// all Unicode numbers (Nd/Nl/No — matching Python's \w which includes roman numerals and
-// superscripts), hyphens, and underscores, replaces spaces with hyphens, and collapses.
 func slugMkDocs(text string) string {
 	text = nfkdStripCombining(text)
 	var sb strings.Builder
@@ -200,8 +152,6 @@ func slugMkDocs(text string) string {
 	return collapseDashes(sb.String())
 }
 
-// slugDocFX computes the DocFX (Markdig AutoIdentifiers) slug.
-// Preserves case, keeps only [a-zA-Z0-9-_.], replaces spaces with hyphens, collapses.
 func slugDocFX(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -216,9 +166,6 @@ func slugDocFX(text string) string {
 	return collapseDashes(sb.String())
 }
 
-// nfkdStripCombining applies NFKD normalization and removes Unicode combining characters (category Mn).
-// This converts precomposed accented characters to their base ASCII equivalents
-// (e.g. 'é' → 'e', 'ü' → 'u') while preserving CJK and other non-combining Unicode.
 func nfkdStripCombining(text string) string {
 	normalized := norm.NFKD.String(text)
 	var sb strings.Builder
@@ -231,9 +178,6 @@ func nfkdStripCombining(text string) string {
 	return sb.String()
 }
 
-// slugQiita computes the Qiita slug.
-// Equivalent to Ruby: downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-")
-// Keeps Unicode letters, digits, underscores, and hyphens; collapses nothing.
 func slugQiita(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -248,9 +192,6 @@ func slugQiita(text string) string {
 	return sb.String()
 }
 
-// slugMdBook computes the mdBook (normalize_id) slug.
-// Rust's is_alphanumeric() keeps Unicode letters and numbers; underscores,
-// spaces, and hyphens collapse to a single hyphen; trailing hyphens are stripped.
 func slugMdBook(text string) string {
 	var sb strings.Builder
 	sb.Grow(len(text))
@@ -271,10 +212,6 @@ func slugMdBook(text string) string {
 	return strings.TrimRight(sb.String(), "-")
 }
 
-// slugVitePress computes the VitePress (markdown-it-anchor) slug.
-// NFKD-normalizes to strip combining chars (accented Latin → ASCII base),
-// then lowercases and replaces non-alphanumeric chars with hyphens, collapsing runs.
-// CJK and other Unicode letters/digits are preserved.
 func slugVitePress(text string) string {
 	text = nfkdStripCombining(text)
 	var sb strings.Builder
@@ -290,20 +227,11 @@ func slugVitePress(text string) string {
 	return collapseDashes(sb.String())
 }
 
-// slugGitea computes the Gitea (goldmark) slug.
-// Algorithm is identical to GitHub (github-slugger v2).
-// Note: Gitea adds "user-content-" to the DOM id attribute for CSP isolation,
-// but users write fragment links without that prefix — the anchor href omits it.
+// Gitea adds "user-content-" to DOM id for CSP isolation, but fragment links omit that prefix.
 func slugGitea(text string) string {
 	return slugGitHub(text)
 }
 
-// slugSphinx computes the Sphinx (Python-Sphinx auto-section-label) slug.
-// NFKD-normalizes to strip combining chars, keeps only lowercase ASCII alphanumerics,
-// replaces runs of non-alphanumeric with a single hyphen, then strips leading hyphens and
-// leading digits (matching docutils _non_id_at_ends: ^[-0-9]+|-+$) and trailing hyphens.
-// Non-Latin-only headings that produce an empty result return "" (the id1/id2 fallback
-// is document-level state that cannot be reproduced outside the build context).
 func slugSphinx(text string) string {
 	text = nfkdStripCombining(text)
 	var ascii strings.Builder
@@ -320,7 +248,6 @@ func slugSphinx(text string) string {
 	return strings.TrimRight(result, "-")
 }
 
-// umlautReplacer expands German umlauts before NFKD, matching @sindresorhus/slugify's char map.
 var umlautReplacer = strings.NewReplacer(
 	"ä", "ae", "Ä", "ae",
 	"ö", "oe", "Ö", "oe",
@@ -328,11 +255,6 @@ var umlautReplacer = strings.NewReplacer(
 	"ß", "ss",
 )
 
-// slugEleventy computes an approximation of the Eleventy (@sindresorhus/slugify) slug.
-// Expands German umlauts, NFKD-normalizes, then converts any non-ASCII-alphanumeric char
-// to a hyphen (collapsing consecutive ones). Non-ASCII chars without a mapping (CJK, etc.)
-// also become hyphens, matching @sindresorhus/slugify which replaces unknown chars with the
-// separator; leading/trailing hyphens are trimmed, so purely non-ASCII input yields "".
 func slugEleventy(text string) string {
 	text = umlautReplacer.Replace(text)
 	text = nfkdStripCombining(text)
@@ -352,9 +274,6 @@ func slugEleventy(text string) string {
 	return strings.TrimRight(sb.String(), "-")
 }
 
-// slugAzureDevOps computes the Azure DevOps Wiki slug.
-// Lowercases, replaces Unicode space-separator chars (Zs) with hyphens, keeps RFC 3986
-// unreserved chars (letters, digits, -, ., _, ~) as-is, and percent-encodes everything else.
 func slugAzureDevOps(text string) string {
 	const hexChars = "0123456789ABCDEF"
 	var sb strings.Builder
@@ -380,7 +299,6 @@ func slugAzureDevOps(text string) string {
 	return sb.String()
 }
 
-// slugCustomParams holds the resolved parameters for the custom slug engine.
 type slugCustomParams struct {
 	lowercase          bool
 	preserveUnicode    bool
@@ -390,7 +308,6 @@ type slugCustomParams struct {
 	collapseRe         *regexp.Regexp // pre-compiled collapse pattern; nil when collapse is off
 }
 
-// parseSlugParams extracts custom slug parameters from an options map.
 func parseSlugParams(opts map[string]interface{}) slugCustomParams {
 	p := slugCustomParams{
 		lowercase:          true,
@@ -431,8 +348,6 @@ func parseSlugParams(opts map[string]interface{}) slugCustomParams {
 	return p
 }
 
-// slugCustom applies the parameterized slug engine.
-// Processing order: lowercase → per-char (space→sep, strip non-Unicode) → strip-chars regex → collapse.
 func slugCustom(text string, p slugCustomParams) string {
 	if p.lowercase {
 		text = strings.ToLower(text)
@@ -462,8 +377,6 @@ func slugCustom(text string, p slugCustomParams) string {
 	return result
 }
 
-// collapseDashes replaces runs of consecutive hyphens with a single hyphen
-// and strips leading and trailing hyphens.
 func collapseDashes(s string) string {
 	if s == "" {
 		return s
@@ -488,9 +401,6 @@ func collapseDashes(s string) string {
 	return result
 }
 
-// buildSlugSet builds the full set of valid fragment slugs from the given headings,
-// applying deduplication. The first occurrence of a slug is bare (e.g. "intro");
-// subsequent duplicates get a numeric suffix (e.g. "intro-1", "intro-2").
 func buildSlugSet(headings []string, slugger func(string) string) map[string]struct{} {
 	slugs := make(map[string]struct{})
 	seen := make(map[string]int)
@@ -513,9 +423,6 @@ func buildSlugSet(headings []string, slugger func(string) string) map[string]str
 	return slugs
 }
 
-// makeSlugger returns a slug function for the given algorithm and options.
-// For "custom", options["slug-params"] is parsed into slugCustomParams.
-// All other algorithm names are dispatched through ComputeSlug.
 func makeSlugger(algorithm string, options map[string]interface{}) func(string) string {
 	if algorithm == "custom" {
 		params := parseSlugParams(options)
@@ -528,11 +435,7 @@ func makeSlugger(algorithm string, options map[string]interface{}) func(string) 
 	}
 }
 
-// slugRegistry maps each supported platform name to its slug function.
-// Each platform is listed independently so configuration is self-evident and
-// individual entries can be updated if an algorithm diverges from its current mapping.
 var slugRegistry = map[string]func(string) string{
-	// GitHub-compatible
 	"github":       slugGitHub,
 	"hugo":         slugGitHub,
 	"pandoc-gfm":   slugGitHub,
@@ -542,38 +445,23 @@ var slugRegistry = map[string]func(string) string{
 	"astro":        slugGitHub,
 	"starlight":    slugGitHub,
 	"nuxt-content": slugGitHub,
-	// GitLab
-	"gitlab": slugGitLab,
-	// Zenn
-	"zenn": slugZenn,
-	// Pandoc family
-	"pandoc": slugPandoc,
-	"quarto": slugPandoc,
-	// kramdown
-	"kramdown": slugKramdown,
-	// MkDocs
-	"mkdocs": slugMkDocs,
-	// DocFX
-	"docfx": slugDocFX,
-	// Qiita
-	"qiita": slugQiita,
-	// mdBook (Rust is_alphanumeric — underscore → hyphen, trailing hyphen stripped)
-	"mdbook": slugMdBook,
-	// VitePress
-	"vitepress": slugVitePress,
-	// Gitea / Forgejo
-	"gitea":   slugGitea,
-	"forgejo": slugGitea,
-	// Sphinx
-	"sphinx": slugSphinx,
-	// Eleventy
-	"eleventy": slugEleventy,
-	// Azure DevOps
+	"gitlab":       slugGitLab,
+	"zenn":         slugZenn,
+	"pandoc":       slugPandoc,
+	"quarto":       slugPandoc,
+	"kramdown":     slugKramdown,
+	"mkdocs":       slugMkDocs,
+	"docfx":        slugDocFX,
+	"qiita":        slugQiita,
+	"mdbook":       slugMdBook,
+	"vitepress":    slugVitePress,
+	"gitea":        slugGitea,
+	"forgejo":      slugGitea,
+	"sphinx":       slugSphinx,
+	"eleventy":     slugEleventy,
 	"azure-devops": slugAzureDevOps,
 }
 
-// ComputeSlug generates a URL fragment slug from heading plain text using the named algorithm.
-// Unknown algorithm names fall back to "github".
 func ComputeSlug(text, algorithm string) string {
 	if fn, ok := slugRegistry[algorithm]; ok {
 		return fn(text)

--- a/internal/rule/max_line_length.go
+++ b/internal/rule/max_line_length.go
@@ -7,9 +7,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// isBareURLLine reports whether the trimmed line consists solely of a single
-// URL token (http:// or https://), possibly wrapped in angle brackets.
-// Lines like "https://example.com extra text" are NOT exempt.
 func isBareURLLine(trimmed string) bool {
 	s := trimmed
 	if strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">") {
@@ -28,14 +25,6 @@ func isBareURLLine(trimmed string) bool {
 	return !strings.ContainsAny(s[schemeLen:], " \t")
 }
 
-// CheckMaxLineLength flags lines whose byte length exceeds lineLength.
-// Lines inside fenced code blocks, ATX heading lines, and lines that consist
-// solely of a URL are exempt.
-//
-// This is a markdownlint divergence (#337 Section B): only fenced code is
-// skipped. Lines inside indented code and HTML blocks are deliberately still
-// checked, so the rule skips just preprocess.InFencedCode rather than every
-// block context.
 func CheckMaxLineLength(filename string, ctx *preprocess.Context, offset int, lineLength int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/no_bare_urls.go
+++ b/internal/rule/no_bare_urls.go
@@ -7,15 +7,10 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// isURLBodyChar returns true for characters allowed in a URL body
-// (everything except whitespace, <>, ()[], and quotes).
 func isURLBodyChar(c byte) bool {
 	return c > ' ' && c != '<' && c != '>' && c != '(' && c != ')' && c != '[' && c != ']' && c != '"' && c != '\''
 }
 
-// isWrappedURL returns true if the URL starting at start in line is wrapped
-// in angle brackets, is a Markdown link/image destination, or appears inside
-// an HTML attribute value (a quote immediately preceded by '=').
 func isWrappedURL(line string, start int) bool {
 	if start > 0 && line[start-1] == '<' {
 		return true
@@ -35,7 +30,6 @@ func isWrappedURL(line string, start int) bool {
 	return false
 }
 
-// scanURLEnd returns the end index of the URL body starting at bodyStart.
 func scanURLEnd(line string, bodyStart int) int {
 	end := bodyStart
 	for end < len(line) && isURLBodyChar(line[end]) {
@@ -44,9 +38,6 @@ func scanURLEnd(line string, bodyStart int) int {
 	return end
 }
 
-// findBareURLs scans line for bare HTTP/HTTPS URLs and returns their text.
-// URLs wrapped in angle brackets or used as Markdown link destinations are
-// skipped.
 func findBareURLs(line string) []string {
 	var urls []string
 	pos := 0
@@ -81,13 +72,7 @@ func findBareURLs(line string) []string {
 	return urls
 }
 
-// isLinkCard reports whether line i is a standalone link-card URL: the
-// trimmed line is a single http/https URL with no surrounding prose, preceded
-// and followed by a blank line (or the file boundary). Such lines are
-// intentionally placed by the author to trigger renderer-level link card
-// previews (GitHub, Zenn, etc.) and must not be flagged. The trimmed argument
-// is derived from the original line so that inline code or comment markers on
-// the line disqualify it from being a bare link card.
+// isLinkCard: a standalone URL surrounded by blank lines is a renderer link-card preview (GitHub, Zenn, etc.) — not a violation.
 func isLinkCard(ctx *preprocess.Context, i int, trimmed string) bool {
 	if !strings.HasPrefix(trimmed, "http://") && !strings.HasPrefix(trimmed, "https://") {
 		return false
@@ -101,37 +86,19 @@ func isLinkCard(ctx *preprocess.Context, i int, trimmed string) bool {
 	return prevBlank && nextBlank
 }
 
-// CheckNoBareURLs flags HTTP/HTTPS URLs that appear as bare text rather than
-// being wrapped in angle brackets or used inside a Markdown link or image.
-// URLs inside fenced code blocks, indented code blocks, HTML blocks, HTML
-// comments, inline code spans, and HTML attribute values are ignored. A URL
-// that stands alone on its own line surrounded by blank lines is treated as a
-// link card and not flagged.
-//
-// This rule is the reference adoption of the shared preprocess pass (#337
-// Phase 2): rather than re-deriving code/comment context, it skips lines the
-// scanner already classified as code or HTML and scans the inline-sanitized
-// text (code spans and inline comments blanked) for the remaining lines.
 func CheckNoBareURLs(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 
 	for i := 0; i < ctx.Len(); i++ {
-		// Skip every block context the scanner already identified. This closes
-		// the indented-code and HTML-block gaps the previous bespoke fence/
-		// comment tracking missed.
 		if ctx.InFencedCode(i) || ctx.InIndentedCode(i) || ctx.InHTMLBlock(i) || ctx.InHTMLComment(i) {
 			continue
 		}
 
-		// Sanitized has inline code spans and inline comments blanked, so URLs
-		// living inside them are not seen here.
 		sanitized := ctx.Sanitized(i)
 		if !strings.Contains(sanitized, "http") {
 			continue
 		}
 
-		// The link-card test uses the original text: a line carrying anything
-		// besides the URL (e.g. an inline code span) is not a bare link card.
 		if isLinkCard(ctx, i, strings.TrimSpace(ctx.Line(i))) {
 			continue
 		}

--- a/internal/rule/no_emphasis_as_heading.go
+++ b/internal/rule/no_emphasis_as_heading.go
@@ -7,9 +7,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// matchDoubleDelim returns the inner text if line is entirely wrapped in a
-// two-character delimiter (e.g. "**" or "__"). The inner text must not contain
-// the delimiter itself.
 func matchDoubleDelim(line, delim string) (string, bool) {
 	if len(line) <= len(delim)*2 {
 		return "", false
@@ -24,9 +21,6 @@ func matchDoubleDelim(line, delim string) (string, bool) {
 	return inner, true
 }
 
-// matchSingleDelim returns the inner text if line is entirely wrapped in a
-// single-character delimiter (e.g. '*' or '_') that is not doubled. The inner
-// text must not contain the delimiter character.
 func matchSingleDelim(line string, ch byte) (string, bool) {
 	double := string([]byte{ch, ch})
 	if len(line) <= 2 || line[0] != ch || line[len(line)-1] != ch {
@@ -42,15 +36,6 @@ func matchSingleDelim(line string, ch byte) (string, bool) {
 	return inner, true
 }
 
-// emphasisContent extracts the inner text if line is entirely a single bold or
-// italic span. Returns ("", false) when the line is not a bare emphasis span.
-//
-// Recognized forms (CommonMark):
-//
-//	**text**   __text__   (strong)
-//	*text*     _text_     (emphasis)
-//
-// The span must cover the entire trimmed line — no surrounding text allowed.
 func emphasisContent(line string) (string, bool) {
 	if inner, ok := matchDoubleDelim(line, "**"); ok {
 		return inner, true
@@ -67,17 +52,11 @@ func emphasisContent(line string) (string, bool) {
 	return "", false
 }
 
-// punctuationChars is the set of sentence-ending punctuation characters that
-// indicate the emphasis is prose rather than a heading substitute.
-// Includes ASCII and full-width equivalents used in CJK writing systems.
-// Mirrors the default punctuation list used by markdownlint MD036.
 var punctuationChars = map[rune]struct{}{
 	'.': {}, ',': {}, ';': {}, ':': {}, '!': {}, '?': {}, // ASCII
 	'。': {}, '、': {}, '；': {}, '：': {}, '！': {}, '？': {}, // Full-width / CJK
 }
 
-// endsWithPunctuation reports whether s ends with sentence-ending punctuation.
-// When true, the emphasis is likely inline prose, not a heading.
 func endsWithPunctuation(s string) bool {
 	if s == "" {
 		return false
@@ -87,13 +66,6 @@ func endsWithPunctuation(s string) bool {
 	return ok
 }
 
-// CheckNoEmphasisAsHeading flags lines where bold or italic text is used as a
-// substitute for an ATX heading (MD036). A violation is reported when:
-//  1. The trimmed line consists entirely of a single bold/italic span.
-//  2. The inner text does not end with sentence-ending punctuation.
-//
-// Lines inside fenced code, indented code, HTML blocks, and HTML comments are
-// ignored.
 func CheckNoEmphasisAsHeading(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/no_empty_links.go
+++ b/internal/rule/no_empty_links.go
@@ -7,16 +7,10 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// emptyLinkDest reports whether dest is an "empty" link destination.
-// Empty means literally empty, a lone fragment "#", or angle-bracket-wrapped
-// empty "<>".
 func emptyLinkDest(dest string) bool {
 	return dest == "" || dest == "#" || dest == "<>"
 }
 
-// findEmptyLinks scans a single line (already stripped of inline code) for
-// Markdown links or images whose destination is empty.
-// It returns the raw matched text for each violation (e.g. "[text]()").
 func findEmptyLinks(line string) []string {
 	var results []string
 	pos := 0
@@ -56,10 +50,6 @@ func findEmptyLinks(line string) []string {
 	return results
 }
 
-// CheckNoEmptyLinks flags Markdown links and images whose destination URL is
-// empty, contains only "#", or is "<>".
-// Links inside fenced code, indented code, HTML blocks, HTML comments, and inline
-// code spans are ignored.
 func CheckNoEmptyLinks(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 
@@ -68,8 +58,6 @@ func CheckNoEmptyLinks(filename string, ctx *preprocess.Context, offset int) []L
 			continue
 		}
 
-		// Sanitized blanks inline code spans and inline comments, so links
-		// living inside them are not seen here.
 		line := ctx.Sanitized(i)
 		if !strings.Contains(line, "](") {
 			continue

--- a/internal/rule/no_hard_tabs.go
+++ b/internal/rule/no_hard_tabs.go
@@ -7,14 +7,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckNoHardTabs flags hard tab characters (\t) outside fenced code blocks
-// and inline code spans. Each tab is reported as a separate violation.
-//
-// This is a markdownlint divergence (#337 Section B): only fenced code is
-// skipped (tabs in indented code are still reported), and inline code spans are
-// stripped. It therefore skips just preprocess.InFencedCode and keeps its own
-// inline-code stripping rather than using the shared block-context helper or the
-// sanitized view (which would also blank inline HTML comments).
 func CheckNoHardTabs(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 

--- a/internal/rule/no_multiple_blank_lines.go
+++ b/internal/rule/no_multiple_blank_lines.go
@@ -6,26 +6,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckNoMultipleBlankLines checks whether the Markdown content contains
-// multiple consecutive blank lines.
-//
-// This rule helps maintain consistency and readability by ensuring
-// no more than one consecutive blank line appears in the document.
-//
-// It ignores multiple consecutive newlines in code blocks.
-//
-// Parameters:
-//   - filename: the name of the file being checked (used in error reporting)
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError with entries for each occurrence of multiple consecutive blank lines.
-//
-// Blank lines inside any block context the scanner identifies are not counted —
-// fenced code, but also blank lines inside type 1–5 HTML blocks (e.g. <pre>) and
-// multi-line HTML comments. Blank lines between indented-code paragraphs are not
-// classified as indented by the scanner, so that case remains a known limitation.
 func CheckNoMultipleBlankLines(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	consecutiveBlankCount := 0

--- a/internal/rule/no_trailing_punctuation.go
+++ b/internal/rule/no_trailing_punctuation.go
@@ -8,9 +8,6 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// atxHeadingText returns the visible text of an ATX heading with the opening
-// '#' markers and optional closing '#' sequence removed.
-// Returns ("", false) if the line is not a valid ATX heading.
 func atxHeadingText(line string) (string, bool) {
 	level := atxHeadingLevel(line)
 	if level == 0 {
@@ -30,8 +27,6 @@ func atxHeadingText(line string) (string, bool) {
 	return text, true
 }
 
-// atxLineText returns the heading text if first == '#' and line is a valid ATX
-// heading. Returns ("", false) otherwise.
 func atxLineText(first byte, line string) (string, bool) {
 	if first != '#' {
 		return "", false
@@ -39,9 +34,6 @@ func atxLineText(first byte, line string) (string, bool) {
 	return atxHeadingText(strings.TrimSpace(line))
 }
 
-// setextHeadingText returns the trimmed heading text when line is a setext
-// underline following a valid heading candidate on the previous line.
-// Returns ("", false) when the conditions are not met.
 func setextHeadingText(first byte, line, prevLine string, prevIsBlock bool) (string, bool) {
 	if prevLine == "" || prevIsBlock || (first != '=' && first != '-') {
 		return "", false
@@ -52,13 +44,10 @@ func setextHeadingText(first byte, line, prevLine string, prevIsBlock bool) (str
 	return strings.TrimSpace(prevLine), true
 }
 
-// isPossibleBlockMarker reports whether b can open a list item, ordered list,
-// or block-quote line per CommonMark, making the line ineligible as setext text.
 func isPossibleBlockMarker(b byte) bool {
 	return b == '*' || b == '+' || b == '-' || b == '>' || (b >= '0' && b <= '9')
 }
 
-// noTPViolation builds a LintError for a heading that ends with rune r.
 func noTPViolation(filename string, lineNum int, r rune) LintError {
 	return LintError{
 		File:    filename,
@@ -67,11 +56,6 @@ func noTPViolation(filename string, lineNum int, r rune) LintError {
 	}
 }
 
-// CheckNoTrailingPunctuation flags ATX and setext headings whose visible text
-// ends with a character contained in punctuation (MD026).
-//
-// Headings inside fenced code, indented code, HTML blocks, and HTML comments are
-// ignored, and a setext underline cannot follow a block line.
 func CheckNoTrailingPunctuation(filename string, ctx *preprocess.Context, offset int, punctuation string) []LintError {
 	if punctuation == "" {
 		return nil
@@ -130,9 +114,6 @@ func CheckNoTrailingPunctuation(filename string, ctx *preprocess.Context, offset
 	return errs
 }
 
-// isOtherBlockLine reports whether line is a CommonMark block-level element
-// (unordered/ordered list item or blockquote) per the pattern ^ {0,3}(?:[*+-]|\d+[.)]|>),
-// using byte scanning instead of a regex. first must equal firstNonSpaceByte(line).
 func isOtherBlockLine(line string, first byte) bool {
 	i := 0
 	for i < len(line) && line[i] == ' ' {
@@ -153,8 +134,6 @@ func isOtherBlockLine(line string, first byte) bool {
 	}
 }
 
-// lastRuneInSet reports whether the last Unicode rune of s is in set.
-// Returns the rune and true when found, zero and false otherwise.
 func lastRuneInSet(s, set string) (rune, bool) {
 	if s == "" {
 		return 0, false

--- a/internal/rule/prefilter.go
+++ b/internal/rule/prefilter.go
@@ -1,9 +1,5 @@
 package rule
 
-// firstNonSpaceByte returns the first non-ASCII-whitespace byte in s, or 0 if
-// s is empty or all ASCII whitespace. Used as a cheap prefilter so that
-// strings.TrimSpace is only called on lines that can plausibly match a
-// rule-relevant pattern (fence opener/closer, ATX heading).
 func firstNonSpaceByte(s string) byte {
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/internal/rule/setext_headings.go
+++ b/internal/rule/setext_headings.go
@@ -12,25 +12,6 @@ var (
 	setextOtherBlockRegex = regexp.MustCompile(`^ {0,3}(?:[*+-]|\d+[.)]|>)\s*`)
 )
 
-// CheckNoSetextHeadings ensures that headings of the "setext" style are never
-// used; you should prefer ATX-type headings instead. It is better that one
-// style is consistently used, and ATX headings are better because:
-//
-//  1. It's easier to remember
-//  2. There is no risk of creating accidental <h2> elements by forgetting a
-//     new line before a "----" horizontal rule.
-//
-// Parameters:
-//   - filename: the name of the file being linted as a string
-//   - ctx: the shared per-line context produced by preprocess.Scan
-//   - offset: the line number offset due to frontmatter removal
-//
-// Returns:
-//   - A slice of LintError containing the line number and description of each
-//     detected issue.
-//
-// A setext underline inside fenced code, indented code, an HTML block, or an HTML
-// comment is not a heading and is not reported.
 func CheckNoSetextHeadings(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	isPrevLineEmpty := true

--- a/internal/rule/single_h1.go
+++ b/internal/rule/single_h1.go
@@ -6,33 +6,22 @@ import (
 	"github.com/shinagawa-web/gomarklint/v3/internal/preprocess"
 )
 
-// CheckSingleH1 flags every ATX-style H1 heading (`# ...`) after the first one in the file.
-// H1 headings inside fenced code, indented code, HTML blocks, and HTML comments
-// are ignored.
 func CheckSingleH1(filename string, ctx *preprocess.Context, offset int) []LintError {
 	var errs []LintError
 	foundFirst := false
 
 	for i := 0; i < ctx.Len(); i++ {
-		// Skip lines the scanner classified as code or HTML: an H1-looking line
-		// there is not a real heading.
 		if inBlockContext(ctx, i) {
 			continue
 		}
 
-		// Byte-level prefilter: skip lines whose first non-ASCII-space byte
-		// cannot start an H1 heading, avoiding strings.TrimSpace on the vast
-		// majority of lines (paragraphs, list items, blank lines, etc.).
 		line := ctx.Line(i)
 		if firstNonSpaceByte(line) != '#' {
 			continue
 		}
 
-		// The prefilter guarantees the first non-space byte is '#', so the
-		// trimmed line begins with '#'.
 		trimmed := strings.TrimSpace(line)
 
-		// Must be "# ..." (H1 with space) or bare "#" (also H1).
 		if len(trimmed) >= 2 && trimmed[1] != ' ' {
 			continue
 		}


### PR DESCRIPTION
## Summary

- Deleted all GoDoc and inline comments that merely restate function/type names or parameter types
- Kept only comments where the WHY is non-obvious: hidden constraints, CommonMark spec edge cases, markdownlint divergences (#337), performance invariants, and workarounds
- 45 files changed, 985 lines deleted

## Test plan

- [x] `make test` passes (100% coverage maintained)
- [x] `make static-lint` passes (gofmt, golangci-lint)
- [x] `make test-e2e` passes
- [x] Benchmark regression within noise (±2%)